### PR TITLE
Remove old processed files

### DIFF
--- a/run_first.py
+++ b/run_first.py
@@ -3,22 +3,39 @@ from scripts.utils.ReadFiles import get_filenames_from_dir
 from scripts.ResumeProcessor import ResumeProcessor
 from scripts.JobDescriptionProcessor import JobDescriptionProcessor
 import logging
-
+import os
 logging.basicConfig(filename='app.log', filemode='w',
                     level=logging.DEBUG,
                     format='%(name)s - %(levelname)s - %(message)s')
 
+PROCESSED_RESUMES_PATH = "Data/Processed/Resumes"
+PROCESSED_JOB_DESCRIPTIONS_PATH = "Data/Processed/JobDescription"
 
 def read_json(filename):
     with open(filename) as f:
         data = json.load(f)
     return data
 
+def remove_old_files(files_path):
+
+    for filename in os.listdir(files_path):
+        try:
+            file_path = os.path.join(files_path, filename)
+
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+        except Exception as e:  
+            logging.error(f"Error deleting {file_path}:\n{e}")
+
+    logging.info("Deleted old files from "+files_path)
+
 
 logging.info('Started to read from Data/Resumes')
 try:
     # Check if there are resumes present or not.
     # If present then parse it.
+    remove_old_files(PROCESSED_RESUMES_PATH)
+
     file_names = get_filenames_from_dir("Data/Resumes")
     logging.info('Reading from Data/Resumes is now complete.')
 except:
@@ -40,6 +57,8 @@ logging.info('Started to read from Data/JobDescription')
 try:
     # Check if there are resumes present or not.
     # If present then parse it.
+    remove_old_files(PROCESSED_JOB_DESCRIPTIONS_PATH)
+
     file_names = get_filenames_from_dir("Data/JobDescription")
     logging.info('Reading from Data/JobDescription is now complete.')
 except:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -136,9 +136,14 @@ avs.add_vertical_space(5)
 
 resume_names = get_filenames_from_dir("Data/Processed/Resumes")
 
-st.write("There are", len(resume_names),
+output = 0
+
+if len(resume_names) > 1:
+    st.write("There are", len(resume_names),
          " resumes present. Please select one from the menu below:")
-output = st.slider('Select Resume Number', 0, len(resume_names)-1, 2)
+    output = st.slider('Select Resume Number', 0, len(resume_names)-1, 0)
+else:
+    st.write("There is 1 resume present")
 
 avs.add_vertical_space(5)
 
@@ -195,10 +200,14 @@ avs.add_vertical_space(5)
 
 job_descriptions = get_filenames_from_dir("Data/Processed/JobDescription")
 
-st.write("There are", len(job_descriptions),
+output = 0
+if len(job_descriptions) > 1:
+    st.write("There are", len(job_descriptions),
          " resumes present. Please select one from the menu below:")
-output = st.slider('Select Job Description Number',
-                   0, len(job_descriptions)-1, 2)
+    output = st.slider('Select Job Description Number',
+                    0, len(job_descriptions)-1, 0)
+else:
+    st.write("There is 1 job description present")
 
 avs.add_vertical_space(5)
 


### PR DESCRIPTION
## Pull Request Title
Improved Data handling

## Related Issue
issue #74

## Description
1. Json files in the Processed folder would stack on top of each other if not deleted manually but now they are removed automatically.
2. If you had 1-2 files the slider would cause an error because you can't have a slide with 1 item and the default value of the sliders was 2.

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [x] Bug Fix
- [x] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
<!-- List the specific changes made in this pull request -->
- added files remover function
- changed the slider default value to 0
- added a condition to show a slider only if you have more than one file in the folder.

## Screenshots / Code Snippets (if applicable)
<!-- Include any relevant screenshots or code snippets that help visualize the changes made -->

## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1. `python run_first.py` would remove the existing files
3. streamlite run streamlite_app.py would work even if you have only 1 resume/job description json file
4. 

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [ ] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [x] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

## Additional Information
<!-- Add any other information about the pull request that you think might be helpful -->

