### PR TITLE
Modified get_filenames_from_dir to exclude .DS_Store files

### DIFF
--- a/scripts/utils/ReadFiles.py
+++ b/scripts/utils/ReadFiles.py
@@ -1,7 +1,5 @@
 import os
 
-
 def get_filenames_from_dir(directory_path: str) -> list:
-    filenames = [f for f in os.listdir(directory_path) if os.path.isfile(
-        os.path.join(directory_path, f))]
+    filenames = [f for f in os.listdir(directory_path) if os.path.isfile(os.path.join(directory_path, f)) and f != '.DS_Store']
     return filenames


### PR DESCRIPTION
## Pull Request Title
Exclude .DS_Store Files in get_filenames_from_dir Function

## Related Issue
N/A

## Description
Updated the `get_filenames_from_dir` function to exclude .DS_Store files, providing a cleaner output list of filenames.

## Type
- [x ] Bug Fix
- [] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
- Updated the `get_filenames_from_dir` function to ignore .DS_Store files in the directory being read.

## Screenshots / Code Snippets (if applicable)
N/A

## How to Test
1. Call the `get_filenames_from_dir` function with a directory that includes .DS_Store file.
2. Check the output list of filenames to verify that .DS_Store file is not included.

## Checklist
- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [x] All tests (if applicable) pass successfully
- [ ] This pull request has been linked to the related issue (if applicable)

## Additional Information
No additional information.
