### PR TITLE
fix(docker): add CJK fonts for Chinese/Japanese/Korean PDF rendering (#777)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 \
     libatspi2.0-0 \
     libgtk-3-0 \
+    # CJK fonts for Chinese/Japanese/Korean PDF rendering via Playwright
+    fonts-noto-cjk \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
Closes #777

## Problem

Users running Resume-Matcher via Docker (`docker compose up`) experience garbled / box-character output when exporting Chinese resumes to PDF. The same code works correctly when running from source, because the host OS has CJK fonts installed.

## Root Cause

The Docker image uses `python:3.13-slim-bookworm` as its base, which is a minimal Debian image that does **not** include any CJK fonts. PDF rendering uses Playwright + headless Chromium, which relies on system font fallback for Chinese characters. Without CJK fonts available in the container, Chromium has nothing to fall back to.

## Fix

Add `fonts-noto-cjk` to the Dockerfile's `apt-get install` block. This package provides comprehensive CJK font coverage (Chinese, Japanese, Korean) and is the standard choice for Debian-based containers.

## Verification

After rebuilding the image:
1. `docker compose up`
2. Create a resume with Chinese text
3. Export to PDF → characters render correctly

## Impact

- Adds ~150MB to the image size (fonts-noto-cjk)
- No code changes — purely an environment fix
- Also benefits Japanese (`ja`) resume exports

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes garbled CJK text in PDF exports when running via Docker by installing `fonts-noto-cjk` in the `python:3.13-slim-bookworm` image. Addresses #777 and improves Chinese/Japanese/Korean rendering in `Playwright`/Chromium, with ~150MB image size increase and no app code changes.

- **Migration**
  - Rebuild the Docker image and rerun `docker compose up`.

<sup>Written for commit c9528efefec0954e72bf005b7e00bf4ac285ed4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

