### PR TITLE
fix(json): tolerate minor non-JSON wrappers and extract JSON object f…

### DIFF
--- a/apps/backend/app/agent/strategies/wrapper.py
+++ b/apps/backend/app/agent/strategies/wrapper.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from typing import Any, Dict
 
 from .base import Strategy
@@ -21,14 +22,24 @@ class JSONWrapper(Strategy):
         response = response.strip()
         logger.info(f"provider response: {response}")
 
-        # First attempt: direct JSON load after removing common wrappers
-        cleaned = response.replace("```", "").replace("json", "").strip()
+        # 1) Try direct parse first
         try:
-            return json.loads(cleaned)
+            return json.loads(response)
         except json.JSONDecodeError:
             pass
 
-        # Fallback: extract the largest JSON-looking block between first '{' and last '}'
+        # 2) If wrapped in a fenced code block, extract inner content
+        #    Matches ```json\n...``` or ```\n...``` variants
+        fence_match = re.search(r"```(?:json)?\s*([\s\S]*?)```", response, re.IGNORECASE)
+        if fence_match:
+            fenced = fence_match.group(1).strip()
+            try:
+                return json.loads(fenced)
+            except json.JSONDecodeError:
+                # continue to next fallback
+                pass
+
+        # 3) Fallback: extract the largest JSON-looking block between first '{' and last '}'
         start = response.find("{")
         end = response.rfind("}")
         if start != -1 and end != -1 and end > start:
@@ -36,7 +47,7 @@ class JSONWrapper(Strategy):
             try:
                 return json.loads(candidate)
             except json.JSONDecodeError:
-                # Try again after stripping backticks/newlines around the candidate
+                # Try again after removing any stray backticks/newlines around candidate
                 candidate2 = candidate.replace("```", "").strip()
                 try:
                     return json.loads(candidate2)
@@ -48,7 +59,7 @@ class JSONWrapper(Strategy):
                     )
                     raise StrategyError(f"JSON parsing error: {e}") from e
 
-        # If no braces found, fail clearly
+        # 4) No braces found: fail clearly
         logger.error(
             "provider response contained no JSON object braces: %s", response
         )
@@ -75,3 +86,4 @@ class MDWrapper(Strategy):
                 f"provider returned non-md. parsing error: {e} - response: {response}"
             )
             raise StrategyError(f"Markdown parsing error: {e}") from e
+


### PR DESCRIPTION
## Pull Request Title
fix(json): tolerate minor non-JSON wrappers and extract JSON object from provider output
### Related Issue
N/A

### Description
Some provider responses include code fences/backticks or extra text around JSON. This improves `JSONWrapper` so those still parse cleanly, reducing false JSON parsing errors and keeping normal behavior unchanged.

### Type
- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other

### Proposed Changes
- Strip common wrappers (backticks, “json”) and trim provider response.
- Fallback: parse between the first “{” and last “}” when direct `json.loads` fails.
- Clearer error logs if parsing still fails.

### How to Test
1. Run `npm run dev`.
2. Upload a resume, paste a job description, click Analyze/Improve.
3. Verify no “JSON parsing error” in backend logs and that structured data is produced.

### Checklist
- [x] Code compiles without errors
- [x] Tested locally
- [x] Follows project guidelines
- [x] Descriptive commit message
- [ ] Docs updated (if needed)
- [ ] Linked to issue (if applicable)

### Additional Information
- File changed: `apps/backend/app/agent/strategies/wrapper.py`
- No API or schema changes; backward compatible.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved JSON parsing in provider responses by stripping common wrappers and extracting the JSON object even if extra text is present.

- **Bug Fixes**
  - Removes code fences and "json" labels before parsing.
  - Falls back to extracting JSON between braces if initial parsing fails.
  - Adds clearer error logs for failed parsing attempts.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of JSON parsing by trimming provider responses before parsing.
  - Better handling of fenced/wrapped content and other extra formatting to reduce false failures.
  - Added a staged fallback that extracts and tries likely JSON blocks when direct parsing fails.
  - Clearer, contextual error messages when no valid JSON can be detected.
  - No changes to public interfaces or existing integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->