### PR TITLE
fix(llm): resolve DeepSeek 500 / Failed to analyze resume

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -300,6 +300,7 @@ _PROVIDER_KEY_MAP: dict[str, str] = {
     "gemini": "google",
     "openrouter": "openrouter",
     "deepseek": "deepseek",
+    "groq": "groq",
     "ollama": "ollama",
 }
 
@@ -410,6 +411,7 @@ def get_model_name(config: LLMConfig) -> str:
         "openrouter": "openrouter/",
         "gemini": "gemini/",
         "deepseek": "deepseek/",
+        "groq": "groq/",
         "ollama": "ollama_chat/",  # ollama_chat/ routes to /api/chat (supports messages array)
     }
 
@@ -428,6 +430,7 @@ def get_model_name(config: LLMConfig) -> str:
         "anthropic/",
         "gemini/",
         "deepseek/",
+        "groq/",
         "ollama/",
         "ollama_chat/",
         "openai/",
@@ -663,7 +666,7 @@ async def complete(
             "model": "primary",
             "messages": messages,
             "max_tokens": max_tokens,
-            "timeout": LLM_TIMEOUT_COMPLETION,
+            "timeout": _calculate_timeout("completion", max_tokens, config.provider),
         }
         if _supports_temperature(model_name, temperature):
             kwargs["temperature"] = temperature
@@ -722,29 +725,49 @@ def _supports_json_mode(model_name: str) -> bool:
         return False
 
 
-def _appears_truncated(data: dict) -> bool:
+def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:
     """LLM-001: Check if JSON data appears to be truncated.
 
     Detects suspicious patterns indicating incomplete responses.
+    The checks are schema-aware so that enrichment/diff/keyword outputs
+    are not evaluated against resume-structure heuristics.
+
+    Args:
+        data: Parsed JSON dict.
+        schema_type: Expected schema — "resume" (full resume), "enrichment"
+            (analyze output), "diff" (diff changes), or "keywords".
+            Determines which fields are checked for truncation.
     """
     if not isinstance(data, dict):
         return False
 
-    # Check for empty arrays that should typically have content
-    suspicious_empty_arrays = ["workExperience", "education", "skills"]
-    for key in suspicious_empty_arrays:
-        if key in data and data[key] == []:
-            # Log warning - these are rarely empty in real resumes
+    if schema_type == "resume":
+        # Full resume structure: check for empty required arrays
+        suspicious_empty_arrays = ["workExperience", "education", "skills"]
+        for key in suspicious_empty_arrays:
+            if key in data and data[key] == []:
+                # Log warning - these are rarely empty in real resumes
+                logging.warning(
+                    "Possible truncation detected: '%s' is empty",
+                    key,
+                )
+                return True
+        return False
+
+    if schema_type == "enrichment":
+        # Enrichment analyze returns items_to_enrich + questions.
+        # Empty arrays are valid (resume is already strong).
+        # Only flag if keys are entirely missing (LLM ignored structure).
+        if "items_to_enrich" not in data or "questions" not in data:
             logging.warning(
-                "Possible truncation detected: '%s' is empty",
-                key,
+                "Possible truncation detected: enrichment missing required keys"
             )
             return True
+        return False
 
-    # personalInfo is intentionally excluded: the improve prompts tell the LLM
-    # to skip it, and _preserve_personal_info() restores it from the original.
-    # Checking for it here caused 3 wasteful retry attempts on every request.
-
+    # For "diff", "keywords", and unknown schemas: no truncation heuristics.
+    # Diff may legitimately return empty changes; keywords may return empty
+    # lists when the job description has no actionable terms.
     return False
 
 
@@ -840,6 +863,8 @@ def _calculate_timeout(
         "openai": 1.0,
         "anthropic": 1.2,
         "openrouter": 1.5,  # More variable latency
+        "deepseek": 1.3,  # DeepSeek API can be slower than OpenAI
+        "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower
     }
     provider_factor = provider_factors.get(provider, 1.0)
@@ -952,12 +977,18 @@ async def complete_json(
     config: LLMConfig | None = None,
     max_tokens: int = 4096,
     retries: int = 2,
+    schema_type: str = "resume",
 ) -> dict[str, Any]:
     """Make a completion request expecting JSON response.
 
     Uses JSON mode when available, with app-level retries for content-quality
     issues (malformed JSON, truncation).  Transport retries (429, 500, timeout)
     are handled by the Router and are NOT retried again here.
+
+    Args:
+        schema_type: Expected schema — "resume", "enrichment", "diff", or
+            "keywords". Passed to _appears_truncated for context-aware truncation
+            detection and used to tailor retry hints.
     """
     router, config = get_router(config)
     model_name = get_model_name(config)
@@ -973,6 +1004,7 @@ async def complete_json(
 
     # Check if we can use JSON mode
     use_json_mode = _supports_json_mode(model_name)
+    json_mode_failed = False
 
     for attempt in range(retries + 1):
         try:
@@ -989,8 +1021,10 @@ async def complete_json(
             if config.reasoning_effort:
                 kwargs["reasoning_effort"] = config.reasoning_effort
 
-            # Add JSON mode if supported
-            if use_json_mode:
+            # JSON-012: Fallback to prompt-only JSON mode after JSON-mode failure.
+            # LiteLLM registry may report support for models that the upstream
+            # aggregator (OpenRouter) cannot actually serve with response_format.
+            if use_json_mode and not json_mode_failed:
                 kwargs["response_format"] = {"type": "json_object"}
 
             response = await router.acompletion(**kwargs)
@@ -1007,17 +1041,26 @@ async def complete_json(
             result = json.loads(json_str)
 
             # LLM-001: Check if parsed result appears truncated
-            if isinstance(result, dict) and _appears_truncated(result):
+            if isinstance(result, dict) and _appears_truncated(result, schema_type):
                 if attempt < retries:
                     logging.warning(
                         "Parsed JSON appears truncated (attempt %d/%d), retrying",
                         attempt + 1,
                         retries + 1,
                     )
-                    messages[-1]["content"] = (
-                        prompt
-                        + "\n\nIMPORTANT: Output the COMPLETE JSON object with ALL sections including personalInfo. Do not truncate."
-                    )
+                    if schema_type == "resume":
+                        hint = (
+                            "\n\nIMPORTANT: Output the COMPLETE JSON object with ALL sections. Do not truncate."
+                        )
+                    elif schema_type == "enrichment":
+                        hint = (
+                            "\n\nIMPORTANT: Output the COMPLETE JSON object with ALL keys: items_to_enrich, questions, analysis_summary. Do not truncate."
+                        )
+                    else:
+                        hint = (
+                            "\n\nIMPORTANT: Output ONLY a valid JSON object. Start with { and end with }."
+                        )
+                    messages[-1]["content"] = prompt + hint
                     continue
                 logging.warning(
                     "Parsed JSON appears truncated on final attempt, proceeding with result"
@@ -1028,6 +1071,14 @@ async def complete_json(
         except json.JSONDecodeError as e:
             # Content quality — malformed JSON, retry with prompt hint
             logging.warning(f"JSON parse failed (attempt {attempt + 1}): {e}")
+            if use_json_mode and not json_mode_failed:
+                # JSON-012: Registry claimed JSON mode support but the upstream
+                # failed to return valid JSON. Disable JSON mode for retries.
+                json_mode_failed = True
+                logging.warning(
+                    "JSON mode failed for %s, falling back to prompt-only (attempt %d)",
+                    model_name, attempt + 1,
+                )
             if attempt < retries:
                 messages[-1]["content"] = (
                     prompt

--- a/apps/backend/app/routers/enrichment.py
+++ b/apps/backend/app/routers/enrichment.py
@@ -115,7 +115,10 @@ async def analyze_resume(resume_id: str) -> AnalysisResponse:
 
     try:
         # Call LLM with increased max_tokens for non-English languages
-        result = await complete_json(prompt, max_tokens=8192)
+        result = await asyncio.wait_for(
+            complete_json(prompt, max_tokens=8192, schema_type="enrichment"),
+            timeout=180.0,  # 3-minute hard limit
+        )
 
         # Parse response into schema objects
         items_to_enrich = [
@@ -146,8 +149,20 @@ async def analyze_resume(resume_id: str) -> AnalysisResponse:
             analysis_summary=result.get("analysis_summary"),
         )
 
+    except asyncio.TimeoutError:
+        logger.error("Resume analysis timed out for resume %s", resume_id)
+        raise HTTPException(
+            status_code=504,
+            detail="Resume analysis timed out. Please try again with a shorter resume or a faster model.",
+        )
+    except ValueError as e:
+        logger.error("Resume analysis failed (content): %s", e)
+        raise HTTPException(
+            status_code=422,
+            detail="The AI returned an unreadable response. Please try again or switch models.",
+        )
     except Exception as e:
-        logger.error(f"Resume analysis failed: {e}")
+        logger.error("Resume analysis failed: %s", e)
         raise HTTPException(
             status_code=500,
             detail="Failed to analyze resume. Please try again.",
@@ -205,9 +220,24 @@ async def generate_enhancements(request: EnhanceRequest) -> EnhancementPreview:
         )
 
         try:
-            analysis_result = await complete_json(analysis_prompt, max_tokens=8192)
+            analysis_result = await asyncio.wait_for(
+                complete_json(analysis_prompt, max_tokens=8192, schema_type="enrichment"),
+                timeout=180.0,
+            )
+        except asyncio.TimeoutError:
+            logger.error("Resume re-analysis timed out for resume %s", request.resume_id)
+            raise HTTPException(
+                status_code=504,
+                detail="Resume analysis timed out. Please try again with a shorter resume or a faster model.",
+            )
+        except ValueError as e:
+            logger.error("Resume re-analysis failed (content): %s", e)
+            raise HTTPException(
+                status_code=422,
+                detail="The AI returned an unreadable response. Please try again or switch models.",
+            )
         except Exception as e:
-            logger.error(f"Failed to re-analyze resume: {e}")
+            logger.error("Failed to re-analyze resume: %s", e)
             raise HTTPException(
                 status_code=500,
                 detail="Failed to process enhancements. Please try again.",
@@ -268,7 +298,7 @@ async def generate_enhancements(request: EnhanceRequest) -> EnhancementPreview:
         )
 
         try:
-            result = await complete_json(prompt)
+            result = await complete_json(prompt, schema_type="diff")
             # Get additional bullets from LLM (new key name)
             additional_bullets = result.get("additional_bullets", [])
             # Fallback to old key for backwards compatibility
@@ -404,7 +434,7 @@ async def _regenerate_experience_or_project(
         user_instruction=instruction,
     )
 
-    result = await complete_json(prompt, max_tokens=4096)
+    result = await complete_json(prompt, max_tokens=4096, schema_type="diff")
 
     new_bullets = result.get("new_bullets", [])
     if not isinstance(new_bullets, list):
@@ -436,7 +466,7 @@ async def _regenerate_skills(
         user_instruction=instruction,
     )
 
-    result = await complete_json(prompt, max_tokens=2048)
+    result = await complete_json(prompt, max_tokens=2048, schema_type="diff")
 
     new_skills = result.get("new_skills", [])
     if not isinstance(new_skills, list):

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -481,6 +481,7 @@ async def generate_resume_diffs(
         prompt=prompt,
         system_prompt="You are an expert resume editor. Output only valid JSON with targeted changes.",
         max_tokens=4096,
+        schema_type="diff",
     )
 
     # Parse result — handle LLM ignoring diff format gracefully
@@ -530,6 +531,7 @@ async def extract_job_keywords(job_description: str) -> dict[str, Any]:
     return await complete_json(
         prompt=prompt,
         system_prompt="You are an expert job description analyzer.",
+        schema_type="keywords",
     )
 
 

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -1,10 +1,10 @@
 """Unit tests for LLM capability helpers in app.llm."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.llm import _get_retry_temperature, _supports_temperature
+from app.llm import _appears_truncated, _get_retry_temperature, _supports_temperature
 
 
 # ---------------------------------------------------------------------------
@@ -123,3 +123,222 @@ class TestGetRetryTemperature:
         }
         assert _get_retry_temperature("gpt-4", 0, base_temp=0.2) == 0.2
         assert _get_retry_temperature("gpt-4", 1, base_temp=0.2) == 0.3
+
+
+# ---------------------------------------------------------------------------
+# _appears_truncated
+# ---------------------------------------------------------------------------
+
+
+class TestAppearsTruncated:
+    """Tests for _appears_truncated() with schema_type awareness."""
+
+    # --- resume schema ---
+
+    def test_resume_empty_work_experience(self):
+        """Empty workExperience array in resume structure is suspicious."""
+        data = {
+            "personalInfo": {"name": "John"},
+            "workExperience": [],
+            "education": [{"degree": "BS"}],
+            "skills": ["Python"],
+        }
+        assert _appears_truncated(data, schema_type="resume") is True
+
+    def test_resume_empty_education(self):
+        """Empty education array in resume structure is suspicious."""
+        data = {
+            "personalInfo": {"name": "John"},
+            "workExperience": [{"title": "Dev"}],
+            "education": [],
+            "skills": ["Python"],
+        }
+        assert _appears_truncated(data, schema_type="resume") is True
+
+    def test_resume_empty_skills(self):
+        """Empty skills array in resume structure is suspicious."""
+        data = {
+            "personalInfo": {"name": "John"},
+            "workExperience": [{"title": "Dev"}],
+            "education": [{"degree": "BS"}],
+            "skills": [],
+        }
+        assert _appears_truncated(data, schema_type="resume") is True
+
+    def test_resume_valid(self):
+        """Well-formed resume with all sections present is not truncated."""
+        data = {
+            "personalInfo": {"name": "John"},
+            "workExperience": [{"title": "Dev"}],
+            "education": [{"degree": "BS"}],
+            "skills": ["Python"],
+        }
+        assert _appears_truncated(data, schema_type="resume") is False
+
+    def test_resume_missing_fields_not_empty(self):
+        """Missing fields are not the same as empty arrays — not flagged."""
+        data = {
+            "personalInfo": {"name": "John"},
+            "workExperience": [{"title": "Dev"}],
+            # education and skills omitted
+        }
+        assert _appears_truncated(data, schema_type="resume") is False
+
+    # --- enrichment schema ---
+
+    def test_enrichment_missing_keys(self):
+        """Missing required keys in enrichment output is suspicious."""
+        data = {"analysis_summary": "Good resume"}
+        assert _appears_truncated(data, schema_type="enrichment") is True
+
+    def test_enrichment_empty_arrays(self):
+        """Empty items_to_enrich and questions are valid (resume already strong)."""
+        data = {
+            "items_to_enrich": [],
+            "questions": [],
+            "analysis_summary": "Already strong",
+        }
+        assert _appears_truncated(data, schema_type="enrichment") is False
+
+    def test_enrichment_populated(self):
+        """Populated enrichment output is not truncated."""
+        data = {
+            "items_to_enrich": [{"item_id": "exp_0"}],
+            "questions": [{"question_id": "q_0"}],
+            "analysis_summary": "Needs work",
+        }
+        assert _appears_truncated(data, schema_type="enrichment") is False
+
+    # --- diff schema ---
+
+    def test_diff_empty_changes(self):
+        """Empty changes array in diff output is valid (no changes needed)."""
+        data = {"changes": [], "strategy_notes": "No changes needed"}
+        assert _appears_truncated(data, schema_type="diff") is False
+
+    def test_diff_populated(self):
+        """Populated diff output is not truncated."""
+        data = {"changes": [{"path": "summary", "action": "replace"}]}
+        assert _appears_truncated(data, schema_type="diff") is False
+
+    # --- keywords schema ---
+
+    def test_keywords_empty(self):
+        """Empty keyword lists are valid (sparse job description)."""
+        data = {"required_skills": [], "preferred_skills": [], "keywords": []}
+        assert _appears_truncated(data, schema_type="keywords") is False
+
+    # --- default / unknown schema ---
+
+    def test_default_schema_acts_like_resume(self):
+        """Default schema_type behaves like 'resume' for backwards compatibility."""
+        data = {"workExperience": [], "education": [{"degree": "BS"}]}
+        assert _appears_truncated(data) is True
+
+    def test_unknown_schema_no_heuristics(self):
+        """Unknown schema types have no truncation heuristics."""
+        data = {"anything": []}
+        assert _appears_truncated(data, schema_type="custom") is False
+
+
+# ---------------------------------------------------------------------------
+# complete_json JSON mode fallback
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteJsonFallback:
+    """Tests for JSON mode fallback in complete_json()."""
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
+    async def test_json_mode_fallback_on_parse_error(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """When JSON mode returns invalid JSON, fallback to prompt-only mode.
+
+        First call: JSON mode enabled → returns malformed JSON (trailing comma)
+          → _extract_json succeeds → json.loads fails → JSONDecodeError
+        Second call: JSON mode disabled → returns valid JSON → success
+        """
+        mock_supports_json.return_value = True
+        mock_get_name.return_value = "openrouter/openai/gpt-5.4"
+
+        # First response: balanced braces but trailing comma → json.loads fails
+        bad_choice = MagicMock()
+        bad_choice.message.content = '{"items_to_enrich": [], "questions": [],}'
+        bad_response = MagicMock()
+        bad_response.choices = [bad_choice]
+
+        # Second response: valid JSON without JSON mode
+        good_choice = MagicMock()
+        good_choice.message.content = '{"items_to_enrich": [], "questions": [], "analysis_summary": "ok"}'
+        good_response = MagicMock()
+        good_response.choices = [good_choice]
+
+        router = MagicMock()
+        router.acompletion = AsyncMock(side_effect=[bad_response, good_response])
+        config = MagicMock()
+        config.provider = "openrouter"
+        config.reasoning_effort = None
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json(
+            prompt="Test prompt",
+            schema_type="enrichment",
+            retries=2,
+        )
+
+        assert result == {
+            "items_to_enrich": [],
+            "questions": [],
+            "analysis_summary": "ok",
+        }
+        # Verify JSON mode was used on first call but not second
+        calls = router.acompletion.call_args_list
+        assert calls[0].kwargs.get("response_format") == {"type": "json_object"}
+        assert "response_format" not in calls[1].kwargs
+
+
+# ---------------------------------------------------------------------------
+# complete() dynamic timeout
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteDynamicTimeout:
+    """Tests for complete() using _calculate_timeout()."""
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._calculate_timeout")
+    @patch("app.llm._supports_temperature")
+    async def test_uses_calculate_timeout(
+        self, mock_supports_temp, mock_calc_timeout, mock_get_name, mock_get_router
+    ):
+        """complete() passes provider and max_tokens to _calculate_timeout."""
+        mock_supports_temp.return_value = True
+        mock_calc_timeout.return_value = 180
+        mock_get_name.return_value = "deepseek/deepseek-chat"
+
+        choice = MagicMock()
+        choice.message.content = "Hello"
+        response = MagicMock()
+        response.choices = [choice]
+
+        router = MagicMock()
+        router.acompletion = AsyncMock(return_value=response)
+        config = MagicMock()
+        config.provider = "deepseek"
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete
+
+        await complete(prompt="Hi", max_tokens=8192)
+
+        mock_calc_timeout.assert_called_once_with("completion", 8192, "deepseek")
+        router.acompletion.assert_awaited_once()
+        assert router.acompletion.call_args.kwargs["timeout"] == 180


### PR DESCRIPTION
Closes #706

## Summary

Fixes five root causes of the Failed to analyze resume (status 500) error reported by DeepSeek and OpenRouter users.

## Root Causes

1. _appears_truncated checked resume-only fields against enrichment/diff/keyword outputs, causing false-positive truncation detection.
2. complete_json sent response_format on every retry even when upstream (OpenRouter) failed to return valid JSON.
3. enrichment/analyze had no asyncio.wait_for guard.
4. complete() used fixed 120s timeout instead of provider-aware _calculate_timeout.
5. DeepSeek had no provider factor, defaulting to 1.0x despite higher latency.

## Changes

- app/llm.py: _appears_truncated gains schema_type param; complete_json gains schema_type + JSON mode fallback; complete() uses dynamic timeout; deepseek factor added.
- app/routers/enrichment.py: analyze_resume wrapped in asyncio.wait_for(timeout=180.0) with specific 504/422/500 errors.
- app/services/improver.py: passes schema_type to complete_json calls.

## Testing

- 27/27 unit tests in test_llm.py pass (12 existing + 15 new).
- New tests cover _appears_truncated schema awareness (12 cases), JSON mode fallback (1 case), dynamic timeout (1 case).

## Backwards Compatibility

- schema_type defaults to resume.
- complete() timeout only increases (base 120s x provider factor).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes recurring “Failed to analyze resume” 500s for DeepSeek and OpenRouter with schema-aware JSON handling, a JSON-mode fallback, and smarter per-provider timeouts. Adds `groq` provider support and stabilizes resume analysis and improvement flows.

- **Bug Fixes**
  - Truncation checks are schema-aware (resume/enrichment/diff/keywords) to avoid false positives.
  - Fallback from JSON mode after the first JSON parsing error; stop sending response_format and add targeted retry hints.
  - Analyze endpoints use a 180s asyncio.wait_for with clear 504 (timeout), 422 (unreadable content), and 500 errors.
  - Completion uses dynamic timeouts per provider; added a DeepSeek factor (1.3x) to handle higher latency.
  - Enrichment/improver calls pass the expected schema_type to JSON completions.
  - Added `groq` routing and provider handling to model maps and timeouts.

<sup>Written for commit 8335828a68831634010103d32e99a3b77d0d04f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

