### PR TITLE
Remove repeated def for _appears_truncated

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -731,7 +731,6 @@ def _supports_json_mode(model_name: str) -> bool:
         return False
 
 
-def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:
 FALLBACK_MAX_TOKENS = 4096
 
 def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKENS) -> int:
@@ -779,7 +778,7 @@ def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKEN
     return safe
 
 
-def _appears_truncated(data: dict) -> bool:
+def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:
     """LLM-001: Check if JSON data appears to be truncated.
 
     Detects suspicious patterns indicating incomplete responses.


### PR DESCRIPTION
# Remove repeated def for _appears_truncated

## Description
This error makes backend crash due to the file `apps/backend/app/llm.py` having a duplicated `def` statement for function `_appears_truncated` with an empty body.
The fix removes the duplicated `def` statement and adds the `schema_type` parameter to the original  `_appears_truncated` definition`.

## Type
- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes
Remove repeated function definition for _appears_truncated

## Checklist

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [ ] This pull request has been linked to the related issue (if applicable)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a backend crash by removing a duplicate `_appears_truncated` definition in `apps/backend/app/llm.py`. Consolidates to a single function and adds the `schema_type` parameter (default: "resume") to maintain expected truncation checks.

<sup>Written for commit 03d06d40d558b2fe60875f1fb99794518894a9eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

