### PR TITLE
fix(deps): pin python-dotenv to 1.0.1 to satisfy litellm (#779)

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pdfminer.six==20260107",
     "playwright==1.58.0",
     "python-docx==1.2.0",
-    "python-dotenv==1.2.2",
+    "python-dotenv==1.0.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Related Issue

Closes #779.

## Description

PR #761 (dependabot) bumped `python-dotenv` from `1.0.1` to `1.2.2`, but `litellm` (already in our dependency tree) still pins `python-dotenv==1.0.1`. The two pins are mutually unsatisfiable, so `uv sync` fails immediately on a clean clone:

- `litellm` requires `python-dotenv==1.0.1`
- `rm-backend` (this project) requires `python-dotenv==1.2.2`

Result: nobody can set up the backend on `main`.

This PR pins `python-dotenv` back to `1.0.1` to match `litellm`'s constraint, as suggested by the issue reporter in #779. Once `litellm` relaxes its dotenv pin, dependabot can lift this back up.

## Type

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes

- `apps/backend/pyproject.toml`: change `python-dotenv==1.2.2` → `python-dotenv==1.0.1`.

## Screenshots / Code Snippets (if applicable)

See #779 for the original `uv sync` failure report.

## How to Test

1. On `main` (or with the dotenv pin reverted to `1.2.2`), `uv sync --extra dev` fails

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `python-dotenv` to `1.0.1` to match `litellm` and restore successful `uv sync` on clean installs.

<sup>Written for commit 98b9f99599884e9b3cacce779c2f2f760c2be3e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

