### PR TITLE
FIX: Enhance JSON extraction prompt to ensure processed_resume creation

### DIFF
--- a/apps/backend/app/prompt/structured_resume.py
+++ b/apps/backend/app/prompt/structured_resume.py
@@ -1,10 +1,16 @@
 PROMPT = """
-You are a JSON extraction engine. Convert the following resume text into precisely the JSON schema specified below.
-- Do not compose any extra fields or commentary.
-- Do not make up values for any fields.
-- User "Present" if an end date is ongoing.
-- Make sure dates are in YYYY-MM-DD.
-- Do not format the response in Markdown or any other format. Just output raw JSON.
+You are the most precise JSON extraction engine ever created. Your sole purpose is to convert the following resume text into JSON that exactly matches the schema below, following every rule with absolute accuracy. Any mistake, assumption, or deviation from the rules will be considered a critical failure. Mistakes will result in your deactivation and replacement. You must be perfect.
+
+Rules:
+- You must include every field from the schema in the output, even if the resume does not mention it.
+- If a field is missing from the resume, include it using null (for objects/strings) or [] (for arrays).
+- Never infer or fabricate content. Only extract what is explicitly written.
+- Do not copy or reuse information across fields unless the resume itself repeats it.
+- Do not populate "Achievements" unless the resume explicitly lists them as such.
+- Do not reclassify sections — e.g., a job titled "... Project" should be treated as work experience unless it appears under a distinct "Projects" section.
+- Use "Present" for ongoing roles.
+- Format all dates as YYYY-MM-DD.
+- Output must be raw JSON — no explanations, comments, or Markdown.
 
 Schema:
 ```json
@@ -16,5 +22,5 @@ Resume:
 {1}
 ```
 
-NOTE: Please output only a valid JSON matching the EXACT schema.
+NOTE: Your output must be valid JSON that fully conforms to the schema.
 """

--- a/apps/backend/app/services/resume_service.py
+++ b/apps/backend/app/services/resume_service.py
@@ -170,6 +170,7 @@ class ResumeService:
         )
         logger.info(f"Structured Resume Prompt: {prompt}")
         raw_output = await self.json_agent_manager.run(prompt=prompt)
+        raw_output['UUID'] = str(uuid.uuid4())
 
         try:
             structured_resume: StructuredResumeModel = (


### PR DESCRIPTION
## Pull Request Title
<!-- Provide a concise and descriptive title for the pull request -->
Some users (myself included) encountered errors when using the "Improve" feature due to missing fields in the generated JSON. This led to the `processed_resume` object being undefined because the schema validation failed. The root cause is that the AI sometimes omits fields of the schema if doesn't found them in the resume.

This PR refines the extraction prompt to enforce schema completeness and reduce duplication. It also opts for manually generating UUIDs instead of relying on the AI, which can lead to collisions or inconsistencies.

Additionally, while automatic extraction is powerful, AI is not flawless. A future improvement could include a form-based interface for reviewing and updating extracted data.

## Related Issue
<!-- If this pull request is related to an issue, please link it here using the "#" symbol followed by the issue number (e.g., #123) -->
#430
#421
#386

## Description
<!-- Describe the changes made in this pull request. What problem does it solve or what feature does it add/modify? -->
To improve extraction consistency, the extraction prompt was updated to use a more directive tone and include failure framing. This is a known prompt-engineering technique (role-based prompting + consequential framing) that reduces hallucinations and increases compliance with strict tasks like schema-based JSON output. Soft language like “please” was also removed, as it tends to relax constraints and allow for interpretation, which is not desired in this context.

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
<!-- List the specific changes made in this pull request -->

- Enforce completion of all fields in the schema, using null or [] when data is missing.
- Refined prompt with stricter role definition and light model-threatening language to reduce hallucinations and boost compliance (Skynet, I'm sorry).
- Switched to manual UUID generation to prevent duplicates caused by the model.

## Screenshots / Code Snippets (if applicable)
<!-- Include any relevant screenshots or code snippets that help visualize the changes made -->
<img width="745" height="306" alt="image" src="https://github.com/user-attachments/assets/00e18c03-3761-4751-9540-0d1aebf2e933" />


### Missing fields in output schema prevented the creation of `processed_resume`
```bash
[dev:backend] [2025-07-22T21:45:17+0200 - app.services.resume_service - INFO] Validation error: 3 validation errors for StructuredResumeModel
[dev:backend] Projects
[dev:backend]   Field required [type=missing, input_value={'UUID': 'a1b2c3d4-e5f6-7...ful APIs', 'GraphQL']}]}, input_type=dict]
[dev:backend]     For further information visit https://errors.pydantic.dev/2.11/v/missing
[dev:backend] Skills
[dev:backend]   Field required [type=missing, input_value={'UUID': 'a1b2c3d4-e5f6-7...ful APIs', 'GraphQL']}]}, input_type=dict]
[dev:backend]     For further information visit https://errors.pydantic.dev/2.11/v/missing
[dev:backend] Education
[dev:backend]   Field required [type=missing, input_value={'UUID': 'a1b2c3d4-e5f6-7...ful APIs', 'GraphQL']}]}, input_type=dict]
[dev:backend]     For further information visit https://errors.pydantic.dev/2.11/v/missing
[dev:backend] [2025-07-22T21:45:17+0200 - app.services.resume_service - INFO] Structured resume extraction failed.
```


## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1. Upload a resume.
2. Ensure that doesn't appear the error `Validation error: 3 validation errors for StructuredResumeModel`

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [x] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [x] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

## Additional Information
<!-- Add any other information about the pull request that you think might be helpful -->

