### PR TITLE
docs: fix documentation discrepancies with codebase

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,12 +81,12 @@ Resume Matcher is an AI-powered application for tailoring resumes to job descrip
 ## Essential Commands
 
 ```bash
-# Backend
+# Backend (from repo root)
 cd apps/backend
 uv sync                                              # Install Python dependencies
 uv run uvicorn app.main:app --reload --port 8000     # FastAPI on :8000
 
-# Frontend
+# Frontend (from repo root, in a separate terminal)
 cd apps/frontend
 npm install                                          # Install Node.js dependencies
 npm run dev                                          # Next.js on :3000

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,21 +81,21 @@ Resume Matcher is an AI-powered application for tailoring resumes to job descrip
 ## Essential Commands
 
 ```bash
-# Install all dependencies
-npm run install
+# Backend
+cd apps/backend
+uv sync                                              # Install Python dependencies
+uv run uvicorn app.main:app --reload --port 8000     # FastAPI on :8000
 
-# Development (both servers)
-npm run dev
+# Frontend
+cd apps/frontend
+npm install                                          # Install Node.js dependencies
+npm run dev                                          # Next.js on :3000
 
-# Individual servers
-npm run dev:backend   # FastAPI on :8000
-npm run dev:frontend  # Next.js on :3000
-
-# Quality checks
+# Quality checks (from apps/frontend)
 npm run lint          # Lint frontend
 npm run format        # Format with Prettier
 
-# Build
+# Build (from apps/frontend)
 npm run build
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Resume Matcher works by creating a master resume that you can use to tailor for 
 1. **Upload** your master resume (PDF or DOCX)
 2. **Paste** a job description you're targeting
 3. **Review** AI-generated improvements and tailored content
-4. **Cover Letter & Email** generator for the job application
+4. **Cover Letter** generator for the job application
 5. **Customize** the layout and sections to fit your style
 6. **Export** as a professional PDF with your preferred template
 
@@ -124,15 +124,15 @@ You can:
 - Rearrange sections via drag-and-drop
 - Choose from multiple resume templates
 
-### Cover Letter & Email Generator
+### Cover Letter Generator
 
-Generate tailored cover letters and email templates based on the job description and your resume.
+Generate tailored cover letters based on the job description and your resume.
 
 ![Cover Letter](assets/cover_letter.png)
 
-### Resume Scoring (In development feature)
+### Resume Scoring & Keyword Highlighting
 
-We are working on a resume scoring feature that will analyze your resume against the job description and provide a match score along with suggestions for improvement.
+Analyze your resume against the job description with a match score, keyword highlighting, and suggestions for improvement.
 
 ![Resume Scoring and Keyword Highlight](assets/keyword_highlighter.png)
 
@@ -151,15 +151,15 @@ Export your tailored resume and cover letter in PDF.
 
 ### Internationalization
 
-- **Multi-Language UI**: Interface available in English, Spanish, Chinese, and Japanese
+- **Multi-Language UI**: Interface available in English, Spanish, Chinese, Japanese, and Portuguese (Brazilian)
 - **Multi-Language Content**: Generate resumes and cover letters in your preferred language
 
 ### Roadmap
 
 If you have any suggestions or feature requests, please feel free to open an issue on GitHub or discuss it on our [Discord](https://dsc.gg/resume-matcher) server.
 
-- Visual keyword highlighting
 - AI Canvas for crafting impactful, metric-driven resume content
+- Email template generator for job applications
 - Multi-job description optimization
 
 <a id="how-to-install"></a>
@@ -206,9 +206,9 @@ Open **<http://localhost:3000>** and configure your AI provider in Settings.
 | Provider | Local/Cloud | Notes |
 |----------|-------------|-------|
 | **Ollama** | Local | Free, runs on your machine |
-| **OpenAI** | Cloud | GPT-4o, GPT-4o-mini |
-| **Anthropic** | Cloud | Claude 3.5 Sonnet |
-| **Google Gemini** | Cloud | Gemini 1.5 Flash/Pro |
+| **OpenAI** | Cloud | GPT-5 Nano, GPT-4o |
+| **Anthropic** | Cloud | Claude Haiku 4.5 |
+| **Google Gemini** | Cloud | Gemini 3 Flash |
 | **OpenRouter** | Cloud | Access to multiple models |
 | **DeepSeek** | Cloud | DeepSeek Chat |
 
@@ -244,7 +244,7 @@ Endpoints:
 | Component | Technology |
 |-----------|------------|
 | Backend | FastAPI, Python 3.13+, LiteLLM |
-| Frontend | Next.js 15, React 19, TypeScript |
+| Frontend | Next.js 16, React 19, TypeScript |
 | Database | TinyDB (JSON file storage) |
 | Styling | Tailwind CSS 4, Swiss International Style |
 | PDF | Headless Chromium via Playwright |

--- a/SETUP.md
+++ b/SETUP.md
@@ -207,7 +207,7 @@ Resume Matcher supports multiple AI providers. You can configure your provider t
 |----------|--------------|-------------|
 | **OpenAI** | `LLM_PROVIDER=openai`<br>`LLM_MODEL=gpt-5-nano-2025-08-07` | [platform.openai.com](https://platform.openai.com/api-keys) |
 | **Anthropic** | `LLM_PROVIDER=anthropic`<br>`LLM_MODEL=claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com/) |
-| **Google Gemini** | `LLM_PROVIDER=gemini`<br>`LLM_MODEL=gemini-3-flash-preview` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
+| **Google Gemini** | `LLM_PROVIDER=gemini`<br>`LLM_MODEL=gemini/gemini-3-flash-preview` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | **OpenRouter** | `LLM_PROVIDER=openrouter`<br>`LLM_MODEL=deepseek/deepseek-chat` | [openrouter.ai](https://openrouter.ai/keys) |
 | **DeepSeek** | `LLM_PROVIDER=deepseek`<br>`LLM_MODEL=deepseek-chat` | [platform.deepseek.com](https://platform.deepseek.com/) |
 

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -2,7 +2,7 @@
 
 > Complete reference for AI agents working with Resume Matcher.
 
-Start at [/AGENTS.md](/AGENTS.md), then dive into topics below.
+Start with the topics below.
 
 ## Quick Navigation
 

--- a/docs/agent/llm-integration.md
+++ b/docs/agent/llm-integration.md
@@ -9,9 +9,9 @@ Backend uses LiteLLM to support multiple providers through a unified API:
 | Provider | Type | Notes |
 |----------|------|-------|
 | **Ollama** | Local | Free, runs on your machine |
-| **OpenAI** | Cloud | GPT-4o, GPT-4o-mini |
-| **Anthropic** | Cloud | Claude 3.5 Sonnet |
-| **Google Gemini** | Cloud | Gemini 1.5 Flash/Pro |
+| **OpenAI** | Cloud | GPT-5 Nano, GPT-4o |
+| **Anthropic** | Cloud | Claude Haiku 4.5 |
+| **Google Gemini** | Cloud | Gemini 3 Flash |
 | **OpenRouter** | Cloud | Access to multiple models |
 | **DeepSeek** | Cloud | DeepSeek Chat |
 

--- a/docs/agent/quickstart.md
+++ b/docs/agent/quickstart.md
@@ -11,11 +11,11 @@
 ## Installation
 
 ```bash
-# Backend
+# Backend (from repo root)
 cd apps/backend
 uv sync
 
-# Frontend
+# Frontend (from repo root)
 cd apps/frontend
 npm install
 ```
@@ -23,11 +23,11 @@ npm install
 ## Development
 
 ```bash
-# Backend (Terminal 1)
+# Backend (Terminal 1, from repo root)
 cd apps/backend
 uv run uvicorn app.main:app --reload --port 8000
 
-# Frontend (Terminal 2)
+# Frontend (Terminal 2, from repo root)
 cd apps/frontend
 npm run dev
 ```

--- a/docs/agent/quickstart.md
+++ b/docs/agent/quickstart.md
@@ -4,27 +4,38 @@
 
 ## Prerequisites
 
-- Node.js 18+
-- Python 3.11+
+- Node.js 22+
+- Python 3.13+
 - [uv](https://docs.astral.sh/uv/) (Python package manager)
 
 ## Installation
 
 ```bash
-npm run install    # Installs frontend (npm) + backend (uv sync)
+# Backend
+cd apps/backend
+uv sync
+
+# Frontend
+cd apps/frontend
+npm install
 ```
 
 ## Development
 
 ```bash
-npm run dev           # Start both servers
-npm run dev:backend   # FastAPI on :8000
-npm run dev:frontend  # Next.js on :3000
+# Backend (Terminal 1)
+cd apps/backend
+uv run uvicorn app.main:app --reload --port 8000
+
+# Frontend (Terminal 2)
+cd apps/frontend
+npm run dev
 ```
 
 ## Quality Checks
 
 ```bash
+# From apps/frontend
 npm run lint     # Lint frontend
 npm run format   # Prettier
 ```


### PR DESCRIPTION
## Summary
- **Next.js version**: 15 → 16 in README tech stack table
- **Model names**: Updated across README, SETUP, and llm-integration docs to match `.env.example` (GPT-5 Nano, Claude Haiku 4.5, Gemini 3 Flash)
- **i18n languages**: Added missing Portuguese (Brazilian) to README
- **Email generator**: Removed claim from features (doesn't exist), moved to roadmap
- **Resume Scoring**: Updated from "in development" to reflect current implementation (match score + keyword highlighting)
- **Gemini model prefix**: Fixed `gemini-3-flash-preview` → `gemini/gemini-3-flash-preview` in SETUP.md
- **npm commands**: Replaced nonexistent root-level `npm run dev/install/build` with actual per-directory commands in CLAUDE.md and quickstart.md
- **Version requirements**: Fixed Node.js 18+ → 22+, Python 3.11+ → 3.13+ in quickstart.md
- **Dead link**: Removed reference to nonexistent `/AGENTS.md` in docs/agent/README.md

## Test plan
- [ ] Verify all commands in CLAUDE.md and quickstart.md work from the specified directories
- [ ] Confirm model names match what ships in `.env.example`
- [ ] Spot-check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the docs in sync with the codebase by fixing model names/provider syntax, setup/dev commands, and runtime versions. Updates features, i18n, and the tech stack, removes a dead link, and clarifies repo‑root and multi‑terminal run steps.

- **Bug Fixes**
  - Models: align names across README/SETUP/LLM docs with `.env.example` (GPT-5 Nano, Claude Haiku 4.5, Gemini 3 Flash); fix Gemini prefix to `gemini/gemini-3-flash-preview`.
  - Commands: replace nonexistent root `npm run install/dev/build` with per-app steps for `apps/backend` and `apps/frontend` in `CLAUDE.md` and `quickstart.md`; clarify commands run from repo root and that backend/frontend run in separate terminals; note quality checks run from `apps/frontend`.
  - Versions: update requirements to Node.js 22+ and Python 3.13+ in quickstart.
  - Features/docs: bump tech stack to Next.js 16; add Portuguese (Brazilian) to i18n; remove Email generator claim (moved to roadmap); update Resume Scoring to match score + keyword highlighting.
  - Cleanup: remove dead link to `/AGENTS.md` in agent docs.

<sup>Written for commit d8bec3b887decedd5f0eee563d61890f406d7f29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

