### PR TITLE
Add 2 MB file size validation to /upload endpoint (#515)

### DIFF
--- a/apps/backend/app/api/router/v1/resume.py
+++ b/apps/backend/app/api/router/v1/resume.py
@@ -68,6 +68,12 @@ async def upload_resume(
             detail="Empty file. Please upload a valid file.",
         )
 
+    if len(file_bytes) > 2 * 1024 * 1024:  # 2MB limit
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="File size exceeds maximum allowed size of 2.0MB.",
+        )
+
     try:
         resume_service = ResumeService(db)
         resume_id = await resume_service.convert_and_store_resume(


### PR DESCRIPTION
## Pull Request Title
Add 2 MB file size validation to /upload endpoint (#515)

## Related Issue
#515

## Description
This pull request adds backend validation to the /upload endpoint to reject files larger than 2 MB, aligning it with the existing frontend limit.

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [ ] Bug Fix
- [ X] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify): 

## Proposed Changes
<!-- List the specific changes made in this pull request -->

- Added backend file size check for /upload endpoint (max 2 MB).
- 
- 

## Screenshots / Code Snippets (if applicable)
<!-- Include any relevant screenshots or code snippets that help visualize the changes made -->

## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1. 
2. 
3. 

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [ X] The code compiles successfully without any errors or warnings
- [ X] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [X ] The changes follow the project's coding guidelines and best practices
- [X ] The commit messages are descriptive and follow the project's guidelines
- [ X] All tests (if applicable) pass successfully
- [ X] This pull request has been linked to the related issue (if applicable)

## Additional Information
<!-- Add any other information about the pull request that you think might be helpful -->

