### PR TITLE
Formatting: Initialize modules folders.

### DIFF
--- a/run_first.py
+++ b/run_first.py
@@ -1,8 +1,6 @@
 import json
-from scripts.utils.ReadFiles import get_filenames_from_dir
-from scripts.ResumeProcessor import ResumeProcessor
-from scripts.JobDescriptionProcessor import JobDescriptionProcessor
-from scripts.utils.logger import init_logging_config
+from scripts import ResumeProcessor, JobDescriptionProcessor
+from scripts.utils import init_logging_config, get_filenames_from_dir
 import logging
 import os
 

--- a/scripts/Extractor.py
+++ b/scripts/Extractor.py
@@ -1,7 +1,7 @@
 import re
 import urllib.request
 import spacy
-from scripts.utils.Utils import TextCleaner
+from .utils import TextCleaner
 
 
 # Load the English model

--- a/scripts/JobDescriptionProcessor.py
+++ b/scripts/JobDescriptionProcessor.py
@@ -1,6 +1,6 @@
-from scripts.parsers.ParseResumeToJson import ParseResume
-from scripts.parsers.ParseJobDescToJson import ParseJobDesc
-from scripts.ReadPdf import read_single_pdf
+from .parsers import ParseResume
+from .parsers import ParseJobDesc
+from .ReadPdf import read_single_pdf
 import os.path
 import pathlib
 import json

--- a/scripts/ResumeProcessor.py
+++ b/scripts/ResumeProcessor.py
@@ -1,6 +1,6 @@
-from scripts.parsers.ParseResumeToJson import ParseResume
-from scripts.parsers.ParseJobDescToJson import ParseJobDesc
-from scripts.ReadPdf import read_single_pdf
+from .parsers import ParseResume
+from .parsers import ParseJobDesc
+from .ReadPdf import read_single_pdf
 import os.path
 import pathlib
 import json

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+from . import ReadPdf
+from .JobDescriptionProcessor import JobDescriptionProcessor
+from .ResumeProcessor import ResumeProcessor

--- a/scripts/parsers/__init__.py
+++ b/scripts/parsers/__init__.py
@@ -1,0 +1,2 @@
+from .ParseJobDescToJson import ParseJobDesc
+from .ParseResumeToJson import ParseResume

--- a/scripts/similarity/__init__.py
+++ b/scripts/similarity/__init__.py
@@ -1,0 +1,1 @@
+from .get_similarity_score import get_similarity_score, find_path, read_config

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -1,0 +1,3 @@
+from .logger import init_logging_config
+from .Utils import TextCleaner
+from .ReadFiles import get_filenames_from_dir

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -12,8 +12,8 @@ from annotated_text import annotated_text, parameters
 from streamlit_extras import add_vertical_space as avs
 from streamlit_extras.badges import badge
 
-from scripts.similarity.get_similarity_score import get_similarity_score, find_path, read_config
-from scripts.utils.ReadFiles import get_filenames_from_dir
+from scripts.similarity import get_similarity_score, find_path, read_config
+from scripts.utils import get_filenames_from_dir
 
 cwd = find_path('Resume-Matcher')
 config_path = os.path.join(cwd, "scripts", "similarity")

--- a/streamlit_second.py
+++ b/streamlit_second.py
@@ -5,7 +5,7 @@ import pandas as pd
 import json
 import plotly.express as px
 import plotly.graph_objects as go
-from scripts.utils.ReadFiles import get_filenames_from_dir
+from scripts.utils import get_filenames_from_dir
 from streamlit_extras import add_vertical_space as avs
 from annotated_text import annotated_text, parameters
 from streamlit_extras.badges import badge


### PR DESCRIPTION
## Pull Request Title
Initialize Modules Folders

## Related Issue
None

## Description
Changed the way functions, classes and files are imported.
Improves readability and reduces naming duplications.

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [ ] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [x] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
<!-- List the specific changes made in this pull request -->
- Created __init__.py in folders to initialize the folders as modules.
- Importing for files with a single function or a single class can be done directly by importing the folder
- No need to go all the way to the root folder everytime you import a module from your current folder or it's sub folders

## Screenshots / Code Snippets (if applicable)
N/A

## How to Test
no feature changes, the app is running as before without any unfound modules errors

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [x] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [x] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

## Additional Information
Probably as the code and number of contributers grows you want to more strictly follow PEP8 guidelines and use the pre-commit library with a linter.