### PR TITLE
fix: nextjs ui throws exception on error ts file

### DIFF
--- a/webapp/app/_components/third-party-services/third-party-services.tsx
+++ b/webapp/app/_components/third-party-services/third-party-services.tsx
@@ -1,5 +1,5 @@
 import SavedKeys from "@/app/_components/third-party-services/saved-keys";
-import { getErrorMessage } from "@/utils/error";
+import { getErrorMessage } from "@/utils/errors";
 import { GetServiceKeysResponse } from "@/types/service-keys";
 import {
   getProtocolAndHost,

--- a/webapp/app/_stores/useGlobalStore.ts
+++ b/webapp/app/_stores/useGlobalStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { JobDescription } from "@/types/job-descriptions";
 import { ResumeProcessorResponse } from "@/types/resume-processor";
-import { getErrorMessage } from "@/utils/error";
+import { getErrorMessage } from "@/utils/errors";
 
 type GlobalStoreState = {
   file: File | null;

--- a/webapp/app/_utils/errors.ts
+++ b/webapp/app/_utils/errors.ts
@@ -1,4 +1,3 @@
-"use client";
 export interface FastAPIError {
   detail: string;
 }


### PR DESCRIPTION
## fix: Next.js UI throws exception on `error.ts` file

Occasionally (not all the time), whenever I start up the local frontend full stack Next.js webapp, and then attempt to load the frontend UI after the Next.js servers are up and ready, the browser displays an exception thrown by Next.js.

The exception which is occasionally thrown, throws with the error message `Attempted to call getErrorMessage() from the server, but getErrorMessage is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a client component.`.

💡 It seems that the `error.ts` file from which the `getErrorMessage()` function is defined conflicts with the reserved Next.js app router keyword for `error.tsx` components, and so Next.js (mistakenly) assumes `error.ts` is client component file, and hence why `use client` was placed at the top of the `error.ts` file in the first place to overcome the initial error. However, in hindsight this is not the correct solution as the function should be called on the server-side, and so the solution is to instead rename `error.ts` to `errors.ts`, which also makes more logical sense, and can be extended with additional error handling functions in future.

This change resolves issue #207.

## Related Issue
#207

## Description
- Renamed `error.ts` to `errors.ts` to avoid Next.js reserved keyword conflict for `Error.tsx` boundary client component files.
- Re-reference imports to the new `errors.ts` file
- Removed `"use client";` declaration in renamed `errors.ts` file, to correctly allow the functions defined within to be called on the server.

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [X] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
<!-- List the specific changes made in this pull request -->

- `error.ts`
- `errors.ts`
- `third-party-services.tsx`
- `useGlobalStore.ts`

## Screenshots / Code Snippets (if applicable)
Exception message rendered on the frontend UI of the full stack Next.js web app.

![screenshot of exception thrown on browser UI, with the message "Attempted to call getErrorMessage() from the server, but getErrorMessage is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a client component."](https://github.com/srbhr/Resume-Matcher/assets/7581546/eabe43f9-dd30-4def-af30-8fe03adcf960)

Exception message thrown before further refactoring to remove `"use client";` declaration on the renamed `errors.ts` file.

![Next.js excpetion message thrown on a server function, where it incorrectly requested for it to be declared as a client component](https://github.com/srbhr/Resume-Matcher/assets/7581546/2ee40a26-13ca-429e-9c5f-f07f168d2dd2)


## How to Test

Please follow steps outlined in issue #207 

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [X] The code compiles successfully without any errors or warnings
- [X] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [X] The changes follow the project's coding guidelines and best practices
- [X] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [X] This pull request has been linked to the related issue (if applicable)

## Additional Information
N/A

