### PR TITLE
fix(parser): prevent JSON truncation on resume parsing

### DIFF
--- a/apps/backend/app/services/parser.py
+++ b/apps/backend/app/services/parser.py
@@ -162,6 +162,8 @@ async def parse_resume_to_json(markdown_text: str) -> dict[str, Any]:
     result = await complete_json(
         prompt=prompt,
         system_prompt="You are a JSON extraction engine. Output only valid JSON, no explanations.",
+        max_tokens=8192,
+        retries=3,
     )
 
     # Patch dates: restore months the LLM may have dropped


### PR DESCRIPTION
## Description
Resume parsing was failing for large resumes due to truncated JSON output when the model hit the default token limit (4096).

This fix ensures more reliable parsing for complex resumes with multiple sections like work experience, projects, and skills.

---

## Pull Request Title
fix(parser): prevent JSON truncation during resume parsing

---

## Related Issue
<!-- Add issue number if applicable, e.g. #123 -->

---

## Description
Increased model limits and robustness of resume parsing to prevent incomplete JSON responses during generation.

---

## Type
- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

---

## Proposed Changes
- Increased max_tokens to 8192
- Increased retries from 2 to 3
- Improved reliability of initial resume parsing step

---

## Screenshots / Code Snippets (if applicable)
N/A

---

## How to Test
1. Upload a large resume (multiple experiences and projects)
2. Run resume parsing flow
3. Verify JSON output is complete and not truncated

---

## Checklist
- [x] The code compiles successfully without errors or warnings
- [x] The changes have been tested and verified
- [x] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

---

## Additional Information
This change improves robustness of resume parsing for large inputs and prevents silent failures caused by truncated LLM output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents truncated JSON when parsing large resumes by raising the model’s output limit and adding an extra retry. Parsing now returns complete JSON for resumes with many sections.

- **Bug Fixes**
  - Set `max_tokens` to 8192 in the `complete_json` call.
  - Increased `retries` to 3 to recover from partial outputs.

<sup>Written for commit 5123c96bb5240602279d43a14e72378e88cc4d6f. Summary will update on new commits. <a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/768?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

