### PR TITLE
fix(llm): remove duplicated _appears_truncated stub

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -731,7 +731,6 @@ def _supports_json_mode(model_name: str) -> bool:
         return False
 
 
-def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:
 FALLBACK_MAX_TOKENS = 4096
 
 def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKENS) -> int:
@@ -779,7 +778,7 @@ def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKEN
     return safe
 
 
-def _appears_truncated(data: dict) -> bool:
+def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:
     """LLM-001: Check if JSON data appears to be truncated.
 
     Detects suspicious patterns indicating incomplete responses.


### PR DESCRIPTION
## Related Issue

Regression introduced by #775 (`fix(llm): resolve DeepSeek 500 / Failed to analyze resume (#706)`, commit `4dda99f`). No dedicated issue tracks this — the symptom is `uv run app` failing immediately at import time with an `IndentationError`, so anyone on `main` cannot start the backend at all.

## Description

`app/llm.py` ends up with **two** definitions of `_appears_truncated`, both broken, so the entire backend crashes at import time:

```
File ".../apps/backend/app/llm.py", line 735
    FALLBACK_MAX_TOKENS = 4096
    ^^^^^^^^^^^^^^^^^^^
IndentationError: expected an indented block after function definition on line 734
```

### Root cause (introduced by #775)

`git blame upstream/main -- apps/backend/app/llm.py` shows the refactor in #775 was only partially applied:

- **L734** (commit `4dda99f`, PR #775): a new schema-aware signature `def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:` was inserted, immediately followed by `FALLBACK_MAX_TOKENS = 4096` -> `IndentationError` at module load.
- **L782** (commit `d2567520`, original): the original implementation `def _appears_truncated(data: dict) -> bool:` was left in place. Its docstring was updated by #775, but its signature was not — so `schema_type` is referenced inside the body without being a parameter, and the only call site `_appears_truncated(result, schema_type)` at L1098 (also added by #775) would have raised `NameError`/`TypeError` even after fixing the `IndentationError`.

In other words: the new signature was pasted on top, the function body was never moved, and the old definition was never deleted.

## Type

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes

- Remove the empty stub at `app/llm.py:734` (keep `FALLBACK_MAX_TOKENS = 4096`, which `get_safe_max_tokens` depends on).
- Update the real implementation at `app/llm.py:782` to use the schema-aware signature `def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:` so it matches both its body and its callers.

## Screenshots / Code Snippets (if applicable)

Reproducer on `main`:

```bash
$ uv run app
Traceback (most recent call last):
  File ".../apps/backend/.venv/bin/app", line 4, in <module>
    from app.main import main
  File ".../apps/backend/app/main.py", line 21, in <module>
    from app.routers import config_router, enrichment_router, health_router, jobs_router, resumes_router
  File ".../apps/backend/app/routers/__init__.py", line 3, in <module>
    from app.routers.config import router as config_router
  File ".../apps/backend/app/routers/config.py", line 10, in <module>
    from app.llm import check_llm_health, LLMConfig, resolve_api_key
  File ".../apps/backend/app/llm.py", line 735
    FALLBACK_MAX_TOKENS = 4096
    ^^^^^^^^^^^^^^^^^^^
IndentationError: expected an indented block after function definition on line 734
```

## How to Test

1. `uv run python -c "from app.llm import _appears_truncated; print('ok')"` -> prints `ok` (no `IndentationError`).
2. `uv run pytest tests/unit/test_llm.py::TestAppearsTruncated -q` -> **13/13 passing** 
3. `uv run pytest -q` -> **179 passing**. One pre-existing failure unrelated to this PR remains.
4. `uv run app` -> backend boots without `IndentationError`.

## Checklist

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [x] All tests (if applicable) pass successfully
- [] This pull request has been linked to the related issue (if applicable)

## Additional Information

While verifying this fix locally I had to pin `python-dotenv` back to `1.0.1` because `1.2.2` (the current `pyproject.toml` pin from #761) conflicts with `litellm`'s `==1.0.1` requirement, so `uv sync` itself fails. The dependency fix is in #780.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes backend import crash by removing a duplicate `_appears_truncated` stub and aligning the function signature with callers. Restores `uv run app` startup by resolving the IndentationError.

- **Bug Fixes**
  - Removed the empty `_appears_truncated` definition; kept `FALLBACK_MAX_TOKENS = 4096`.
  - Updated `_appears_truncated` to `def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:` to match usage.

<sup>Written for commit 820dc37488dbcd9220446cf2c75395e5e7f1d0e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

