### PR TITLE
fix(docker): make frontend accessible for PDF generation

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -240,7 +240,7 @@ if [ ! -f "server.js" ]; then
 fi
 
 trap '' SIGTERM SIGINT SIGQUIT
-node server.js "$@" &
+HOSTNAME=0.0.0.0 PORT="${FRONTEND_PORT}" node server.js "$@" &
 FRONTEND_PID=$!
 trap cleanup SIGTERM SIGINT SIGQUIT
 status "Frontend is running (PID: $FRONTEND_PID)"

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -233,6 +233,7 @@ info "Starting frontend server on port ${FRONTEND_PORT}..."
 cd /app/frontend
 
 # Next.js uses PORT environment variable
+export HOSTNAME="0.0.0.0"
 export PORT="${FRONTEND_PORT}"
 if [ ! -f "server.js" ]; then
     error "Missing frontend standalone server.js. Rebuild the Docker image."
@@ -240,7 +241,7 @@ if [ ! -f "server.js" ]; then
 fi
 
 trap '' SIGTERM SIGINT SIGQUIT
-HOSTNAME=0.0.0.0 PORT="${FRONTEND_PORT}" node server.js "$@" &
+node server.js "$@" &
 FRONTEND_PID=$!
 trap cleanup SIGTERM SIGINT SIGQUIT
 status "Frontend is running (PID: $FRONTEND_PID)"


### PR DESCRIPTION
# Pull Request Title
<!-- Provide a concise and descriptive title for the pull request -->
Cannot connect to frontend for PDF generation

## Related Issue
<!-- If this pull request is related to an issue, please link it here using the "#" symbol followed by the issue number (e.g., #123) -->

## Description
<!-- Describe the changes made in this pull request. What problem does it solve or what feature does it add/modify? -->
<img width="787" height="111" alt="image" src="https://github.com/user-attachments/assets/7047148c-e594-4fce-b442-037c34768109" />

I just cloned the repo today and started using `docker compose up -d`, when i tried to download the PDF i get this 503 error

`{"detail":"Cannot connect to frontend for PDF generation. Attempted URL: http://localhost:3000/print/resumes/adabad6e-e484-467f-aa44-54ba0377e448?template=swiss-single&pageSize=A4&marginTop=10&marginBottom=10&marginLeft=10&marginRight=10&sectionSpacing=3&itemSpacing=2&lineHeight=3&fontSize=3&headerScale=3&headerFont=serif&bodyFont=sans-serif&compactMode=false&showContactIcons=false&accentColor=blue&lang=en. Please ensure: 1) The frontend is running, 2) The FRONTEND_BASE_URL environment variable in the backend .env file matches the URL where your frontend is accessible."}`

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes
<!-- List the specific changes made in this pull request -->

- Update start.sh to pass HOSTNAME=0.0.0.0 and PORT to Next.js server
- Allow frontend to bind correctly inside single-container setup
- Fix backend -> frontend communication (resume PDF export 503 error)
- Support dynamic port via environment variables

## Screenshots / Code Snippets (if applicable)
<!-- Include any relevant screenshots or code snippets that help visualize the changes made -->

## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1. Pull the repo on MacBook M1 pro
2. docker compose up -d
3. Try to download PDF file

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [ ] This pull request has been linked to the related issue (if applicable)

## Additional Information
<!-- Add any other information about the pull request that you think might be helpful -->
copilot:walkthrough

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 503 errors during PDF generation in Docker by making the frontend reachable from the backend. The Next.js server now binds to 0.0.0.0 on the configured port via exported env vars.

- **Bug Fixes**
  - Export `HOSTNAME="0.0.0.0"` and `PORT="$FRONTEND_PORT"` in `docker/start.sh` for the Next.js standalone server.
  - Restores backend-to-frontend calls in single-container setups and supports dynamic ports.

<sup>Written for commit 2d0aac9f962dc6f80ef30660b8baacba42f12941. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

