### PR TITLE
Fix: llm health check failing for thinking models

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -200,7 +200,8 @@ def _extract_choice_text(choice: Any) -> str | None:
         return content
 
     if hasattr(choice, "text"):
-        content = _join_text_parts(_extract_text_parts(getattr(choice, "text")))
+        content = _join_text_parts(
+            _extract_text_parts(getattr(choice, "text")))
         if content:
             return content
     if isinstance(choice, dict) and "text" in choice:
@@ -209,7 +210,8 @@ def _extract_choice_text(choice: Any) -> str | None:
             return content
 
     if hasattr(choice, "delta"):
-        content = _join_text_parts(_extract_text_parts(getattr(choice, "delta")))
+        content = _join_text_parts(
+            _extract_text_parts(getattr(choice, "delta")))
         if content:
             return content
     if isinstance(choice, dict) and "delta" in choice:
@@ -280,7 +282,8 @@ def get_model_name(config: LLMConfig) -> str:
         return f"openrouter/{config.model}"
 
     # For other providers, don't add prefix if model already has a known prefix
-    known_prefixes = ["openrouter/", "anthropic/", "gemini/", "deepseek/", "ollama/"]
+    known_prefixes = ["openrouter/", "anthropic/",
+                      "gemini/", "deepseek/", "ollama/"]
     if any(config.model.startswith(p) for p in known_prefixes):
         return config.model
 
@@ -355,23 +358,28 @@ async def check_llm_health(
         response = await litellm.acompletion(**kwargs)
         content = _extract_choice_text(response.choices[0])
         if not content:
-            # LLM-003: Empty response should mark health check as unhealthy
-            logging.warning(
-                "LLM health check returned empty content",
-                extra={"provider": config.provider, "model": config.model},
-            )
-            result: dict[str, Any] = {
-                "healthy": False,  # Fixed: empty content means unhealthy
-                "provider": config.provider,
-                "model": config.model,
-                "response_model": response.model if response else None,
-                "error_code": "empty_content",  # Changed from warning_code
-                "message": "LLM returned empty response",
-            }
-            if include_details:
-                result["test_prompt"] = _to_code_block(prompt)
-                result["model_output"] = _to_code_block(None)
-            return result
+            # Check if the model responded with reasoning/thinking content
+            message = response.choices[0].message
+            has_reasoning = getattr(message, "reasoning_content", None) or getattr(
+                message, "thinking", None)
+            if not has_reasoning:
+                # LLM-003: Empty response should mark health check as unhealthy
+                logging.warning(
+                    "LLM health check returned empty content",
+                    extra={"provider": config.provider, "model": config.model},
+                )
+                result: dict[str, Any] = {
+                    "healthy": False,  # Fixed: empty content means unhealthy
+                    "provider": config.provider,
+                    "model": config.model,
+                    "response_model": response.model if response else None,
+                    "error_code": "empty_content",  # Changed from warning_code
+                    "message": "LLM returned empty response",
+                }
+                if include_details:
+                    result["test_prompt"] = _to_code_block(prompt)
+                    result["model_output"] = _to_code_block(None)
+                return result
 
         result = {
             "healthy": True,
@@ -454,7 +462,8 @@ async def complete(
         return content
     except Exception as e:
         # Log the actual error server-side for debugging
-        logging.error(f"LLM completion failed: {e}", extra={"model": model_name})
+        logging.error(f"LLM completion failed: {e}", extra={
+                      "model": model_name})
         raise ValueError(
             "LLM completion failed. Please check your API configuration and try again."
         ) from e
@@ -552,9 +561,11 @@ def _extract_json(content: str, _depth: int = 0) -> str:
     """
     # JSON-010: Safety limits
     if _depth > MAX_JSON_EXTRACTION_RECURSION:
-        raise ValueError(f"JSON extraction exceeded max recursion depth: {_depth}")
+        raise ValueError(
+            f"JSON extraction exceeded max recursion depth: {_depth}")
     if len(content) > MAX_JSON_CONTENT_SIZE:
-        raise ValueError(f"Content too large for JSON extraction: {len(content)} bytes")
+        raise ValueError(
+            f"Content too large for JSON extraction: {len(content)} bytes")
 
     original = content
 
@@ -666,7 +677,8 @@ async def complete_json(
             if _supports_temperature(config.provider, model_name):
                 # LLM-002: Increase temperature on retry for variation
                 kwargs["temperature"] = _get_retry_temperature(attempt)
-            reasoning_effort = _get_reasoning_effort(config.provider, model_name)
+            reasoning_effort = _get_reasoning_effort(
+                config.provider, model_name)
             if reasoning_effort:
                 kwargs["reasoning_effort"] = reasoning_effort
 
@@ -680,7 +692,8 @@ async def complete_json(
             if not content:
                 raise ValueError("Empty response from LLM")
 
-            logging.debug(f"LLM response (attempt {attempt + 1}): {content[:300]}")
+            logging.debug(
+                f"LLM response (attempt {attempt + 1}): {content[:300]}")
 
             # Extract and parse JSON
             json_str = _extract_json(content)
@@ -715,7 +728,8 @@ async def complete_json(
                     + "\n\nIMPORTANT: Output ONLY a valid JSON object. Start with { and end with }."
                 )
                 continue
-            raise ValueError(f"Failed to parse JSON after {retries + 1} attempts: {e}")
+            raise ValueError(
+                f"Failed to parse JSON after {retries + 1} attempts: {e}")
 
         except Exception as e:
             last_error = e


### PR DESCRIPTION
Closes [Bug]: Health checks do not support models with thinking capabilities, such as deepseek-r1 Fixes #707

# Pull Request Title
<!-- Provide a concise and descriptive title for the pull request -->
Fix LLM health check failing for thinking models

## Related Issue
<!-- If this pull request is related to an issue, please link it here using the "#" symbol followed by the issue number (e.g., #123) -->
Closes #707 

## Description
<!-- Describe the changes made in this pull request. What problem does it solve or what feature does it add/modify? -->
copilot:summary
Added checks for reasoning messaging in the health check content. If reasoning is not present, proceed with normal empty content response.

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [ x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes
<!-- List the specific changes made in this pull request -->

- update check_llm_health in llm.py
-
-

## Screenshots / Code Snippets (if applicable)
<!-- Include any relevant screenshots or code snippets that help visualize the changes made -->
<img width="627" height="532" alt="image" src="https://github.com/user-attachments/assets/3893b12c-aeb0-41e4-b91a-a27ee95be413" />


## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1. Attempt to use a reasoning llm model such as DeepSeek-R1 and save
2.
3.

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [ x] The code compiles successfully without any errors or warnings
- [x ] The changes have been tested and verified
- [ x] The documentation has been updated (if applicable)
- [ x] The changes follow the project's coding guidelines and best practices
- [ x] The commit messages are descriptive and follow the project's guidelines
- [ x] All tests (if applicable) pass successfully
- [ x] This pull request has been linked to the related issue (if applicable)

## Additional Information
<!-- Add any other information about the pull request that you think might be helpful -->
copilot:walkthrough


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LLM health checks for reasoning/thinking models by recognizing reasoning output even when the text field is empty. Prevents false negatives for models like `deepseek-r1`.

- **Bug Fixes**
  - Updated `check_llm_health` to accept `reasoning_content`/`thinking` as a valid response when `content` is empty.
  - Still marks truly empty responses as unhealthy with `error_code: empty_content`.
  - Minor logging and formatting tweaks; no API changes.

<sup>Written for commit cbac3a001289f844ea9b6a360271275cc5b29a39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

