### PR TITLE
fix: Clears api_base in config when cleared from frontend settings page

### DIFF
--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -134,8 +134,9 @@ async def update_llm_config(
         stored["model"] = request.model
     if request.api_key is not None:
         stored["api_key"] = request.api_key
-    if request.api_base is not None:
-        stored["api_base"] = request.api_base
+
+    stored["api_base"] = request.api_base if request.api_base is not None else ""
+
     if request.reasoning_effort is not None:
         # Persist empty string on clear so the gpt-5 auto-migration doesn't
         # re-fire on next get_llm_config() call.

--- a/apps/backend/tests/integration/test_config_api.py
+++ b/apps/backend/tests/integration/test_config_api.py
@@ -46,6 +46,34 @@ class TestLlmConfig:
         data = resp.json()
         assert data["provider"] == "anthropic"
 
+    @patch("app.routers.config._save_config")
+    @patch("app.routers.config._load_config")
+    @patch("app.routers.config._log_llm_health_check", new_callable=AsyncMock)
+    async def test_put_llm_config_api_base_clears(self, mock_log, mock_load, mock_save, client):
+        # Simulate storage
+        stored = {}
+        mock_load.side_effect = lambda: stored.copy()
+
+        async with client:
+            resp = await client.put("/api/v1/config/llm-api-key", json={
+                "provider": "anthropic",
+                "model": "claude-3-sonnet",
+                "api_base": "https://openrouter.ai/api/v1"
+            })
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["provider"] == "anthropic"
+            assert data["api_base"] == "https://openrouter.ai/api/v1"
+
+            resp = await client.put("/api/v1/config/llm-api-key", json={
+                "provider": "anthropic",
+                "model": "claude-3-sonnet",
+            })
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["provider"] == "anthropic"
+            assert data["api_base"] == ""
+
 
 class TestLlmTest:
     """POST /api/v1/config/llm-test"""


### PR DESCRIPTION
# Pull Request Title
Clears api_base in config when cleared from frontend settings page

## Related Issue
#760 

## Description
A stale value for `api_base` persisted in the config after adding it and removing it. This made it impossible for the user to clear it.

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes
<!-- List the specific changes made in this pull request -->
Set the `api_base` value to empty string even when the request doesn't have `api_base` value
```python
stored["api_base"] = request.api_base if request.api_base is not None else ""
``` 
Added a test case to `apps/backend/tests/integration/test_config_api.py`

## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1. Open settings page on the web UI
2. Add an `Base Url` value to the llm provider and click Save
3. Remove the `Base Url` value and click Save.
4. Reload the page and see the value doesn't persist

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [ ] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale `api_base` values in config when users clear the Base URL in the settings UI. Clearing now persists correctly so users can remove a custom base URL.

- **Bug Fixes**
  - Always set `api_base` to an empty string when the request omits it in `update_llm_config`.
  - Added an integration test that sets and then clears `api_base` via `/api/v1/config/llm-api-key`.

<sup>Written for commit 01463b353af5433ba9bfaaa03c590fc0821dec1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

