### PR TITLE
fix(parser): prevent JSON truncation by clamping tokens to model limit

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -44,6 +44,12 @@ LLM_TIMEOUT_JSON = 180  # JSON completions may take longer
 MAX_JSON_EXTRACTION_RECURSION = 10
 MAX_JSON_CONTENT_SIZE = 1024 * 1024  # 1MB
 
+# Default token budget for structured JSON completions (e.g. resume parsing).
+# Chosen to accommodate large resumes while staying within most providers'
+# output limits. Callers should use get_safe_max_tokens() so this is
+# automatically clamped to the model's actual capacity.
+DEFAULT_JSON_MAX_TOKENS = 8192
+
 
 class LLMConfig(BaseModel):
     """LLM configuration model."""
@@ -719,6 +725,53 @@ def _supports_json_mode(model_name: str) -> bool:
         # reject it.
         logging.debug("Model %s not in LiteLLM registry, skipping JSON mode", model_name)
         return False
+
+
+FALLBACK_MAX_TOKENS = 4096
+
+def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKENS) -> int:
+    """Return a token count safe for the given model, clamped to its output limit.
+
+    Queries LiteLLM's model registry for ``max_output_tokens`` and returns
+    ``min(requested, model_limit)`` so callers never send a value that exceeds
+    what the backend actually supports.
+
+    If the model is not in the registry (e.g. custom Ollama models), it falls
+    back to a safe conservative limit (FALLBACK_MAX_TOKENS).
+
+    Args:
+        model_name: LiteLLM-formatted model name (from get_model_name).
+        requested: Desired token budget; defaults to DEFAULT_JSON_MAX_TOKENS.
+
+    Returns:
+        Safe token count, clamped correctly and always >= 1.
+    """
+    safe_requested = max(1, requested)
+
+    try:
+        info = litellm.get_model_info(model=model_name)
+        model_limit = info.get("max_output_tokens") or info.get("max_tokens")
+        if model_limit and isinstance(model_limit, int) and model_limit > 0:
+            safe = min(safe_requested, model_limit)
+            if safe < safe_requested:
+                logging.debug(
+                    "max_tokens clamped %d → %d for model %s (model limit)",
+                    safe_requested,
+                    safe,
+                    model_name,
+                )
+            return safe
+    except Exception:
+        pass  # Model not in registry, drop down to fallback logic
+
+    safe = min(safe_requested, FALLBACK_MAX_TOKENS)
+    logging.debug(
+        "Model %s not in LiteLLM registry, clamping requested max_tokens %d → %d constraint",
+        model_name,
+        safe_requested,
+        safe,
+    )
+    return safe
 
 
 def _appears_truncated(data: dict) -> bool:

--- a/apps/backend/app/services/parser.py
+++ b/apps/backend/app/services/parser.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from markitdown import MarkItDown
 
-from app.llm import complete_json
+from app.llm import complete_json, get_llm_config, get_model_name, get_safe_max_tokens
 from app.prompts import PARSE_RESUME_PROMPT
 from app.prompts.templates import RESUME_SCHEMA_EXAMPLE
 from app.schemas import ResumeData
@@ -159,9 +159,13 @@ async def parse_resume_to_json(markdown_text: str) -> dict[str, Any]:
         resume_text=markdown_text,
     )
 
+    config = get_llm_config()
+    model_name = get_model_name(config)
     result = await complete_json(
         prompt=prompt,
         system_prompt="You are a JSON extraction engine. Output only valid JSON, no explanations.",
+        max_tokens=get_safe_max_tokens(model_name),
+        retries=3,
     )
 
     # Patch dates: restore months the LLM may have dropped


### PR DESCRIPTION
## Description
Resume parsing was failing for large resumes due to truncated JSON output when the model hit the default token limit (4096). This PR implements a robust way to increase the token budget while respecting model-specific provider limits.

---

## Pull Request Title
fix(parser): prevent JSON truncation by dynamically clamping tokens to model limits

---

## Related Issue
<!-- Add issue number if applicable, e.g. #123 -->

---

## Description
Increased model limits and robustness of resume parsing to prevent incomplete JSON responses during generation.

---

## Type
- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

---

## Proposed Changes
- **Dynamic Token Clamping**: Added `get_safe_max_tokens()` in `llm.py` that queries LiteLLM's model registry for `max_output_tokens` and clamps the request to the model's actual capacity.
- **Improved Token Budget**: Set `DEFAULT_JSON_MAX_TOKENS = 8192` as the budget for resume parsing (clamped by the model limit).
- **Increased Resilience**: Bumped retries from 2 to 3 for the initial document parsing step.
- **Refactored Parser**: Updated `parse_resume_to_json` to use the new safety helper instead of a hardcoded value.

---

## Screenshots / Code Snippets (if applicable)
N/A

---

## How to Test
1. Upload a large resume (multiple experiences and projects)
2. Run resume parsing flow
3. Verify JSON output is complete and not truncated
4. (Optional) Test with a model known to have lower output limits to verify clamping works without causing 400 errors.

---

## Checklist
- [x] The code compiles successfully without errors or warnings
- [x] The changes have been tested and verified
- [x] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

---

## Additional Information
This update resolves the `JSON extraction found unbalanced braces` error while specifically addressing the P2 reviewer feedback. By querying the LiteLLM registry, we avoid sending `max_tokens` values that exceed provider capabilities, ensuring compatibility across different backends (Local/Ollama vs. Cloud APIs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents truncated JSON during resume parsing by clamping max_tokens to each model’s limit from the `litellm` registry. Sets a higher default JSON budget (8192) with a 4096 fallback when model info is missing.

- **Bug Fixes**
  - Added get_safe_max_tokens() to clamp to `max_output_tokens`/`max_tokens` from `litellm`, with a 4096 fallback.
  - Set DEFAULT_JSON_MAX_TOKENS to 8192 and used it in the parser.
  - Increased initial parsing retries to 3.

<sup>Written for commit 720705563f327c4131d8debf610335323070e8ce. Summary will update on new commits. <a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/770?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

