### PR TITLE
[codex] Add verifier-led resume tailoring loop

### DIFF
--- a/apps/backend/app/prompts/__init__.py
+++ b/apps/backend/app/prompts/__init__.py
@@ -11,6 +11,7 @@ from app.prompts.templates import (
     IMPROVE_RESUME_PROMPT,
     IMPROVE_RESUME_PROMPTS,
     PARSE_RESUME_PROMPT,
+    SKILL_TARGET_PLAN_PROMPT,
     get_language_name,
 )
 
@@ -48,6 +49,7 @@ __all__ = [
     "CRITICAL_TRUTHFULNESS_RULES",
     "DIFF_IMPROVE_PROMPT",
     "DIFF_STRATEGY_INSTRUCTIONS",
+    "SKILL_TARGET_PLAN_PROMPT",
     "GENERATE_TITLE_PROMPT",
     "REQUIRED_FEATURE_PROMPT_PLACEHOLDERS",
     "validate_prompt_placeholders",

--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -416,8 +416,43 @@ RESUME_SCHEMA = RESUME_SCHEMA_EXAMPLE
 DIFF_STRATEGY_INSTRUCTIONS = {
     "nudge": "Make minimal edits. Only rephrase where there is a clear match. Do not add new bullet points.",
     "keywords": "Weave in relevant keywords where evidence already exists. You may rephrase bullets but do not add new ones.",
-    "full": "Make targeted adjustments. You may rephrase bullets and add new ones that elaborate on existing work, but do not invent new responsibilities.",
+    "full": "Make targeted adjustments. You may rephrase bullets, add verified JD skills, and add new bullets that elaborate on existing work, but do not invent new responsibilities.",
 }
+
+SKILL_TARGET_PLAN_PROMPT = """Build a concise skill target plan for tailoring this resume to the job.
+
+Return ONLY a JSON object. Do not rewrite the resume.
+
+Rules:
+1. Prefer required and preferred JD skills.
+2. Include existing resume skills that are highly relevant to the JD.
+3. You may include JD skills that are missing from the resume skills list.
+4. Do not include skills unrelated to the JD.
+5. Do not include certifications.
+6. Generate reasons in {output_language}.
+
+Existing resume skills:
+{existing_skills}
+
+JD keywords and skills:
+{job_keywords}
+
+Job Description:
+{job_description}
+
+Resume JSON:
+{original_resume}
+
+Output this exact JSON format:
+{{
+  "target_skills": [
+    {{
+      "skill": "skill name",
+      "reason": "why this skill should be emphasized"
+    }}
+  ],
+  "strategy_notes": "brief notes for the next editing pass"
+}}"""
 
 DIFF_IMPROVE_PROMPT = """Given this resume and job description, output a JSON object with targeted changes to better align the resume with the job.
 
@@ -431,6 +466,8 @@ RULES:
 7. Generate all new text in {output_language}
 8. Do not use em dash characters
 9. Keep changes minimal and targeted — do not rewrite content that already aligns well
+10. Use skill additions only from the verified skill targets below
+11. Improve work and project bullets around the verified skill targets when the original text supports that alignment
 
 PATHS you can target:
 - "summary" — the resume summary text
@@ -438,12 +475,15 @@ PATHS you can target:
 - "workExperience[i].description" — append a new bullet (action: "append")
 - "personalProjects[i].description[j]" — a specific project bullet
 - "personalProjects[i].description" — append a new project bullet
-- "additional.technicalSkills" — reorder the skills list (action: "reorder")
+- "additional.technicalSkills" — reorder the skills list (action: "reorder") or add one verified skill (action: "add_skill")
 
 Do NOT target: personalInfo, dates/years, company names, education, customSections.
 
 Keywords to emphasize (only if already supported by resume content):
 {job_keywords}
+
+Verified skill targets:
+{skill_targets}
 
 Job Description:
 {job_description}
@@ -474,6 +514,13 @@ Output this exact JSON format, nothing else:
       "original": null,
       "value": ["most relevant skill first", "then next", "..."],
       "reason": "reordered to prioritize JD-relevant skills"
+    }},
+    {{
+      "path": "additional.technicalSkills",
+      "action": "add_skill",
+      "original": null,
+      "value": "verified skill target missing from the skills list",
+      "reason": "added verified JD skill for review"
     }}
   ],
   "strategy_notes": "brief summary of the tailoring approach"

--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -458,7 +458,7 @@ DIFF_IMPROVE_PROMPT = """Given this resume and job description, output a JSON ob
 
 RULES:
 1. Only modify content — never change names, companies, dates, institutions, or degrees
-2. Do not invent skills, metrics, or achievements not supported by the original resume text
+2. Do not invent metrics or achievements not supported by the original resume text
 3. Do not add new work entries, education entries, or project entries
 4. {strategy_instruction}
 5. Each change MUST include the original text (copied exactly) so it can be verified
@@ -466,7 +466,7 @@ RULES:
 7. Generate all new text in {output_language}
 8. Do not use em dash characters
 9. Keep changes minimal and targeted — do not rewrite content that already aligns well
-10. Use skill additions only from the verified skill targets below
+10. Exception to rule 2: you may add a skill only if it appears in the verified skill targets below
 11. Improve work and project bullets around the verified skill targets when the original text supports that alignment
 
 PATHS you can target:

--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -47,8 +47,10 @@ from app.services.improver import (
     apply_diffs,
     extract_job_keywords,
     generate_improvements,
+    generate_skill_target_plan,
     generate_resume_diffs,
     improve_resume,
+    verify_skill_target_plan,
     verify_diff_result,
 )
 from app.services.refiner import refine_resume, calculate_keyword_match
@@ -744,6 +746,35 @@ async def _improve_preview_flow(
 
     # Diff-based improvement: generate targeted changes, apply with verification
     if original_resume_data:
+        skill_targets: list[dict[str, Any]] = []
+        try:
+            raw_skill_plan = await generate_skill_target_plan(
+                original_resume_data=original_resume_data,
+                job_description=job["content"],
+                job_keywords=job_keywords,
+                language=language,
+            )
+            verified_skill_plan = verify_skill_target_plan(
+                raw_skill_plan,
+                original_resume_data=original_resume_data,
+                job_keywords=job_keywords,
+            )
+            accepted_targets = verified_skill_plan.get("accepted", [])
+            if isinstance(accepted_targets, list):
+                skill_targets = [
+                    target
+                    for target in accepted_targets
+                    if isinstance(target, dict)
+                ]
+            rejected_targets = verified_skill_plan.get("rejected", [])
+            if isinstance(rejected_targets, list) and rejected_targets:
+                response_warnings.append(
+                    f"{len(rejected_targets)} unsupported skill target(s) rejected"
+                )
+        except Exception as e:
+            logger.warning("Skill target planning failed, continuing without it: %s", e)
+            response_warnings.append("Skill target planning failed")
+
         diff_result = await generate_resume_diffs(
             original_resume=resume["content"],
             job_description=job["content"],
@@ -751,6 +782,7 @@ async def _improve_preview_flow(
             language=language,
             prompt_id=prompt_id,
             original_resume_data=original_resume_data,
+            skill_targets=skill_targets,
         )
 
         improved_data, applied_changes, rejected_changes = apply_diffs(

--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -758,6 +758,7 @@ async def _improve_preview_flow(
                 raw_skill_plan,
                 original_resume_data=original_resume_data,
                 job_keywords=job_keywords,
+                job_description=job["content"],
             )
             accepted_targets = verified_skill_plan.get("accepted", [])
             if isinstance(accepted_targets, list):
@@ -788,6 +789,7 @@ async def _improve_preview_flow(
         improved_data, applied_changes, rejected_changes = apply_diffs(
             original=original_resume_data,
             changes=diff_result.changes,
+            allowed_skill_targets=skill_targets,
         )
 
         diff_warnings = verify_diff_result(

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -747,7 +747,7 @@ class ResumeChange(BaseModel):
     path: str = Field(
         description="Dot+bracket path, e.g. 'workExperience[0].description[1]'"
     )
-    action: Literal["replace", "append", "reorder"]
+    action: Literal["replace", "append", "reorder", "add_skill"]
     original: str | None = Field(
         default=None, description="Current text at path — for verification"
     )

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -214,6 +214,7 @@ def _verify_original_matches(actual: Any, expected: str | None) -> bool:
 def apply_diffs(
     original: dict[str, Any],
     changes: list[ResumeChange],
+    allowed_skill_targets: list[dict[str, Any] | str] | None = None,
 ) -> tuple[dict[str, Any], list[ResumeChange], list[ResumeChange]]:
     """Apply verified diffs to original resume.
 
@@ -228,6 +229,7 @@ def apply_diffs(
     Args:
         original: The original resume data (ResumeData-compatible dict)
         changes: List of changes from the LLM
+        allowed_skill_targets: Verified skill targets allowed for add_skill actions
 
     Returns:
         (result_dict, applied_changes, rejected_changes)
@@ -235,6 +237,7 @@ def apply_diffs(
     result = copy.deepcopy(original)
     applied: list[ResumeChange] = []
     rejected: list[ResumeChange] = []
+    allowed_skill_keys = _build_allowed_skill_target_keys(allowed_skill_targets)
 
     for change in changes:
         path = change.path
@@ -342,6 +345,10 @@ def apply_diffs(
             }
             if new_skill.casefold() in existing:
                 logger.info("Diff rejected (duplicate skill): %s", new_skill)
+                rejected.append(change)
+                continue
+            if _normalize_skill_key(new_skill) not in allowed_skill_keys:
+                logger.info("Diff rejected (skill not in verified targets): %s", new_skill)
                 rejected.append(change)
                 continue
             actual_value.append(new_skill)
@@ -642,10 +649,38 @@ def _extract_skill_index(items: Any) -> dict[str, str]:
     return index
 
 
-def _extract_jd_skill_index(job_keywords: dict[str, Any]) -> dict[str, str]:
-    """Build a normalized index of JD-approved skills and keywords."""
+def _skill_mentioned_in_text(skill: str, text: str) -> bool:
+    """Return True when a skill phrase appears as a whole term in text."""
+    escaped = re.escape(skill.strip().lower())
+    if not escaped:
+        return False
+    return bool(re.search(rf"(?<!\w){escaped}(?!\w)", text.lower()))
+
+
+def _build_allowed_skill_target_keys(
+    allowed_skill_targets: list[dict[str, Any] | str] | None,
+) -> set[str]:
+    """Build normalized keys for skills approved by the planning verifier."""
+    keys: set[str] = set()
+    for target in allowed_skill_targets or []:
+        if isinstance(target, str):
+            skill = target
+        elif isinstance(target, dict):
+            skill = str(target.get("skill", ""))
+        else:
+            continue
+        if skill.strip():
+            keys.add(_normalize_skill_key(skill))
+    return keys
+
+
+def _extract_jd_skill_index(
+    job_keywords: dict[str, Any],
+    job_description: str | None = None,
+) -> dict[str, str]:
+    """Build a normalized index of explicit JD skills."""
     index: dict[str, str] = {}
-    for field in ("required_skills", "preferred_skills", "keywords"):
+    for field in ("required_skills", "preferred_skills"):
         values = job_keywords.get(field, [])
         if not isinstance(values, list):
             continue
@@ -653,35 +688,37 @@ def _extract_jd_skill_index(job_keywords: dict[str, Any]) -> dict[str, str]:
             if not isinstance(value, str):
                 continue
             skill = value.strip()
-            if skill:
+            if skill and (
+                job_description is None
+                or _skill_mentioned_in_text(skill, job_description)
+            ):
                 index.setdefault(_normalize_skill_key(skill), skill)
     return index
 
 
 def _skill_present_in_resume_text(skill: str, resume_data: dict[str, Any]) -> bool:
     """Return True when a skill phrase already appears in the resume text."""
-    text = json.dumps(resume_data, ensure_ascii=False).lower()
-    normalized = re.escape(skill.strip().lower())
-    if not normalized:
-        return False
-    return bool(re.search(rf"(?<!\w){normalized}(?!\w)", text))
+    text = json.dumps(resume_data, ensure_ascii=False)
+    return _skill_mentioned_in_text(skill, text)
 
 
 def verify_skill_target_plan(
     raw_plan: dict[str, Any],
     original_resume_data: dict[str, Any],
     job_keywords: dict[str, Any],
+    job_description: str | None = None,
 ) -> dict[str, list[dict[str, str]] | str]:
     """Filter and classify LLM-proposed skill targets before diff generation.
 
-    Existing resume skills are accepted as low-risk targets. JD skills and
-    keywords are accepted as explicit JD-added targets for user review. Other
-    skills are accepted only when they already appear in the resume text.
+    Existing resume skills are accepted as low-risk targets. Required and
+    preferred JD skills are accepted as explicit JD-added targets for user
+    review. Other skills are accepted only when they already appear in the
+    resume text.
     """
     original_skills = _extract_skill_index(
         original_resume_data.get("additional", {}).get("technicalSkills", [])
     )
-    jd_skills = _extract_jd_skill_index(job_keywords)
+    jd_skills = _extract_jd_skill_index(job_keywords, job_description)
     raw_targets = raw_plan.get("target_skills", [])
     accepted: list[dict[str, str]] = []
     rejected: list[dict[str, str]] = []
@@ -772,7 +809,7 @@ async def generate_skill_target_plan(
             "target_skills and strategy_notes."
         ),
         max_tokens=2048,
-        schema_type="skill_plan",
+        schema_type="diff",
     )
 
     raw_targets = result.get("target_skills", [])

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -16,6 +16,7 @@ from app.prompts import (
     DIFF_STRATEGY_INSTRUCTIONS,
     EXTRACT_KEYWORDS_PROMPT,
     IMPROVE_RESUME_PROMPTS,
+    SKILL_TARGET_PLAN_PROMPT,
     get_language_name,
 )
 from app.prompts.templates import IMPROVE_SCHEMA_EXAMPLE
@@ -320,6 +321,32 @@ def apply_diffs(
                 continue
             applied.append(change)
 
+        elif action == "add_skill":
+            if path != "additional.technicalSkills":
+                logger.info("Diff rejected (add_skill outside skills): %s", path)
+                rejected.append(change)
+                continue
+            if not isinstance(actual_value, list):
+                logger.info("Diff rejected (add_skill to non-list): %s", path)
+                rejected.append(change)
+                continue
+            if not isinstance(change.value, str) or not change.value.strip():
+                logger.info("Diff rejected (add_skill empty/non-string): %s", path)
+                rejected.append(change)
+                continue
+            new_skill = change.value.strip()
+            existing = {
+                item.casefold()
+                for item in actual_value
+                if isinstance(item, str)
+            }
+            if new_skill.casefold() in existing:
+                logger.info("Diff rejected (duplicate skill): %s", new_skill)
+                rejected.append(change)
+                continue
+            actual_value.append(new_skill)
+            applied.append(change)
+
         else:
             logger.info("Diff rejected (unknown action): %s", action)
             rejected.append(change)
@@ -427,6 +454,7 @@ async def generate_resume_diffs(
     language: str = "en",
     prompt_id: str | None = None,
     original_resume_data: dict[str, Any] | None = None,
+    skill_targets: list[dict[str, Any]] | None = None,
 ) -> ImproveDiffResult:
     """Generate targeted resume diffs via LLM.
 
@@ -440,6 +468,7 @@ async def generate_resume_diffs(
         language: Output language code (en, es, zh, ja)
         prompt_id: Strategy id (nudge/keywords/full)
         original_resume_data: Structured resume JSON
+        skill_targets: Verified skill targets from the planning pass
 
     Returns:
         ImproveDiffResult with list of changes and strategy notes
@@ -473,6 +502,7 @@ async def generate_resume_diffs(
         strategy_instruction=strategy_instruction,
         output_language=output_language,
         job_keywords=keywords_str,
+        skill_targets=_prepare_skill_targets_for_prompt(skill_targets),
         job_description=sanitized_jd,
         original_resume=resume_input,
     )
@@ -591,6 +621,199 @@ def _prepare_keywords_for_prompt(job_keywords: dict[str, Any]) -> str:
         sections.append("Additional keywords to weave in naturally:\n- " + "\n- ".join(str(k) for k in keywords))
 
     return "\n\n".join(sections) if sections else "No specific keywords extracted."
+
+
+def _normalize_skill_key(skill: str) -> str:
+    """Normalize a skill for case-insensitive comparison."""
+    return re.sub(r"\s+", " ", skill.strip()).casefold()
+
+
+def _extract_skill_index(items: Any) -> dict[str, str]:
+    """Build a normalized skill index from a string list."""
+    if not isinstance(items, list):
+        return {}
+    index: dict[str, str] = {}
+    for item in items:
+        if not isinstance(item, str):
+            continue
+        skill = item.strip()
+        if skill:
+            index.setdefault(_normalize_skill_key(skill), skill)
+    return index
+
+
+def _extract_jd_skill_index(job_keywords: dict[str, Any]) -> dict[str, str]:
+    """Build a normalized index of JD-approved skills and keywords."""
+    index: dict[str, str] = {}
+    for field in ("required_skills", "preferred_skills", "keywords"):
+        values = job_keywords.get(field, [])
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if not isinstance(value, str):
+                continue
+            skill = value.strip()
+            if skill:
+                index.setdefault(_normalize_skill_key(skill), skill)
+    return index
+
+
+def _skill_present_in_resume_text(skill: str, resume_data: dict[str, Any]) -> bool:
+    """Return True when a skill phrase already appears in the resume text."""
+    text = json.dumps(resume_data, ensure_ascii=False).lower()
+    normalized = re.escape(skill.strip().lower())
+    if not normalized:
+        return False
+    return bool(re.search(rf"(?<!\w){normalized}(?!\w)", text))
+
+
+def verify_skill_target_plan(
+    raw_plan: dict[str, Any],
+    original_resume_data: dict[str, Any],
+    job_keywords: dict[str, Any],
+) -> dict[str, list[dict[str, str]] | str]:
+    """Filter and classify LLM-proposed skill targets before diff generation.
+
+    Existing resume skills are accepted as low-risk targets. JD skills and
+    keywords are accepted as explicit JD-added targets for user review. Other
+    skills are accepted only when they already appear in the resume text.
+    """
+    original_skills = _extract_skill_index(
+        original_resume_data.get("additional", {}).get("technicalSkills", [])
+    )
+    jd_skills = _extract_jd_skill_index(job_keywords)
+    raw_targets = raw_plan.get("target_skills", [])
+    accepted: list[dict[str, str]] = []
+    rejected: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    if not isinstance(raw_targets, list):
+        raw_targets = []
+
+    for target in raw_targets:
+        if isinstance(target, str):
+            skill = target.strip()
+            reason = ""
+        elif isinstance(target, dict):
+            skill = str(target.get("skill", "")).strip()
+            reason = str(target.get("reason", "")).strip()
+        else:
+            continue
+
+        skill_key = _normalize_skill_key(skill)
+        if not skill or skill_key in seen:
+            continue
+        seen.add(skill_key)
+
+        if skill_key in original_skills:
+            accepted.append(
+                {
+                    "skill": original_skills[skill_key],
+                    "source": "existing",
+                    "reason": reason or "Already present in resume skills",
+                }
+            )
+        elif skill_key in jd_skills:
+            accepted.append(
+                {
+                    "skill": jd_skills[skill_key],
+                    "source": "jd_added",
+                    "reason": reason or "Required or preferred by the job description",
+                }
+            )
+        elif _skill_present_in_resume_text(skill, original_resume_data):
+            accepted.append(
+                {
+                    "skill": skill,
+                    "source": "supported_by_resume",
+                    "reason": reason or "Appears in the existing resume content",
+                }
+            )
+        else:
+            rejected.append(
+                {
+                    "skill": skill,
+                    "source": "unsupported",
+                    "reason": reason or "Not found in resume or job keywords",
+                }
+            )
+
+    return {
+        "accepted": accepted,
+        "rejected": rejected,
+        "strategy_notes": str(raw_plan.get("strategy_notes", "")),
+    }
+
+
+async def generate_skill_target_plan(
+    original_resume_data: dict[str, Any],
+    job_description: str,
+    job_keywords: dict[str, Any],
+    language: str = "en",
+) -> dict[str, Any]:
+    """Ask the LLM for a compact skill target plan before editing diffs."""
+    output_language = get_language_name(language)
+    existing_skills = original_resume_data.get("additional", {}).get(
+        "technicalSkills", []
+    )
+    sanitized_jd = _sanitize_user_input(job_description)
+    prompt = SKILL_TARGET_PLAN_PROMPT.format(
+        output_language=output_language,
+        existing_skills=json.dumps(existing_skills, ensure_ascii=False),
+        job_keywords=_prepare_keywords_for_prompt(job_keywords),
+        job_description=sanitized_jd,
+        original_resume=json.dumps(original_resume_data, ensure_ascii=False),
+    )
+
+    result = await complete_json(
+        prompt=prompt,
+        system_prompt=(
+            "You are a resume skill planning agent. Output only valid JSON with "
+            "target_skills and strategy_notes."
+        ),
+        max_tokens=2048,
+        schema_type="skill_plan",
+    )
+
+    raw_targets = result.get("target_skills", [])
+    target_skills: list[dict[str, str]] = []
+    if isinstance(raw_targets, list):
+        for raw in raw_targets:
+            if isinstance(raw, str):
+                skill = raw.strip()
+                reason = ""
+            elif isinstance(raw, dict):
+                skill = str(raw.get("skill", "")).strip()
+                reason = str(raw.get("reason", "")).strip()
+            else:
+                continue
+            if skill:
+                target_skills.append({"skill": skill, "reason": reason})
+    else:
+        logger.warning("Skill target plan returned non-list target_skills")
+
+    return {
+        "target_skills": target_skills,
+        "strategy_notes": str(result.get("strategy_notes", "")),
+    }
+
+
+def _prepare_skill_targets_for_prompt(
+    skill_targets: list[dict[str, Any]] | None,
+) -> str:
+    """Format verified skill targets for the diff prompt."""
+    if not skill_targets:
+        return "No verified skill targets."
+    lines: list[str] = []
+    for target in skill_targets:
+        skill = str(target.get("skill", "")).strip()
+        if not skill:
+            continue
+        source = str(target.get("source", "unknown")).strip() or "unknown"
+        reason = str(target.get("reason", "")).strip()
+        suffix = f": {reason}" if reason else ""
+        lines.append(f"- {skill} ({source}){suffix}")
+    return "\n".join(lines) if lines else "No verified skill targets."
 
 
 async def improve_resume(

--- a/apps/backend/app/services/refiner.py
+++ b/apps/backend/app/services/refiner.py
@@ -36,15 +36,15 @@ MIN_TRUNCATION_WARNING_LENGTH = 1500
 
 
 def _keyword_in_text(keyword: str, text: str) -> bool:
-    """Check if keyword exists as a whole word in text.
+    """Check if keyword exists as a whole term in text.
 
-    SVC-010: Uses word boundaries instead of substring matching to avoid
+    SVC-010: Uses term boundaries instead of substring matching to avoid
     false positives like 'python' matching 'pythonic' or 'go' matching 'going'.
     """
-    # Escape special regex characters in keyword
-    escaped = re.escape(keyword.lower())
-    # Use word boundaries
-    pattern = rf"\b{escaped}\b"
+    escaped = re.escape(keyword.strip().lower())
+    if not escaped:
+        return False
+    pattern = rf"(?<!\w){escaped}(?!\w)"
     return bool(re.search(pattern, text.lower()))
 
 

--- a/apps/backend/app/services/refiner.py
+++ b/apps/backend/app/services/refiner.py
@@ -48,6 +48,24 @@ def _keyword_in_text(keyword: str, text: str) -> bool:
     return bool(re.search(pattern, text.lower()))
 
 
+def _normalize_skill_key(skill: str) -> str:
+    """Normalize a skill for case-insensitive comparisons."""
+    return re.sub(r"\s+", " ", skill.strip()).casefold()
+
+
+def _extract_jd_skill_keys(job_keywords: dict[str, Any]) -> set[str]:
+    """Extract normalized skills and keywords that are explicitly in the JD."""
+    keys: set[str] = set()
+    for field in ("required_skills", "preferred_skills", "keywords"):
+        values = job_keywords.get(field, [])
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if isinstance(value, str) and value.strip():
+                keys.add(_normalize_skill_key(value))
+    return keys
+
+
 async def refine_resume(
     initial_tailored: dict[str, Any],
     master_resume: dict[str, Any],
@@ -107,7 +125,11 @@ async def refine_resume(
     # Pass 3: Master alignment validation
     # LLM-008: Alignment validation is MANDATORY - not optional fallback
     if config.enable_master_alignment_check:
-        alignment = validate_master_alignment(current, master_resume)
+        alignment = validate_master_alignment(
+            current,
+            master_resume,
+            allowed_new_skills=_extract_jd_skill_keys(job_keywords),
+        )
         if not alignment.is_aligned:
             # Count critical violations
             critical_violations = [
@@ -258,6 +280,7 @@ def remove_ai_phrases(
 def validate_master_alignment(
     tailored: dict[str, Any],
     master: dict[str, Any],
+    allowed_new_skills: set[str] | None = None,
 ) -> AlignmentReport:
     """Verify tailored resume doesn't contain fabricated content.
 
@@ -284,9 +307,16 @@ def validate_master_alignment(
         for s in master.get("additional", {}).get("technicalSkills", [])
         if isinstance(s, str)
     )
+    allowed_skills = {
+        _normalize_skill_key(skill)
+        for skill in (allowed_new_skills or set())
+        if isinstance(skill, str) and skill.strip()
+    }
     master_full_text = _extract_all_text(master).lower()
 
     for skill in tailored_skills - master_skills:
+        if _normalize_skill_key(skill) in allowed_skills:
+            continue
         # Check substring/containment: e.g. "Python" in "Python 3.x"
         has_substring_match = any(
             skill in ms or ms in skill for ms in master_skills if ms

--- a/apps/backend/app/services/refiner.py
+++ b/apps/backend/app/services/refiner.py
@@ -53,15 +53,22 @@ def _normalize_skill_key(skill: str) -> str:
     return re.sub(r"\s+", " ", skill.strip()).casefold()
 
 
-def _extract_jd_skill_keys(job_keywords: dict[str, Any]) -> set[str]:
-    """Extract normalized skills and keywords that are explicitly in the JD."""
+def _extract_jd_skill_keys(
+    job_keywords: dict[str, Any],
+    job_description: str,
+) -> set[str]:
+    """Extract normalized required/preferred skills present in the raw JD."""
     keys: set[str] = set()
-    for field in ("required_skills", "preferred_skills", "keywords"):
+    for field in ("required_skills", "preferred_skills"):
         values = job_keywords.get(field, [])
         if not isinstance(values, list):
             continue
         for value in values:
-            if isinstance(value, str) and value.strip():
+            if (
+                isinstance(value, str)
+                and value.strip()
+                and _keyword_in_text(value, job_description)
+            ):
                 keys.add(_normalize_skill_key(value))
     return keys
 
@@ -128,7 +135,10 @@ async def refine_resume(
         alignment = validate_master_alignment(
             current,
             master_resume,
-            allowed_new_skills=_extract_jd_skill_keys(job_keywords),
+            allowed_new_skills=_extract_jd_skill_keys(
+                job_keywords,
+                job_description,
+            ),
         )
         if not alignment.is_aligned:
             # Count critical violations

--- a/apps/backend/tests/service/test_improver.py
+++ b/apps/backend/tests/service/test_improver.py
@@ -241,16 +241,19 @@ class TestSkillTargetPlanning:
             "Kubernetes",
         ]
         assert result["strategy_notes"] == "Prioritize platform keywords"
+        assert mock_llm.call_args.kwargs["schema_type"] == "diff"
 
     def test_verify_skill_target_plan_allows_existing_and_jd_skills(
         self,
         sample_resume,
         sample_job_keywords,
+        sample_job_description,
     ):
         raw_plan = {
             "target_skills": [
                 {"skill": "Python", "reason": "Already in resume"},
                 {"skill": "Kubernetes", "reason": "JD required"},
+                {"skill": "CI/CD", "reason": "Generic keyword, not skill field"},
                 {"skill": "BananaDB", "reason": "Unsupported"},
             ]
         }
@@ -258,11 +261,12 @@ class TestSkillTargetPlanning:
             raw_plan,
             original_resume_data=sample_resume,
             job_keywords=sample_job_keywords,
+            job_description=sample_job_description,
         )
         accepted_skills = [item["skill"] for item in verified["accepted"]]
         rejected_skills = [item["skill"] for item in verified["rejected"]]
         assert accepted_skills == ["Python", "Kubernetes"]
-        assert rejected_skills == ["BananaDB"]
+        assert rejected_skills == ["CI/CD", "BananaDB"]
         assert verified["accepted"][0]["source"] == "existing"
         assert verified["accepted"][1]["source"] == "jd_added"
 

--- a/apps/backend/tests/service/test_improver.py
+++ b/apps/backend/tests/service/test_improver.py
@@ -7,8 +7,10 @@ import pytest
 
 from app.services.improver import (
     extract_job_keywords,
+    generate_skill_target_plan,
     generate_resume_diffs,
     improve_resume,
+    verify_skill_target_plan,
 )
 
 
@@ -68,6 +70,33 @@ class TestGenerateResumeDiffs:
         assert len(result.changes) == 1
         assert result.changes[0].path == "summary"
         assert result.strategy_notes == "Focused on backend keywords"
+
+    @patch("app.services.improver.complete_json", new_callable=AsyncMock)
+    async def test_includes_verified_skill_targets_in_prompt(
+        self,
+        mock_llm,
+        sample_resume,
+        sample_job_keywords,
+    ):
+        mock_llm.return_value = {"changes": [], "strategy_notes": "test"}
+        await generate_resume_diffs(
+            original_resume="# Resume",
+            job_description="JD",
+            job_keywords=sample_job_keywords,
+            prompt_id="full",
+            original_resume_data=sample_resume,
+            skill_targets=[
+                {
+                    "skill": "Kubernetes",
+                    "source": "jd_added",
+                    "reason": "Required by JD",
+                }
+            ],
+        )
+        prompt = mock_llm.call_args.kwargs.get("prompt") or mock_llm.call_args.args[0]
+        assert "Verified skill targets" in prompt
+        assert "Kubernetes" in prompt
+        assert "add_skill" in prompt
 
     @patch("app.services.improver.complete_json", new_callable=AsyncMock)
     async def test_handles_empty_changes(self, mock_llm, sample_resume, sample_job_keywords):
@@ -181,6 +210,61 @@ class TestGenerateResumeDiffs:
         )
         prompt = mock_llm.call_args.kwargs.get("prompt") or mock_llm.call_args.args[0]
         assert "targeted adjustments" in prompt.lower()
+
+
+class TestSkillTargetPlanning:
+    """Tests for skill target planning and verification."""
+
+    @patch("app.services.improver.complete_json", new_callable=AsyncMock)
+    async def test_generate_skill_target_plan_parses_llm_output(
+        self,
+        mock_llm,
+        sample_resume,
+        sample_job_keywords,
+        sample_job_description,
+    ):
+        mock_llm.return_value = {
+            "target_skills": [
+                {"skill": "Python", "reason": "Already present"},
+                {"skill": "Kubernetes", "reason": "Required by JD"},
+            ],
+            "strategy_notes": "Prioritize platform keywords",
+        }
+        result = await generate_skill_target_plan(
+            original_resume_data=sample_resume,
+            job_description=sample_job_description,
+            job_keywords=sample_job_keywords,
+            language="en",
+        )
+        assert [item["skill"] for item in result["target_skills"]] == [
+            "Python",
+            "Kubernetes",
+        ]
+        assert result["strategy_notes"] == "Prioritize platform keywords"
+
+    def test_verify_skill_target_plan_allows_existing_and_jd_skills(
+        self,
+        sample_resume,
+        sample_job_keywords,
+    ):
+        raw_plan = {
+            "target_skills": [
+                {"skill": "Python", "reason": "Already in resume"},
+                {"skill": "Kubernetes", "reason": "JD required"},
+                {"skill": "BananaDB", "reason": "Unsupported"},
+            ]
+        }
+        verified = verify_skill_target_plan(
+            raw_plan,
+            original_resume_data=sample_resume,
+            job_keywords=sample_job_keywords,
+        )
+        accepted_skills = [item["skill"] for item in verified["accepted"]]
+        rejected_skills = [item["skill"] for item in verified["rejected"]]
+        assert accepted_skills == ["Python", "Kubernetes"]
+        assert rejected_skills == ["BananaDB"]
+        assert verified["accepted"][0]["source"] == "existing"
+        assert verified["accepted"][1]["source"] == "jd_added"
 
 
 class TestGenerateResumeDiffsEdgeCases:

--- a/apps/backend/tests/unit/test_apply_diffs.py
+++ b/apps/backend/tests/unit/test_apply_diffs.py
@@ -118,10 +118,33 @@ class TestApplyDiffsAddSkill:
                 reason="JD-required skill approved by verifier",
             )
         ]
-        result, applied, rejected = apply_diffs(sample_resume, changes)
+        result, applied, rejected = apply_diffs(
+            sample_resume,
+            changes,
+            allowed_skill_targets=[{"skill": "Kubernetes"}],
+        )
         assert len(applied) == 1
         assert len(rejected) == 0
         assert "Kubernetes" in result["additional"]["technicalSkills"]
+
+    def test_add_skill_rejects_unverified_skill(self, sample_resume):
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="add_skill",
+                original=None,
+                value="BananaDB",
+                reason="Unsupported skill should not be appended",
+            )
+        ]
+        result, applied, rejected = apply_diffs(
+            sample_resume,
+            changes,
+            allowed_skill_targets=[{"skill": "Kubernetes"}],
+        )
+        assert len(applied) == 0
+        assert len(rejected) == 1
+        assert "BananaDB" not in result["additional"]["technicalSkills"]
 
     def test_add_skill_rejects_duplicate_case_insensitive(self, sample_resume):
         changes = [
@@ -133,7 +156,11 @@ class TestApplyDiffsAddSkill:
                 reason="Duplicate skill should not be appended",
             )
         ]
-        result, applied, rejected = apply_diffs(sample_resume, changes)
+        result, applied, rejected = apply_diffs(
+            sample_resume,
+            changes,
+            allowed_skill_targets=[{"skill": "Python"}],
+        )
         assert len(applied) == 0
         assert len(rejected) == 1
         assert result["additional"]["technicalSkills"].count("Python") == 1
@@ -148,7 +175,11 @@ class TestApplyDiffsAddSkill:
                 reason="Skill additions are only allowed in technical skills",
             )
         ]
-        result, applied, rejected = apply_diffs(sample_resume, changes)
+        result, applied, rejected = apply_diffs(
+            sample_resume,
+            changes,
+            allowed_skill_targets=[{"skill": "Kubernetes"}],
+        )
         assert len(applied) == 0
         assert len(rejected) == 1
         assert "Kubernetes" not in result["additional"]["technicalSkills"]

--- a/apps/backend/tests/unit/test_apply_diffs.py
+++ b/apps/backend/tests/unit/test_apply_diffs.py
@@ -105,6 +105,55 @@ class TestApplyDiffsAppend:
         assert len(result["personalProjects"][0]["description"]) == original_count + 1
 
 
+class TestApplyDiffsAddSkill:
+    """Tests for adding verified skills to the technical skills list."""
+
+    def test_add_skill_to_technical_skills(self, sample_resume):
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="add_skill",
+                original=None,
+                value="Kubernetes",
+                reason="JD-required skill approved by verifier",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(applied) == 1
+        assert len(rejected) == 0
+        assert "Kubernetes" in result["additional"]["technicalSkills"]
+
+    def test_add_skill_rejects_duplicate_case_insensitive(self, sample_resume):
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="add_skill",
+                original=None,
+                value="python",
+                reason="Duplicate skill should not be appended",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(applied) == 0
+        assert len(rejected) == 1
+        assert result["additional"]["technicalSkills"].count("Python") == 1
+
+    def test_add_skill_rejects_non_skill_path(self, sample_resume):
+        changes = [
+            ResumeChange(
+                path="summary",
+                action="add_skill",
+                original=None,
+                value="Kubernetes",
+                reason="Skill additions are only allowed in technical skills",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(applied) == 0
+        assert len(rejected) == 1
+        assert "Kubernetes" not in result["additional"]["technicalSkills"]
+
+
 class TestApplyDiffsReorder:
     """Tests for the 'reorder' action."""
 

--- a/apps/backend/tests/unit/test_refiner.py
+++ b/apps/backend/tests/unit/test_refiner.py
@@ -85,6 +85,21 @@ class TestValidateMasterAlignment:
         assert len(skill_violations) >= 1
         assert any("kubernetes" in v.value.lower() for v in skill_violations)
 
+    def test_allows_jd_added_skill_when_explicitly_allowed(self, sample_resume, master_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["additional"]["technicalSkills"].append("Kubernetes")
+        report = validate_master_alignment(
+            tailored,
+            master_resume,
+            allowed_new_skills={"Kubernetes"},
+        )
+        critical_skill_violations = [
+            v
+            for v in report.violations
+            if "skill" in v.violation_type and v.severity == "critical"
+        ]
+        assert critical_skill_violations == []
+
     def test_detects_fabricated_certification(self, sample_resume, master_resume):
         tailored = copy.deepcopy(sample_resume)
         tailored["additional"]["certificationsTraining"].append("Google Cloud Professional")

--- a/apps/backend/tests/unit/test_refiner.py
+++ b/apps/backend/tests/unit/test_refiner.py
@@ -149,6 +149,39 @@ class TestValidateMasterAlignment:
         )
         assert "Kubernetes" in result.refined_data["additional"]["technicalSkills"]
 
+    @pytest.mark.parametrize(
+        ("skill", "job_description"),
+        [
+            ("C++", "Experience with C++ is required for systems tooling."),
+            ("C#", "Experience with C# is required for .NET services."),
+        ],
+    )
+    async def test_refiner_allows_required_punctuated_skill_present_in_job_description(
+        self,
+        sample_resume,
+        master_resume,
+        skill,
+        job_description,
+    ):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["additional"]["technicalSkills"].append(skill)
+        result = await refine_resume(
+            initial_tailored=tailored,
+            master_resume=master_resume,
+            job_description=job_description,
+            job_keywords={
+                "required_skills": [skill],
+                "preferred_skills": [],
+                "keywords": [],
+            },
+            config=RefinementConfig(
+                enable_keyword_injection=False,
+                enable_ai_phrase_removal=False,
+                enable_master_alignment_check=True,
+            ),
+        )
+        assert skill in result.refined_data["additional"]["technicalSkills"]
+
     def test_detects_fabricated_certification(self, sample_resume, master_resume):
         tailored = copy.deepcopy(sample_resume)
         tailored["additional"]["certificationsTraining"].append("Google Cloud Professional")

--- a/apps/backend/tests/unit/test_refiner.py
+++ b/apps/backend/tests/unit/test_refiner.py
@@ -7,10 +7,11 @@ from app.services.refiner import (
     analyze_keyword_gaps,
     calculate_keyword_match,
     fix_alignment_violations,
+    refine_resume,
     remove_ai_phrases,
     validate_master_alignment,
 )
-from app.schemas.refinement import AlignmentViolation
+from app.schemas.refinement import AlignmentViolation, RefinementConfig
 
 
 class TestRemoveAiPhrases:
@@ -99,6 +100,54 @@ class TestValidateMasterAlignment:
             if "skill" in v.violation_type and v.severity == "critical"
         ]
         assert critical_skill_violations == []
+
+    async def test_refiner_rejects_skill_from_generic_keyword_only(
+        self,
+        sample_resume,
+        master_resume,
+    ):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["additional"]["technicalSkills"].append("CI/CD")
+        result = await refine_resume(
+            initial_tailored=tailored,
+            master_resume=master_resume,
+            job_description="Familiarity with CI/CD pipelines and agile practices",
+            job_keywords={
+                "required_skills": [],
+                "preferred_skills": [],
+                "keywords": ["CI/CD"],
+            },
+            config=RefinementConfig(
+                enable_keyword_injection=False,
+                enable_ai_phrase_removal=False,
+                enable_master_alignment_check=True,
+            ),
+        )
+        assert "CI/CD" not in result.refined_data["additional"]["technicalSkills"]
+
+    async def test_refiner_allows_required_skill_present_in_job_description(
+        self,
+        sample_resume,
+        master_resume,
+    ):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["additional"]["technicalSkills"].append("Kubernetes")
+        result = await refine_resume(
+            initial_tailored=tailored,
+            master_resume=master_resume,
+            job_description="Experience with Kubernetes is required.",
+            job_keywords={
+                "required_skills": ["Kubernetes"],
+                "preferred_skills": [],
+                "keywords": [],
+            },
+            config=RefinementConfig(
+                enable_keyword_injection=False,
+                enable_ai_phrase_removal=False,
+                enable_master_alignment_check=True,
+            ),
+        )
+        assert "Kubernetes" in result.refined_data["additional"]["technicalSkills"]
 
     def test_detects_fabricated_certification(self, sample_resume, master_resume):
         tailored = copy.deepcopy(sample_resume)

--- a/docs/superpowers/plans/2026-05-06-resume-tailor-verifier-loop.md
+++ b/docs/superpowers/plans/2026-05-06-resume-tailor-verifier-loop.md
@@ -1,0 +1,53 @@
+# Resume Tailor Verifier Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make full resume tailoring add JD-aligned skills and improve work/project wording through smaller structured LLM passes guarded by local verification.
+
+**Architecture:** Keep the existing diff-based safety model, but split planning from editing. A first LLM call produces skill targets, a local verifier filters and classifies them, then the existing diff call receives the verified target plan and can append allowed JD skills while rewriting summary, work, and project bullets around those targets.
+
+**Tech Stack:** Python 3.13, FastAPI, Pydantic v2, LiteLLM via `complete_json()`, pytest
+
+---
+
+## File Map
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `apps/backend/app/schemas/models.py` | Diff action model | Add `add_skill` action support |
+| `apps/backend/app/prompts/templates.py` | LLM instructions | Add skill planning prompt and expand diff prompt with verified targets |
+| `apps/backend/app/prompts/__init__.py` | Prompt exports | Export the planning prompt |
+| `apps/backend/app/services/improver.py` | Tailoring harness | Add skill-plan generation, verifier, prompt wiring, `add_skill` applier |
+| `apps/backend/tests/unit/test_apply_diffs.py` | Diff applier coverage | Add add-skill pass/reject tests |
+| `apps/backend/tests/service/test_improver.py` | LLM prompt harness coverage | Add skill-plan parser/verifier and prompt wiring tests |
+
+## Tasks
+
+### Task 1: Add Verified Skill Additions
+
+- [ ] Write failing tests proving `apply_diffs()` can append a new skill through `action="add_skill"` and reject duplicates/empty values.
+- [ ] Update `ResumeChange.action` to include `add_skill`.
+- [ ] Implement `add_skill` in `apply_diffs()` for `additional.technicalSkills` only.
+- [ ] Run the focused unit tests.
+
+### Task 2: Build and Verify a Skill Target Plan
+
+- [ ] Write failing service tests for parsing LLM skill-plan output.
+- [ ] Add `SKILL_TARGET_PLAN_PROMPT`.
+- [ ] Add `generate_skill_target_plan()` using `complete_json(schema_type="skill_plan")`.
+- [ ] Add `verify_skill_target_plan()` that keeps existing skills, allows JD-added skills, and rejects unsupported non-JD items.
+- [ ] Run the focused service tests.
+
+### Task 3: Wire Verified Targets into Diff Generation
+
+- [ ] Write a failing test proving `generate_resume_diffs()` includes verified skill targets in the prompt and advertises `add_skill`.
+- [ ] Pass `skill_targets` into `generate_resume_diffs()`.
+- [ ] Expand `DIFF_IMPROVE_PROMPT` so full tailor can add verified JD skills and improve work/project bullets around them.
+- [ ] In `_improve_preview_flow()`, run the plan before diff generation and feed verified targets into the diff pass.
+- [ ] Run backend unit/service tests for improver, diff applier, and refiner.
+
+### Task 4: Verify the Preview Path
+
+- [ ] Run backend focused tests.
+- [ ] Run frontend lint if frontend files changed; otherwise skip and state why.
+- [ ] Report the exact commands and outcomes.


### PR DESCRIPTION
## Summary

- Adds a skill target planning pass before resume diff generation so full tailoring can reason about JD skills explicitly.
- Adds verified `add_skill` diff support with local duplicate/path guards and preview-visible skill additions.
- Allows explicitly JD-approved skills through the refinement alignment pass instead of silently removing them.
- Updates prompts and tests across improver, diff applier, and refiner to cover the new flow.

## Root Cause

The existing diff harness could rewrite bullets and reorder `additional.technicalSkills`, but it could not add skills. The later refiner also treated new skills as fabricated unless they already existed in the master resume, so full tailor often produced shallow wording changes and `0 skills added`.

## Commit Sequence

1. `docs: plan resume tailor verifier loop`
2. `feat: add skill diff action contract`
3. `feat: add skill planning prompt`
4. `chore: export skill target prompt`
5. `feat: verify skill targets for tailoring`
6. `feat: preserve approved JD skills in refiner`
7. `feat: run skill planning before resume diffs`
8. `test: cover verified skill additions`
9. `test: cover skill planning prompt flow`
10. `test: cover JD-approved skill alignment`

## Test Plan

- `cd apps/backend && uv run pytest tests/unit/test_apply_diffs.py tests/service/test_improver.py tests/unit/test_refiner.py tests/unit/test_resume_diff.py -v` -> 96 passed

## Notes

- Full backend suite was also run before splitting commits and showed 186 passed, 1 unrelated existing failure in `tests/integration/test_health_api.py::TestHealthEndpoint::test_health_returns_degraded`; `/health` currently returns liveness-only `healthy` by design in `app/routers/health.py`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a verifier-led resume tailoring loop that plans JD-aligned skills, filters them, and feeds verified targets into diffs. Enables safe `add_skill` changes with strict gates and correct matching for punctuated skills like C++/C#.

- **New Features**
  - Added skill planning prompt and verifier; verified targets flow into the diff prompt and applier. Full strategy can add one verified skill to `additional.technicalSkills` and improve related bullets.
  - Updated schema/applier for `add_skill` with case-insensitive dedupe and allowed-target checks. Preview runs planning first and warns on rejected targets.

- **Bug Fixes**
  - Verification only accepts JD-required/preferred skills present in the JD or skills already in the resume; rejects generic-only keywords (e.g., `CI/CD`).
  - Correctly matches punctuated skills in JD/resume text (e.g., `C++`, `C#`) during planning verification and refiner alignment.

<sup>Written for commit e4350c89595f1a26c3c3ab067c0b8f399bcd819a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

