### PR TITLE
fix(llm): conditionally pass temperature based on model capability

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -663,9 +663,10 @@ async def complete(
             "model": "primary",
             "messages": messages,
             "max_tokens": max_tokens,
-            "temperature": temperature,
             "timeout": LLM_TIMEOUT_COMPLETION,
         }
+        if _supports_temperature(model_name, temperature):
+            kwargs["temperature"] = temperature
         if config.reasoning_effort:
             kwargs["reasoning_effort"] = config.reasoning_effort
 
@@ -747,12 +748,72 @@ def _appears_truncated(data: dict) -> bool:
     return False
 
 
-def _get_retry_temperature(attempt: int, base_temp: float = 0.1) -> float:
-    """LLM-002: Get temperature for retry attempt - increases with each retry.
+def _supports_temperature(model_name: str, temperature: float | None = None) -> bool:
+    """Check if the model supports the given temperature value.
 
-    Higher temperature on retries gives the model more variation to produce
-    different (hopefully valid) output.
+    Uses LiteLLM model registry for capability detection, with
+    provider-specific fallbacks for known restrictions:
+      - Anthropic claude-opus-4.*: temperature is deprecated
+      - Moonshot kimi-k2.6: only temperature=1 allowed
+
+    Queries LiteLLM's model info for every provider so that capability is
+    always determined from the registry rather than a hardcoded list.
+
+    Args:
+        model_name: LiteLLM-formatted model name (from get_model_name).
+        temperature: The temperature value to check. If None, returns True
+            (caller isn't setting a specific value).
+
+    Returns:
+        True if the model supports the given temperature, False otherwise.
     """
+    if temperature is None:
+        return True
+
+    # Ollama models are often not in LiteLLM's registry (custom/local),
+    # but they universally support temperature.
+    if model_name.startswith(("ollama/", "ollama_chat/")):
+        return True
+
+    try:
+        info = litellm.get_model_info(model=model_name)
+        supported_params = info.get("supported_openai_params", [])
+        if "temperature" not in supported_params:
+            return False
+    except Exception:
+        # Model not in LiteLLM's registry — be conservative and skip
+        # temperature to avoid BadRequestError from unsupported params.
+        logging.debug(
+            "Model %s not in LiteLLM registry, skipping temperature", model_name
+        )
+        return False
+
+    # Provider-specific restrictions not captured by the registry.
+    # Anthropic Opus 4.x deprecated temperature entirely.
+    if "claude-opus-4" in model_name.lower():
+        return False
+
+    # Moonshot kimi-k2.6 only allows temperature=1.
+    if "kimi-k2.6" in model_name.lower() and temperature != 1.0:
+        return False
+
+    return True
+
+
+def _get_retry_temperature(model_name: str, attempt: int, base_temp: float = 0.1) -> float | None:
+    """LLM-002: Get temperature for retry attempt.
+
+    Returns None if the model does not support temperature at all.
+    Returns 1.0 for models that only support temperature=1.
+    Otherwise returns increasing temperatures for retry variation.
+    """
+    # Moonshot kimi-k2.6 only allows temperature=1.
+    if "kimi-k2.6" in model_name.lower():
+        return 1.0
+
+    if not _supports_temperature(model_name, base_temp):
+        return None
+
     temperatures = [base_temp, 0.3, 0.5, 0.7]
     return temperatures[min(attempt, len(temperatures) - 1)]
 
@@ -918,11 +979,13 @@ async def complete_json(
             kwargs: dict[str, Any] = {
                 "model": "primary",
                 "messages": messages,
-                # LLM-002: Increase temperature on retry for variation
-                "temperature": _get_retry_temperature(attempt),
                 "max_tokens": max_tokens,
                 "timeout": _calculate_timeout("json", max_tokens, config.provider),
             }
+            # LLM-002: Increase temperature on retry for variation
+            retry_temp = _get_retry_temperature(model_name, attempt)
+            if retry_temp is not None:
+                kwargs["temperature"] = retry_temp
             if config.reasoning_effort:
                 kwargs["reasoning_effort"] = config.reasoning_effort
 

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -1,0 +1,125 @@
+"""Unit tests for LLM capability helpers in app.llm."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.llm import _get_retry_temperature, _supports_temperature
+
+
+# ---------------------------------------------------------------------------
+# _supports_temperature
+# ---------------------------------------------------------------------------
+
+
+class TestSupportsTemperature:
+    """Tests for _supports_temperature()."""
+
+    def test_none_temperature_returns_true(self):
+        """When temperature is None, the caller isn't setting a value — allow."""
+        assert _supports_temperature("gpt-4", None) is True
+
+    def test_ollama_always_true(self):
+        """Ollama models support temperature even when not in registry."""
+        assert _supports_temperature("ollama/llama3", 0.7) is True
+        assert _supports_temperature("ollama_chat/llama3", 0.7) is True
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_openai_gpt4_supports_temperature(self, mock_get_model_info):
+        """GPT-4 has temperature in supported_openai_params."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens", "top_p"]
+        }
+        assert _supports_temperature("gpt-4", 0.7) is True
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_model_without_temperature_param(self, mock_get_model_info):
+        """Model registry omits temperature → not supported."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["max_tokens"]
+        }
+        assert _supports_temperature("some-model", 0.7) is False
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_opus4_deprecated_temperature(self, mock_get_model_info):
+        """Anthropic Opus 4.x deprecated temperature entirely."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _supports_temperature("anthropic/claude-opus-4-7", 0.7) is False
+        # Also check with temperature=1 — still deprecated
+        assert _supports_temperature("anthropic/claude-opus-4-7", 1.0) is False
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_kimi_k26_only_allows_one(self, mock_get_model_info):
+        """Moonshot kimi-k2.6 only allows temperature=1."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _supports_temperature("openai/kimi-k2.6", 0.7) is False
+        assert _supports_temperature("openai/kimi-k2.6", 1.0) is True
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_model_not_in_registry(self, mock_get_model_info):
+        """Unknown model not in registry — be conservative, skip temperature."""
+        mock_get_model_info.side_effect = Exception("model not found")
+        assert _supports_temperature("unknown-vendor/model", 0.7) is False
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_case_insensitive_model_name(self, mock_get_model_info):
+        """Provider-specific checks are case-insensitive."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _supports_temperature("Anthropic/Claude-Opus-4-7", 0.7) is False
+        assert _supports_temperature("OPENAI/KIMI-K2.6", 0.7) is False
+        assert _supports_temperature("openai/KIMI-K2.6", 1.0) is True
+
+
+# ---------------------------------------------------------------------------
+# _get_retry_temperature
+# ---------------------------------------------------------------------------
+
+
+class TestGetRetryTemperature:
+    """Tests for _get_retry_temperature()."""
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_openai_progression(self, mock_get_model_info):
+        """Standard retry temperature progression for supported models."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _get_retry_temperature("gpt-4", 0) == 0.1
+        assert _get_retry_temperature("gpt-4", 1) == 0.3
+        assert _get_retry_temperature("gpt-4", 2) == 0.5
+        assert _get_retry_temperature("gpt-4", 3) == 0.7
+        assert _get_retry_temperature("gpt-4", 10) == 0.7  # clamped
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_opus4_returns_none(self, mock_get_model_info):
+        """Opus 4 doesn't support temperature → None on all retries."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _get_retry_temperature("anthropic/claude-opus-4-7", 0) is None
+        assert _get_retry_temperature("anthropic/claude-opus-4-7", 3) is None
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_kimi_k26_returns_one(self, mock_get_model_info):
+        """Kimi K2.6 only allows temperature=1 → always 1.0."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _get_retry_temperature("openai/kimi-k2.6", 0) == 1.0
+        assert _get_retry_temperature("openai/kimi-k2.6", 1) == 1.0
+        assert _get_retry_temperature("openai/kimi-k2.6", 5) == 1.0
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_custom_base_temp(self, mock_get_model_info):
+        """Custom base_temp is respected for supported models."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _get_retry_temperature("gpt-4", 0, base_temp=0.2) == 0.2
+        assert _get_retry_temperature("gpt-4", 1, base_temp=0.2) == 0.3


### PR DESCRIPTION
## Problem

Issue #759: Model Connection for Opus 4.7 and Kimi K2.6 fails because 	emperature is unconditionally passed to LiteLLM.

**Error messages:**
- Anthropic Claude Opus 4.7: 	emperature is deprecated for this model
- Moonshot Kimi K2.6: invalid temperature: only 1 is allowed for this model

**Why litellm.drop_params=True doesn't help:** The error comes from LiteLLM's internal parameter validation (before sending to the API), not from the upstream provider response.

## Solution

Follow the existing _supports_json_mode() pattern in llm.py:

1. **Add _supports_temperature()** — queries litellm.get_model_info() for capability detection, with provider-specific fallbacks:
   - Anthropic claude-opus-4.*: temperature deprecated → skip
   - Moonshot kimi-k2.6: only 	emperature=1 allowed → use 1.0
   - Unknown models (not in registry): be conservative → skip

2. **Modify complete()** — only add 	emperature to kwargs when _supports_temperature() returns True

3. **Modify _get_retry_temperature()** — returns None for unsupported models, 1.0 for Kimi K2.6, normal progression otherwise

4. **Modify complete_json()** — conditionally pass retry temperature

5. **Add unit tests** (	ests/unit/test_llm.py) — 12 tests covering all cases

## Testing

`ash
cd apps/backend
pytest tests/unit/test_llm.py -v
`

**Results:** 12 passed

| Test | Description |
|------|-------------|
| 	est_none_temperature_returns_true | No temperature set → allow |
| 	est_ollama_always_true | Ollama models always support temperature |
| 	est_openai_gpt4_supports_temperature | GPT-4 supports temperature |
| 	est_model_without_temperature_param | Registry omits temperature → not supported |
| 	est_opus4_deprecated_temperature | Opus 4.x rejects any temperature |
| 	est_kimi_k26_only_allows_one | Kimi K2.6 only allows temperature=1 |
| 	est_model_not_in_registry | Unknown model → conservative skip |
| 	est_case_insensitive_model_name | Provider checks are case-insensitive |
| 	est_openai_progression | Standard retry progression [0.1, 0.3, 0.5, 0.7] |
| 	est_opus4_returns_none | Opus 4 retry returns None |
| 	est_kimi_k26_returns_one | Kimi K2.6 retry always returns 1.0 |
| 	est_custom_base_temp | Custom base_temp respected |

## Checklist

- [x] Code follows project style (PEP 8, explicit returns)
- [x] Added unit tests with mocked litellm.get_model_info()
- [x] No breaking changes to public API
- [x] Private function signature change (_get_retry_temperature) is safe — only called internally
- [x] Extensible design — new model restrictions can be added to _supports_temperature()

Fixes #759
