### PR TITLE
Fix: Add missing dependencies and Ollama model setup instructions

### DIFF
--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -6,6 +6,7 @@ certifi==2025.1.31
 cffi==1.17.1
 charset-normalizer==3.4.1
 click==8.1.8
+cobble==0.1.4
 coloredlogs==15.0.1
 cryptography==44.0.2
 distro==1.9.0
@@ -24,9 +25,11 @@ idna==3.10
 itsdangerous==2.2.0
 jiter==0.9.0
 magika==0.6.1
+mammoth==1.9.1
 Markdown==3.8
 markdownify==1.1.0
 markitdown==0.1.1
+markitdown[docx]
 mpmath==1.3.0
 numpy==2.2.4
 ollama==0.4.7
@@ -42,6 +45,7 @@ pydantic_core==2.33.1
 python-dotenv==1.1.0
 python-multipart==0.0.20
 requests==2.32.3
+-e git+https://github.com/srbhr/Resume-Matcher.git@64371f7505ccf4389b8a5fcd2796c20e9aa9b628#egg=resume_matcher_backend&subdirectory=apps/backend
 six==1.17.0
 sniffio==1.3.1
 soupsieve==2.6


### PR DESCRIPTION
## Problem
- Backend throws `MissingDependencyException` when processing .docx files due to missing markitdown[docx] dependency
- Application fails with Ollama model not found error for `nomic-embed-text:137m-v1.5-fp16`

## Solution
- Added `markitdown[docx]` to requirements.txt
- Added Ollama `nomic-embed-text:137m-v1.5-fp16` model setup to setup.sh

## Testing
- Verified .docx file processing works after installing markitdown[docx]
- Confirmed application runs successfully after pulling the required Ollama model
