### PR TITLE
Uv not getting installed during setup on macos

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -99,9 +99,14 @@ success "pip3 is available"
 
 # ensure uv
 if ! command -v uv &> /dev/null; then
-  info "uv not found; installing via Astral.sh…"
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  export PATH="$HOME/.local/bin:$PATH"
+  info "uv not found; installing…"
+  if [[ "$OS_TYPE" == "macOS" ]]; then
+    brew install uv || error "Failed to install uv via Homebrew"
+  else
+    curl -LsSf https://astral.sh/uv/install.sh | sh || error "Failed to install uv"
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
+  success "uv installed"
 fi
 check_cmd uv
 success "All prerequisites satisfied."


### PR DESCRIPTION
## Pull Request Title
Improving setup script to install uv on macos with homebrew

## Related Issue
#475 

## Description
if macos added the installation script for uv using homebrew

## Type

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
use homebrew to install uv on mac

- 
- 
- 

## Screenshots / Code Snippets (if applicable)
# ensure uv
if ! command -v uv &> /dev/null; then
  info "uv not found; installing…"
  if [[ "$OS_TYPE" == "macOS" ]]; then
    brew install uv || error "Failed to install uv via Homebrew"
  else
    curl -LsSf https://astral.sh/uv/install.sh | sh || error "Failed to install uv"
    export PATH="$HOME/.local/bin:$PATH"
  fi
  success "uv installed"
fi
check_cmd uv
success "All prerequisites satisfied."

## How to Test
1. run the setup script on a macos laptop that doesn't have uv already installed
2. start the project
3. upload the PDF
4. at the moment it gives error because uv is missing, after running the updated script everything works.

## Checklist

- [ x] The code compiles successfully without any errors or warnings
- [ x] The changes have been tested and verified
- [ x] The documentation has been updated (if applicable)
- [ x] The changes follow the project's coding guidelines and best practices
- [ x] The commit messages are descriptive and follow the project's guidelines
- [ x] All tests (if applicable) pass successfully
- [ x] This pull request has been linked to the related issue (if applicable)

## Additional Information

