### PR TITLE
chore(deps-dev): bump brace-expansion transitive deps

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4481,9 +4481,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Lockfile-only patch bumps for the dev-only \`brace-expansion\` transitive dependency. No direct dependency change and no functional impact.

- \`brace-expansion\` (root): **1.1.12 → 1.1.13**
- \`brace-expansion\` (via \`@typescript-eslint/typescript-estree\`): **5.0.4 → 5.0.5**

Both are under \`node_modules\` dev paths and only affect lint/type tooling. Keeping the lockfile current for good hygiene.

## Test plan

- [ ] \`cd apps/frontend && ./node_modules/.bin/tsc --noEmit\` still passes
- [ ] \`cd apps/frontend && ./node_modules/.bin/vitest run\` still passes
- [ ] \`cd apps/frontend && ./node_modules/.bin/eslint .\` still passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lockfile-only patch bump of the dev-only transitive `brace-expansion` in the frontend. No runtime or functional impact; only affects linting and type tooling.

- **Dependencies**
  - `brace-expansion` (root): 1.1.12 → 1.1.13
  - `brace-expansion` (via `@typescript-eslint/typescript-estree`): 5.0.4 → 5.0.5

<sup>Written for commit bc483bb95510433ab4898672deb848c6983f4216. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

