### PR TITLE
docs: Adding doc badge redirect folks to Resume Matcher Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![Discord](https://custom-icon-badges.demolab.com/badge/Join%20Discord-blue?style=flat-square&logo=discord&color=F0FF42&logoColor=293462)](https://discord.gg/t3Y9HEuV34)
 [![Resume Matcher](https://custom-icon-badges.demolab.com/badge/www.resumematcher.fyi-gold?style=flat-square&logo=globe&logoColor=black)](https://www.resumematcher.fyi)
 [![Resume Matcher](https://custom-icon-badges.demolab.com/badge/Live_Demo_on_Streamlit-green?style=flat-square&logo=live&color=F55353)](https://resume-matcher.streamlit.app/)
+[![Resume Matcher Docs](https://img.shields.io/badge/Checkout%20Resume%20Matcher%20Docs-%230288D1.svg?style=flat-square&logo=bookstack&logoColor=white&color=red)](https://github.com/srbhr/Resume-Matcher-Docs)
 
 <a href="https://www.producthunt.com/posts/resume-matcher?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-resume&#0045;matcher" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=401261&theme=light" alt="Resume&#0032;Matcher - Free&#0032;and&#0032;Open&#0045;Source&#0032;ATS&#0032;Tool&#0032;to&#0032;Match&#0032;Resumes&#0032;to&#0032;Job&#0032;Desc&#0046; | Product Hunt" style="width: 180px; height: 50px;" width="200" height="54"/></a>
 


### PR DESCRIPTION
## Pull Request Title
Adding documentation badge for redirecting folks to Resume Matcher Docs

## Related Issue
<!-- If this pull request is related to an issue, please link it here using the "#" symbol followed by the issue number (e.g., #123) -->

## Description
This PR deals with adding badge to move/redirect the user from our main repository to documentation repository.

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [ ] Bug Fix
- [ ] Feature Enhancement
- [x] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
<!-- List the specific changes made in this pull request -->

- 
- 
- 

## Screenshots / Code Snippets (if applicable)
<!-- Include any relevant screenshots or code snippets that help visualize the changes made -->

## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1. 
2. 
3. 

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [ ] The code compiles successfully without any errors or warnings
- [ ] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [ ] The changes follow the project's coding guidelines and best practices
- [ ] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [ ] This pull request has been linked to the related issue (if applicable)

## Additional Information
Will add separate PR to migrate the existing information to ResumeMatcher-Docs in separate PR.

