### PR TITLE
Fixed Indentation

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -732,7 +732,7 @@ def _supports_json_mode(model_name: str) -> bool:
 
 
 def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:
-FALLBACK_MAX_TOKENS = 4096
+    FALLBACK_MAX_TOKENS = 4096
 
 def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKENS) -> int:
     """Return a token count safe for the given model, clamped to its output limit.


### PR DESCRIPTION
# Pull Request Title
<!-- Provide a concise and descriptive title for the pull request -->

## Related Issue
<!-- If this pull request is related to an issue, please link it here using the "#" symbol followed by the issue number (e.g., #123) -->

## Description
<!-- Describe the changes made in this pull request. What problem does it solve or what feature does it add/modify? -->
copilot:summary

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [ ] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes
<!-- List the specific changes made in this pull request -->

-
-
-

## Screenshots / Code Snippets (if applicable)
<!-- Include any relevant screenshots or code snippets that help visualize the changes made -->

## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1.
2.
3.

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [ ] The code compiles successfully without any errors or warnings
- [ ] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [ ] The changes follow the project's coding guidelines and best practices
- [ ] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [ ] This pull request has been linked to the related issue (if applicable)

## Additional Information
<!-- Add any other information about the pull request that you think might be helpful -->
copilot:walkthrough


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes indentation in apps/backend/app/llm.py so _appears_truncated has a valid body, preventing a SyntaxError and restoring backend startup.

<sup>Written for commit d2f463a4d3f537c16f4ead1c4312127a9d343a06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

