### PR TITLE
test(backend): cover config settings flows

### DIFF
--- a/apps/backend/tests/integration/test_config_api.py
+++ b/apps/backend/tests/integration/test_config_api.py
@@ -46,6 +46,35 @@ class TestLlmConfig:
         data = resp.json()
         assert data["provider"] == "anthropic"
 
+    @patch("app.routers.config._log_llm_health_check", new_callable=AsyncMock)
+    @patch("app.routers.config._save_config")
+    @patch("app.routers.config._load_config")
+    async def test_put_llm_config_persists_optional_provider_api_key(
+        self, mock_load, mock_save, mock_log_health, client
+    ):
+        mock_load.return_value = {}
+        async with client:
+            resp = await client.put("/api/v1/config/llm-api-key", json={
+                "provider": "openai_compatible",
+                "model": "llama-3.1-8b",
+                "api_key": "local-secret-key",
+                "api_base": "http://localhost:8080/v1",
+            })
+
+        assert resp.status_code == 200
+        saved_config = mock_save.call_args.args[0]
+        assert saved_config["provider"] == "openai_compatible"
+        assert saved_config["model"] == "llama-3.1-8b"
+        assert saved_config["api_key"] == "local-secret-key"
+        assert saved_config["api_base"] == "http://localhost:8080/v1"
+        data = resp.json()
+        assert data["provider"] == "openai_compatible"
+        assert data["api_base"] == "http://localhost:8080/v1"
+        assert data["api_key"].startswith("loca")
+        assert data["api_key"].endswith("-key")
+        assert "*" in data["api_key"]
+        mock_log_health.assert_awaited_once()
+
 
 class TestLlmTest:
     """POST /api/v1/config/llm-test"""
@@ -79,6 +108,71 @@ class TestLlmTest:
         assert resp.status_code == 200
         assert resp.json()["healthy"] is False
 
+    @patch("app.routers.config.check_llm_health", new_callable=AsyncMock)
+    @patch("app.routers.config._load_config")
+    async def test_connection_test_uses_request_api_key_for_optional_provider(
+        self, mock_load, mock_health, client
+    ):
+        mock_load.return_value = {
+            "provider": "openai_compatible",
+            "model": "stored-model",
+            "api_key": "stored-key",
+            "api_base": "http://localhost:8080/v1",
+        }
+        mock_health.return_value = {
+            "healthy": True,
+            "provider": "openai_compatible",
+            "model": "llama-3.1-8b",
+            "test_prompt": "Hi",
+            "model_output": "Hello!",
+        }
+        async with client:
+            resp = await client.post("/api/v1/config/llm-test", json={
+                "provider": "openai_compatible",
+                "model": "llama-3.1-8b",
+                "api_key": "typed-local-key",
+                "api_base": "http://localhost:1234/v1",
+            })
+
+        assert resp.status_code == 200
+        config = mock_health.await_args.args[0]
+        assert config.provider == "openai_compatible"
+        assert config.model == "llama-3.1-8b"
+        assert config.api_key == "typed-local-key"
+        assert config.api_base == "http://localhost:1234/v1"
+
+    @patch("app.routers.config.check_llm_health", new_callable=AsyncMock)
+    @patch("app.routers.config._load_config")
+    async def test_connection_test_falls_back_to_stored_key_when_request_omits_it(
+        self, mock_load, mock_health, client
+    ):
+        mock_load.return_value = {
+            "provider": "openai_compatible",
+            "model": "stored-model",
+            "api_key": "stored-local-key",
+            "api_base": "http://localhost:8080/v1",
+        }
+        mock_health.return_value = {
+            "healthy": True,
+            "provider": "openai_compatible",
+            "model": "llama-3.1-8b",
+            "test_prompt": "Hi",
+            "model_output": "Hello!",
+        }
+        async with client:
+            resp = await client.post("/api/v1/config/llm-test", json={
+                "provider": "openai_compatible",
+                "model": "llama-3.1-8b",
+                "api_base": "http://localhost:8080/v1",
+            })
+
+        assert resp.status_code == 200
+        config = mock_health.await_args.args[0]
+        assert config.provider == "openai_compatible"
+        assert config.model == "llama-3.1-8b"
+        assert config.api_key == "stored-local-key"
+        assert config.api_base == "http://localhost:8080/v1"
+
 
 class TestFeatureConfig:
     """GET/PUT /api/v1/config/features"""
@@ -106,6 +200,72 @@ class TestFeatureConfig:
             })
         assert resp.status_code == 200
         assert resp.json()["enable_cover_letter"] is True
+
+
+class TestFeaturePrompts:
+    """GET/PUT /api/v1/config/feature-prompts"""
+
+    @patch("app.routers.config._load_config")
+    async def test_get_feature_prompts(self, mock_load, client):
+        mock_load.return_value = {
+            "cover_letter_prompt": "Custom cover prompt",
+            "outreach_message_prompt": "",
+        }
+        async with client:
+            resp = await client.get("/api/v1/config/feature-prompts")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cover_letter_prompt"] == "Custom cover prompt"
+        assert data["outreach_message_prompt"] == ""
+        assert "{job_description}" in data["cover_letter_default"]
+        assert "{resume_data}" in data["cover_letter_default"]
+        assert "{output_language}" in data["cover_letter_default"]
+        assert "{job_description}" in data["outreach_message_default"]
+        assert "{resume_data}" in data["outreach_message_default"]
+        assert "{output_language}" in data["outreach_message_default"]
+
+    @patch("app.routers.config._load_config")
+    async def test_put_feature_prompts_rejects_missing_placeholders(self, mock_load, client):
+        mock_load.return_value = {}
+        async with client:
+            resp = await client.put("/api/v1/config/feature-prompts", json={
+                "cover_letter_prompt": "Use {job_description} only",
+            })
+
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == {
+            "code": "missing_placeholders",
+            "field": "cover_letter_prompt",
+            "missing": ["{resume_data}", "{output_language}"],
+        }
+
+    @patch("app.routers.config._save_config")
+    @patch("app.routers.config._load_config")
+    async def test_put_feature_prompts_strips_and_clears_values(
+        self, mock_load, mock_save, client
+    ):
+        mock_load.return_value = {
+            "cover_letter_prompt": "Old cover prompt",
+            "outreach_message_prompt": "Old outreach prompt",
+        }
+        async with client:
+            resp = await client.put("/api/v1/config/feature-prompts", json={
+                "cover_letter_prompt": "  {job_description}\n{resume_data}\n{output_language}\n  ",
+                "outreach_message_prompt": "   ",
+            })
+
+        assert resp.status_code == 200
+        saved_config = mock_save.call_args.args[0]
+        assert saved_config["cover_letter_prompt"] == (
+            "{job_description}\n{resume_data}\n{output_language}"
+        )
+        assert saved_config["outreach_message_prompt"] == ""
+        data = resp.json()
+        assert data["cover_letter_prompt"] == (
+            "{job_description}\n{resume_data}\n{output_language}"
+        )
+        assert data["outreach_message_prompt"] == ""
 
 
 class TestLanguageConfig:


### PR DESCRIPTION
## Summary
- add backend integration coverage for config settings flows
- verify optional-provider API key save and test-connection behavior
- verify custom feature-prompt fetch, validation, trimming, and clearing behavior

## Testing
- `cd apps/backend && uv run pytest tests/integration/test_config_api.py`

## Artifacts
- Conversation: https://app.warp.dev/conversation/a5da6769-19d4-4a11-a75a-48e4d3e001f7

Co-Authored-By: Oz <oz-agent@warp.dev>
