### PR TITLE
fix(frontend): remove invalid turbopackUseSystemTlsCerts flag to unblock Docker Publish

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -5,7 +5,6 @@ const BACKEND_ORIGIN = process.env.BACKEND_ORIGIN || 'http://127.0.0.1:8000';
 const nextConfig: NextConfig = {
   output: 'standalone',
   experimental: {
-    turbopackUseSystemTlsCerts: true,
     proxyTimeout: 240_000,
     // Tree-shake barrel imports — saves ~200-800ms cold start per route
     optimizePackageImports: [


### PR DESCRIPTION
## Summary

The **Publish Docker Image** workflow has been failing on every merge to \`main\` since the Next.js 16.2.3 bump. Root cause is a single line in \`apps/frontend/next.config.ts\`:

\`\`\`diff
 const nextConfig: NextConfig = {
   output: 'standalone',
   experimental: {
-    turbopackUseSystemTlsCerts: true,
     proxyTimeout: 240_000,
     ...
   },
 };
\`\`\`

\`turbopackUseSystemTlsCerts\` is not a recognized key in Next.js 16.2.3's \`ExperimentalConfig\` type. Inside the Docker build, \`next build\` runs full TypeScript type-checking on \`next.config.ts\` itself and hard-fails:

\`\`\`
Type error: Object literal may only specify known properties, and
'turbopackUseSystemTlsCerts' does not exist in type 'ExperimentalConfig'.
\`\`\`

Next.js also logs it as an *unrecognized experimental key* at runtime — so the flag is a no-op AND a build blocker.

### Why local \`npm run lint\` didn't catch it

ESLint doesn't type-check \`next.config.ts\`. Only \`next build\` (and the Docker image build) runs the type check. We only see it when the Publish Docker Image workflow runs post-merge.

### History

Added in \`ca3c0bd\` (Jan 2026) — *"fix: stabilize pdf rendering and i18n for print/build"* — presumably before the key was removed/renamed upstream. If the original intent was "use system TLS CAs for Turbopack", the Node-level replacement is setting \`NODE_EXTRA_CA_CERTS=/path/to/ca-bundle.crt\` in the build environment (out of scope for this PR).

### Affected runs

- https://github.com/srbhr/Resume-Matcher/actions/runs/24577790518 (merge of PR #757, SHA \`fff5d2f\`)
- https://github.com/srbhr/Resume-Matcher/actions/runs/24572403242 (merge of PR #756, SHA \`c1e2dd5\`)

Both failed identically at the same line.

## Test plan

- [ ] \`Publish Docker Image\` workflow runs green on merge
- [ ] Local \`npm run dev\` still starts the frontend
- [ ] Frontend still proxies \`/api/*\` to the backend (rewrites unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed invalid `turbopackUseSystemTlsCerts` from `apps/frontend/next.config.ts` to fix the Next 16.2.3 type error and unblock the Publish Docker Image workflow. No functional changes; local dev and proxy rewrites are unchanged.

<sup>Written for commit 0912b4363ab4beb33830a8ea2236a29c9e33b001. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

