### PR TITLE
feat: Add Groq LLM provider support

### DIFF
--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -104,6 +104,7 @@ def _get_llm_api_key_with_fallback() -> str:
         "gemini": "google",
         "openrouter": "openrouter",
         "deepseek": "deepseek",
+        "groq": "groq",
         "ollama": "ollama",
     }
 
@@ -128,6 +129,7 @@ class Settings(BaseSettings):
         "openrouter",
         "gemini",
         "deepseek",
+        "groq",
         "ollama",
     ] = "openai"
     llm_model: str = "gpt-5-nano-2025-08-07"

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -306,6 +306,7 @@ _PROVIDER_KEY_MAP: dict[str, str] = {
     "gemini": "google",
     "openrouter": "openrouter",
     "deepseek": "deepseek",
+    "groq": "groq",
     "ollama": "ollama",
 }
 
@@ -416,6 +417,7 @@ def get_model_name(config: LLMConfig) -> str:
         "openrouter": "openrouter/",
         "gemini": "gemini/",
         "deepseek": "deepseek/",
+        "groq": "groq/",
         "ollama": "ollama_chat/",  # ollama_chat/ routes to /api/chat (supports messages array)
     }
 
@@ -434,6 +436,7 @@ def get_model_name(config: LLMConfig) -> str:
         "anthropic/",
         "gemini/",
         "deepseek/",
+        "groq/",
         "ollama/",
         "ollama_chat/",
         "openai/",
@@ -893,6 +896,7 @@ def _calculate_timeout(
         "openai": 1.0,
         "anthropic": 1.2,
         "openrouter": 1.5,  # More variable latency
+        "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower
     }
     provider_factor = provider_factors.get(provider, 1.0)

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -420,7 +420,7 @@ async def update_feature_prompts(
 
 
 # Supported API key providers
-SUPPORTED_PROVIDERS = ["openai", "anthropic", "google", "openrouter", "deepseek"]
+SUPPORTED_PROVIDERS = ["openai", "anthropic", "google", "openrouter", "deepseek", "groq"]
 
 
 def _mask_key_short(key: str | None) -> str | None:
@@ -500,6 +500,13 @@ async def update_api_keys(request: ApiKeysUpdateRequest) -> ApiKeysUpdateRespons
         elif "deepseek" in stored_keys:
             del stored_keys["deepseek"]
         updated.append("deepseek")
+
+    if request.groq is not None:
+        if request.groq:
+            stored_keys["groq"] = request.groq
+        elif "groq" in stored_keys:
+            del stored_keys["groq"]
+        updated.append("groq")
 
     save_api_keys_to_config(stored_keys)
     invalidate_config_cache()

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -680,6 +680,7 @@ class ApiKeysUpdateRequest(BaseModel):
     google: str | None = None
     openrouter: str | None = None
     deepseek: str | None = None
+    groq: str | None = None
 
 
 class ApiKeysUpdateResponse(BaseModel):

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -67,6 +67,7 @@ const PROVIDERS: LLMProvider[] = [
   'openrouter',
   'gemini',
   'deepseek',
+  'groq',
   'ollama',
 ];
 

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -8,6 +8,7 @@ export type LLMProvider =
   | 'openrouter'
   | 'gemini'
   | 'deepseek'
+  | 'groq'
   | 'ollama';
 
 // Reasoning-effort levels supported by LiteLLM. `null` (or absent) means
@@ -156,6 +157,7 @@ export const PROVIDER_INFO: Record<
   },
   gemini: { name: 'Google Gemini', defaultModel: 'gemini-3-flash-preview', requiresKey: true },
   deepseek: { name: 'DeepSeek', defaultModel: 'deepseek-chat', requiresKey: true },
+  groq: { name: 'Groq', defaultModel: 'llama-3.3-70b-versatile', requiresKey: true },
   ollama: { name: 'Ollama (Local)', defaultModel: 'gemma3:4b', requiresKey: false },
 };
 
@@ -367,7 +369,7 @@ export async function updateFeaturePrompts(update: FeaturePromptsUpdate): Promis
 }
 
 // API Key Management types
-export type ApiKeyProvider = 'openai' | 'anthropic' | 'google' | 'openrouter' | 'deepseek';
+export type ApiKeyProvider = 'openai' | 'anthropic' | 'google' | 'openrouter' | 'deepseek' | 'groq';
 
 export interface ApiKeyProviderStatus {
   provider: ApiKeyProvider;
@@ -385,6 +387,7 @@ export interface ApiKeysUpdateRequest {
   google?: string;
   openrouter?: string;
   deepseek?: string;
+  groq?: string;
 }
 
 export interface ApiKeysUpdateResponse {
@@ -400,6 +403,7 @@ export const API_KEY_PROVIDER_INFO: Record<ApiKeyProvider, { name: string; descr
     google: { name: 'Google', description: 'Gemini 1.5, Gemini 2, etc.' },
     openrouter: { name: 'OpenRouter', description: 'Access multiple providers' },
     deepseek: { name: 'DeepSeek', description: 'DeepSeek chat models' },
+    groq: { name: 'Groq', description: 'Llama, Mixtral, Gemma on Groq' },
   };
 
 // Fetch API key status for all providers


### PR DESCRIPTION
Closes #743

This PR adds Groq as a fully supported LLM provider across the entire stack.

## Changes

### Backend
- **config.py**: Added groq to llm_provider Literal and provider_map
- **llm.py**: Added groq/ prefix mapping, known prefix detection, _PROVIDER_KEY_MAP entry, and timeout factor (1.0x)
- **routers/config.py**: Added groq to SUPPORTED_PROVIDERS and API key update/delete handlers
- **schemas/models.py**: Added groq field to ApiKeysUpdateRequest

### Frontend
- **lib/api/config.ts**: Added groq to LLMProvider, PROVIDER_INFO (default: llama-3.3-70b-versatile), ApiKeyProvider, ApiKeysUpdateRequest, and API_KEY_PROVIDER_INFO
- **settings/page.tsx**: Added groq to PROVIDERS array

## Testing
- All existing unit tests pass (12/12)
- Groq uses LiteLLM native groq/ provider prefix
- Default model: llama-3.3-70b-versatile

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `groq` as a first-class LLM provider across the stack. You can add a Groq API key and set Groq as the default provider (default model: `llama-3.3-70b-versatile`).

- **New Features**
  - Backend/API: Added `groq` to provider maps and fallback key map, allowed default providers, `SUPPORTED_PROVIDERS`, and API key add/remove routes.
  - Frontend: Added `groq` to `LLMProvider`, `PROVIDER_INFO`, `ApiKeyProvider`, `ApiKeysUpdateRequest`, `API_KEY_PROVIDER_INFO`, and the Settings provider list.

<sup>Written for commit 7c75db6fd1c938c7807daf75c5dc78f2896634cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

