### PR TITLE
Fix #763: preserve new lines in Additional Info textareas

### DIFF
--- a/apps/frontend/components/builder/forms/additional-form.tsx
+++ b/apps/frontend/components/builder/forms/additional-form.tsx
@@ -17,7 +17,7 @@ export const AdditionalForm: React.FC<AdditionalFormProps> = ({ data, onChange }
   // Helper to handle array conversions (text -> string[])
   const handleArrayChange = (field: keyof AdditionalInfo, value: string) => {
     // Split by newlines only (preserving spaces within items)
-    const items = value.split('\n').filter((item) => item.trim() !== '');
+    const items = value.split('\n');
     onChange({
       ...data,
       [field]: items,

--- a/apps/frontend/components/builder/highlighted-resume-view.tsx
+++ b/apps/frontend/components/builder/highlighted-resume-view.tsx
@@ -134,7 +134,9 @@ export function HighlightedResumeView({ resumeData, keywords }: HighlightedResum
                     {t('resume.additional.technicalSkills')}
                   </div>
                   <div className="flex flex-wrap gap-1">
-                    {resumeData.additional.technicalSkills.map((skill, i) => (
+                    {resumeData.additional.technicalSkills
+                    .filter((skill) => skill.trim() !== '')
+                    .map((skill, i) => (
                       <SkillTag key={i} text={skill} keywords={keywords} />
                     ))}
                   </div>
@@ -147,7 +149,9 @@ export function HighlightedResumeView({ resumeData, keywords }: HighlightedResum
                   {t('resume.sections.languages')}
                 </div>
                 <div className="flex flex-wrap gap-1">
-                  {resumeData.additional.languages.map((lang, i) => (
+                  {resumeData.additional.languages
+                  .filter((lang) => lang.trim() !== '')
+                  .map((lang, i) => (
                     <SkillTag key={i} text={lang} keywords={keywords} />
                   ))}
                 </div>
@@ -161,7 +165,9 @@ export function HighlightedResumeView({ resumeData, keywords }: HighlightedResum
                     {t('resume.sections.certifications')}
                   </div>
                   <ul className="list-disc list-inside space-y-1 text-sm">
-                    {resumeData.additional.certificationsTraining.map((cert, i) => (
+                    {resumeData.additional.certificationsTraining
+                    .filter((cert) => cert.trim() !== '')
+                    .map((cert, i) => (
                       <li key={i} className="text-ink-soft">
                         <HighlightedText text={cert} keywords={keywords} />
                       </li>

--- a/apps/frontend/components/resume/resume-modern-two-column.tsx
+++ b/apps/frontend/components/resume/resume-modern-two-column.tsx
@@ -306,7 +306,9 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
               <div className={baseStyles['resume-section']}>
                 <h3 className={styles.sectionTitleAccent}>{headingFallbacks.certifications}</h3>
                 <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}>
-                  {additional.certificationsTraining.map((cert, index) => (
+                  {additional.certificationsTraining
+                                     .filter((cert) => cert.trim() !== '')
+                  .map((cert, index) => (
                     <li key={index} className="flex">
                       <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
                       <span>{cert}</span>
@@ -371,7 +373,9 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                   {headingFallbacks.skills}
                 </h3>
                 <div className="flex flex-wrap gap-1">
-                  {additional.technicalSkills.map((skill, index) => (
+                  {additional.technicalSkills
+                   .filter((skill) => skill.trim() !== '')
+                  .map((skill, index) => (
                     <span key={index} className={baseStyles['resume-skill-pill']}>
                       {skill}
                     </span>
@@ -390,8 +394,12 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                 >
                   {headingFallbacks.languages}
                 </h3>
-                <p className={baseStyles['resume-text-xs']}>{additional.languages.join(' • ')}</p>
+                <p className={baseStyles['resume-text-xs']}>
+  {additional.languages.filter((language) => language.trim() !== '').join(' • ')}
+</p>
               </div>
+
+              
             )}
 
           {/* Awards Section */}
@@ -403,7 +411,10 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                 {headingFallbacks.awards}
               </h3>
               <ul className={baseStyles['resume-list']}>
-                {additional.awards.map((award, index) => (
+                {additional.awards
+
+                .filter((award) => award.trim() !== '')
+                .map((award, index) => (
                   <li key={index} className={baseStyles['resume-text-xs']}>
                     {award}
                   </li>

--- a/apps/frontend/components/resume/resume-modern.tsx
+++ b/apps/frontend/components/resume/resume-modern.tsx
@@ -396,25 +396,33 @@ const AdditionalSection: React.FC<{
         {technicalSkills.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.technicalSkills}</span>
-            <span>{technicalSkills.join(', ')}</span>
+            <span>{technicalSkills
+            .filter((skill) => skill.trim() !== '')
+            .join(', ')}</span>
           </div>
         )}
         {languages.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.languages}</span>
-            <span>{languages.join(', ')}</span>
+            <span>{languages
+            .filter((language) => language.trim() !== '')
+            .join(', ')}</span>
           </div>
         )}
         {certificationsTraining.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.certifications}</span>
-            <span>{certificationsTraining.join(', ')}</span>
+            <span>{certificationsTraining
+            .filter((cert) => cert.trim() !== '')
+            .join(', ')}</span>
           </div>
         )}
         {awards.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.awards}</span>
-            <span>{awards.join(', ')}</span>
+            <span>{awards
+            .filter((award) => award.trim() !== '')
+            .join(', ')}</span>
           </div>
         )}
       </div>

--- a/apps/frontend/components/resume/resume-single-column.tsx
+++ b/apps/frontend/components/resume/resume-single-column.tsx
@@ -394,25 +394,33 @@ const AdditionalSection: React.FC<{
         {technicalSkills.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.technicalSkills}</span>
-            <span>{technicalSkills.join(', ')}</span>
+            <span>{technicalSkills
+            .filter((skill) => skill.trim() !== '')
+            .join(', ')}</span>
           </div>
         )}
         {languages.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.languages}</span>
-            <span>{languages.join(', ')}</span>
+            <span>{languages
+            .filter((language) => language.trim() !== '')
+            .join(', ')}</span>
           </div>
         )}
         {certificationsTraining.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.certifications}</span>
-            <span>{certificationsTraining.join(', ')}</span>
+            <span>{certificationsTraining
+            .filter((cert) => cert.trim() !== '')
+            .join(', ')}</span>
           </div>
         )}
         {awards.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.awards}</span>
-            <span>{awards.join(', ')}</span>
+            <span>{awards
+            .filter((award) => award.trim() !== '')
+            .join(', ')}</span>
           </div>
         )}
       </div>

--- a/apps/frontend/components/resume/resume-two-column.tsx
+++ b/apps/frontend/components/resume/resume-two-column.tsx
@@ -343,7 +343,9 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
                   {headingFallbacks.certifications}
                 </h3>
                 <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}>
-                  {additional.certificationsTraining.map((cert, index) => (
+                  {additional.certificationsTraining
+                  .filter((cert) => cert.trim() !== '')
+                  .map((cert, index) => (
                     <li key={index} className="flex">
                       <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
                       <span>{cert}</span>
@@ -402,7 +404,9 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
               <div className={baseStyles['resume-section']}>
                 <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.skills}</h3>
                 <div className="flex flex-wrap gap-1">
-                  {additional.technicalSkills.map((skill, index) => (
+                  {additional.technicalSkills
+                  .filter((skill) => skill.trim() !== '')
+                  .map((skill, index) => (
                     <span key={index} className={baseStyles['resume-skill-pill']}>
                       {skill}
                     </span>
@@ -419,7 +423,9 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
                 <h3 className={baseStyles['resume-section-title-sm']}>
                   {headingFallbacks.languages}
                 </h3>
-                <p className={baseStyles['resume-text-xs']}>{additional.languages.join(' • ')}</p>
+                <p className={baseStyles['resume-text-xs']}>{additional.languages
+                .filter((language) => language.trim() !== '')
+                .join(' • ')}</p>
               </div>
             )}
 
@@ -428,7 +434,9 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
             <div className={baseStyles['resume-section']}>
               <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.awards}</h3>
               <ul className={baseStyles['resume-list']}>
-                {additional.awards.map((award, index) => (
+                {additional.awards
+                .filter((award) => award.trim() !== '')
+                .map((award, index) => (
                   <li key={index} className={baseStyles['resume-text-xs']}>
                     {award}
                   </li>


### PR DESCRIPTION
# Pull Request Title

Fix #763: preserve new lines in Additional Info textareas

## Related Issue

#763

## Description

This pull request fixes an issue where pressing the Enter key inside Additional Info textareas did not create new lines correctly.

The problem occurred because empty strings were filtered during input handling, causing blank lines to be removed immediately after pressing Enter.

This update preserves empty lines during typing and moves filtering logic to the renderer level.

## Type

* [x] Bug Fix
* [ ] Feature Enhancement
* [ ] Documentation Update
* [ ] Code Refactoring
* [ ] Other (please specify):

## Proposed Changes

* Removed empty-string filtering from `handleArrayChange`
* Preserved newline behavior while typing in Additional Info textareas
* Added filtering at rendering level to avoid displaying empty entries

## Screenshots / Code Snippets (if applicable)

No screenshots included.

## How to Test

1. Open the Additional Info section.
2. Type text into a textarea field.
3. Press Enter and confirm a new line is created and preserved.

## Checklist

* [ ] The code compiles successfully without any errors or warnings
* [ ] The changes have been tested and verified
* [ ] The documentation has been updated (if applicable)
* [x] The changes follow the project's coding guidelines and best practices
* [x] The commit messages are descriptive and follow the project's guidelines
* [x] All tests (if applicable) pass successfully
* [x] This pull request has been linked to the related issue (if applicable)

## Additional Information

This fix improves textarea usability while keeping rendered data clean by filtering empty values only during display.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves new lines in Additional Info textareas. Moves empty-string filtering to render-time so pressing Enter keeps blank lines while typing.

- **Bug Fixes**
  - Removed empty-string filtering in `handleArrayChange` to keep raw newline entries.
  - Filter out empty values when rendering (skills, languages, certifications, awards) to avoid empty pills/items.

<sup>Written for commit a2e51bde49b4349e78b5a2411a2250376f3945e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

