### PR TITLE
Fix #117 - Having less than 2 resumes causes an error: "IndexError: list index out of range"

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -147,14 +147,16 @@ avs.add_vertical_space(5)
 
 resume_names = get_filenames_from_dir("Data/Processed/Resumes")
 
-output = 0
-
 if len(resume_names) > 1:
-    st.write("There are", len(resume_names),
-             " resumes present. Please select one from the menu below:")
-    output = st.slider('Select Resume Number', 0, len(resume_names) - 1, 0)
+    default_value = min(2, len(resume_names) - 1)
+    st.write("There are", len(resume_names), "resumes present. Please select one from the slider below:")
+    output = st.slider('Select Resume Number:', 0, len(resume_names) - 1, default_value)
+elif len(resume_names) == 1:
+    st.write("There is :green[1] resume present.")
+    output = 0
 else:
-    st.write("There is 1 resume present")
+    st.write(':red[**WARNING: No resumes are present. Please add at least 1 resume then refresh your browser tab!**]')
+    output = None
 
 avs.add_vertical_space(5)
 

--- a/streamlit_second.py
+++ b/streamlit_second.py
@@ -138,6 +138,7 @@ resume_names = get_filenames_from_dir("Data/Processed/Resumes")
 
 if len(resume_names) > 1:
     default_value = min(2, len(resume_names) - 1)
+    st.write("There are", len(resume_names), "resumes present. Please select one from the slider below:")
     output = st.slider('Select Resume Number:', 0, len(resume_names) - 1, default_value)
 elif len(resume_names) == 1:
     st.write("There is :green[1] resume present.")

--- a/streamlit_second.py
+++ b/streamlit_second.py
@@ -136,9 +136,15 @@ avs.add_vertical_space(5)
 
 resume_names = get_filenames_from_dir("Data/Processed/Resumes")
 
-st.write("There are", len(resume_names),
-         " resumes present. Please select one from the menu below:")
-output = st.slider('Select Resume Number', 0, len(resume_names)-1, 2)
+if len(resume_names) > 1:
+    default_value = min(2, len(resume_names) - 1)
+    output = st.slider('Select Resume Number:', 0, len(resume_names) - 1, default_value)
+elif len(resume_names) == 1:
+    st.write("There is :green[1] resume present.")
+    output = 0
+else:
+    st.write(':red[**WARNING: No resumes are present. Please add at least 1 resume then refresh your browser tab!**]')
+    output = None
 
 avs.add_vertical_space(5)
 


### PR DESCRIPTION
## Pull Request Title
Fixed having less than 2 resumes causes an error: "IndexError: list index out of range"

## Related Issue
#117

## Description
This PR fixes an issue where users having at most 2 resumes in their Data directory will have errors in certain conditions.
It will also improve the UX: For example, if the user added only 1 resume, we should remove the slider. On the other hand, if he has no resumes, a warning should appear reminding him to add a resume. 

## Type

- [x] Bug Fix
- [x] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes

- Add condition when there are no resumes
- Add condition when there is only 1 resume (remove slider and display only text)
- Fix slider indexing when the user has precisely 2 resumes.

## Screenshots / Code Snippets (if applicable)
No resumes:
![brave_y6nI7Bz9wa](https://github.com/srbhr/Resume-Matcher/assets/43639707/c9ef4e83-fd97-48be-836f-37687b3ede3c)

1 resume:
![brave_RaHfthsfCm](https://github.com/srbhr/Resume-Matcher/assets/43639707/542e0217-72f6-467c-bf2e-d373bdc94c77)

2 resumes:
![brave_s6Eb6w0sXx](https://github.com/srbhr/Resume-Matcher/assets/43639707/ff96b044-5ccd-449d-99f0-1dce8179a522)

More than 2 resumes:
![brave_KiBdzCc3gE](https://github.com/srbhr/Resume-Matcher/assets/43639707/493cee98-3b94-4b90-adbf-5cf5ad95c6f7)



## How to Test

1. Launch the app after removing all current items in the Data folder.
2. Conditions:
2.1. Keep it with no resumes, then refresh tab and test.
2.2. Add exactly 1 resume, then refresh tab and test.
2.3. Add exactly 2 resumes, then refresh tab and test.

## Checklist

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [x] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

## Additional Information

