### PR TITLE
Fix: Remove direct folder reference

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -15,7 +15,7 @@ from streamlit_extras.badges import badge
 from scripts.similarity import get_similarity_score, find_path, read_config
 from scripts.utils import get_filenames_from_dir
 
-cwd = find_path('Resume-Matcher')
+cwd = os.getcwd()
 config_path = os.path.join(cwd, "scripts", "similarity")
 
 try:


### PR DESCRIPTION
## Pull Request Title
Remove direct folder reference to "Resume-Matcher"

## Related Issue
#147 

## Description
Removes the restriction to always have the base directory as "Resume-Matcher"

## Type
- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
- Use os.getcwd() to get current working directory in streamlit_app.py
- Fix references in scripts/similarity/get_similarity_score.py
- Also fix the standalone section in get_similarity_score.py in case anyone wants to test it separately

## Screenshots / Code Snippets (if applicable)
N/A - Git commit has all the details

## How to Test
1. `git clone https://github.com/srbhr/Resume-Matcher.git Test`
2. Following the remaining steps as-is 

## Checklist
- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

## Additional Information
N/A

