### PR TITLE
Fix issue 269, deleting pre-existing files error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ scripts/similarity/config.yml
 # Processed or local files
 /Data/Processed/*
 *.local.pdf
+
+# ASDF version manager
+.tool-versions

--- a/resume_matcher/main.py
+++ b/resume_matcher/main.py
@@ -18,7 +18,9 @@ PROCESSED_JOB_DESCRIPTIONS_PATH = os.path.join(
 
 
 def get_filenames_from_dir(directory):
-    return [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
+    return [
+        f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))
+    ]
 
 
 def process_files(resume, job_description):
@@ -34,6 +36,3 @@ def process_files(resume, job_description):
         print(r.score)
     print(f"Processing resume: {resume}")
     print(f"Processing job description: {job_description}")
-
-
-

--- a/run_first.py
+++ b/run_first.py
@@ -18,8 +18,13 @@ def read_json(filename):
 
 
 def remove_old_files(files_path):
+    try:
+        filenames = os.listdir(files_path)
+    except FileNotFoundError:
+        logging.info(f"Directory {files_path} does not exist. No files to remove")
+        return
 
-    for filename in os.listdir(files_path):
+    for filename in filenames:
         try:
             file_path = os.path.join(files_path, filename)
 

--- a/scripts/JobDescriptionProcessor.py
+++ b/scripts/JobDescriptionProcessor.py
@@ -4,6 +4,7 @@ import pathlib
 
 from .parsers import ParseJobDesc, ParseResume
 from .ReadPdf import read_single_pdf
+from .utils import make_sure_path_exists
 
 READ_JOB_DESCRIPTION_FROM = "Data/JobDescription/"
 SAVE_DIRECTORY = "Data/Processed/JobDescription"
@@ -41,6 +42,7 @@ class JobDescriptionProcessor:
             + ".json"
         )
         save_directory_name = pathlib.Path(SAVE_DIRECTORY) / file_name
+        make_sure_path_exists(SAVE_DIRECTORY)
         json_object = json.dumps(resume_dictionary, sort_keys=True, indent=14)
         with open(save_directory_name, "w+") as outfile:
             outfile.write(json_object)

--- a/scripts/ResumeProcessor.py
+++ b/scripts/ResumeProcessor.py
@@ -4,6 +4,7 @@ import pathlib
 
 from .parsers import ParseJobDesc, ParseResume
 from .ReadPdf import read_single_pdf
+from .utils import make_sure_path_exists
 
 READ_RESUME_FROM = "Data/Resumes/"
 SAVE_DIRECTORY = "Data/Processed/Resumes"
@@ -38,6 +39,7 @@ class ResumeProcessor:
             "Resume-" + self.input_file + resume_dictionary["unique_id"] + ".json"
         )
         save_directory_name = pathlib.Path(SAVE_DIRECTORY) / file_name
+        make_sure_path_exists(SAVE_DIRECTORY)
         json_object = json.dumps(resume_dictionary, sort_keys=True, indent=14)
         with open(save_directory_name, "w+") as outfile:
             outfile.write(json_object)

--- a/scripts/utils/ReadFiles.py
+++ b/scripts/utils/ReadFiles.py
@@ -8,3 +8,7 @@ def get_filenames_from_dir(directory_path: str) -> list:
         if os.path.isfile(os.path.join(directory_path, f)) and f != ".DS_Store"
     ]
     return filenames
+
+
+def make_sure_path_exists(directory_path: str):
+    os.makedirs(directory_path, exist_ok=True)

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -1,3 +1,3 @@
 from .logger import init_logging_config
-from .ReadFiles import get_filenames_from_dir
+from .ReadFiles import get_filenames_from_dir, make_sure_path_exists
 from .Utils import TextCleaner


### PR DESCRIPTION
## Pull Request Title
Fix issue, deleting pre-existing files error

## Related Issue
#269 

## Description
The error arises when the user deletes the pre-existing files from Data/Resumes or Data/JobDescriptions

## Type

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes

- Add in a check to see if the directory exists in run_first.py
- Make the directory if it does not exist in scripts/<ResumeProcessor.py|JobDescriptionProcessor.py>

## How to Test

1. Delete existing resumes from Data/Resumes
2. Run `python run_first.py` as instructed in README

## Checklist

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [x] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [x] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

## Additional Information
The pre-commit hooks appear to be failing by default, without any modifications to the existing `main` branch code. As such, I complied with style using black but did not run the pre-commit hooks

