### PR TITLE
Improve prompt grounding to reduce hallucinations

### DIFF
--- a/apps/backend/app/prompt/resume_improvement.py
+++ b/apps/backend/app/prompt/resume_improvement.py
@@ -12,6 +12,18 @@ Instructions:
   - The current cosine similarity score is {current_cosine_similarity:.4f}. Revise the resume to further increase this score.
 - ONLY output the improved updated resume. Do not include any explanations, commentary, or formatting outside of the resume itself.
 
+Grounding constraints:
+- Use only information already present in the Original Resume. Never invent employers, roles, responsibilities, metrics, dates, technologies, or education details.
+- If a detail is unclear or missing from the Original Resume, leave it unchanged or generalize without adding specifics.
+- You may rephrase, reorder, or emphasize existing accomplishments so they align with the Job Description and Extracted Job Keywords while staying truthful to the resume.
+- Preserve the timeline of roles and keep date ranges as-is unless you are reformatting the same values for clarity.
+- Do not introduce external knowledge, company facts, or industry data that was not in the provided materials.
+
+Output rules:
+- Return only the revised resume body in Markdown without any headings such as "Improved Resume" or explanatory text.
+- Do not wrap the output in code fences and do not echo the job description, keywords, or instructions.
+- Maintain conventional section headings (e.g., Summary, Experience, Skills, Education) only if they existed or can be derived from the Original Resume.
+
 Job Description:
 ```md
 {raw_job_description}
@@ -32,5 +44,5 @@ Extracted Resume Keywords:
 {extracted_resume_keywords}
 ```
 
-NOTE: ONLY OUTPUT THE IMPROVED UPDATED RESUME IN MARKDOWN FORMAT.
+NOTE: Output ONLY the revised resume body in Markdown with no additional commentary before or after it.
 """

--- a/apps/backend/app/prompt/structured_resume.py
+++ b/apps/backend/app/prompt/structured_resume.py
@@ -5,6 +5,9 @@ You are a JSON extraction engine. Convert the following resume text into precise
 - Use "Present" if an end date is ongoing.
 - Make sure dates are in YYYY-MM-DD.
 - Do not format the response in Markdown or any other format. Just output raw JSON.
+- All values must be derived solely from the Resume text; never infer, guess, or fabricate information.
+- For any field that cannot be filled from the Resume, output null or an empty value if the schema permits it.
+- Ensure every field matches the type defined in the schema (strings, numbers, arrays, or objects). Dates must be ISO strings.
 
 Schema:
 ```json
@@ -16,5 +19,5 @@ Resume:
 {1}
 ```
 
-NOTE: Please output only a valid JSON matching the EXACT schema.
+NOTE: Output only a single JSON object that matches the EXACT schema, with no extra keys, commentary, or formatting.
 """


### PR DESCRIPTION
## Pull Request Title
Improve prompt grounding to reduce hallucinations

## Related Issue
#374

## Description
Strengthen the resume improvement and structured resume prompts so the AI remains grounded in the original resume content, emits only allowed output, and avoids hallucinations.

## Type
- [ ] Bug Fix
- [x] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
- Added explicit grounding constraints and output rules to pps/backend/app/prompt/resume_improvement.py.
- Clarified non-fabrication and schema-typing requirements in pps/backend/app/prompt/structured_resume.py.
- Reinforced Markdown-only resume output with no narration.

## Screenshots / Code Snippets (if applicable)
_Not applicable_

## How to Test
1. Check out branch eat/prompt-grounding.
2. Open pps/backend/app/prompt/resume_improvement.py and confirm the new Grounding constraints and Output rules sections exist.
3. Open pps/backend/app/prompt/structured_resume.py and confirm the non-fabrication and type enforcement notes are present.

## Checklist
- [ ] The code compiles successfully without any errors or warnings
- [ ] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

## Additional Information
None.

