### PR TITLE
Reject empty extracted resume uploads

### DIFF
--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -543,6 +543,15 @@ async def upload_resume(file: UploadFile = File(...)) -> ResumeUploadResponse:
             detail="Failed to parse document. Please ensure it's a valid PDF or DOCX file.",
         )
 
+    if not markdown_content or not markdown_content.strip():
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Failed to extract text from document. Please upload a text-based "
+                "PDF/DOCX or run OCR on scanned files first."
+            ),
+        )
+
     # Store in database first with "processing" status (atomic master assignment)
     # original_markdown is preserved permanently for date reference even after
     # builder saves overwrite `content` with JSON.

--- a/apps/backend/app/services/parser.py
+++ b/apps/backend/app/services/parser.py
@@ -154,6 +154,9 @@ async def parse_resume_to_json(markdown_text: str) -> dict[str, Any]:
     Returns:
         Structured resume data matching ResumeData schema
     """
+    if not markdown_text or not markdown_text.strip():
+        raise ValueError("Resume content is empty after text extraction.")
+
     prompt = PARSE_RESUME_PROMPT.format(
         schema=RESUME_SCHEMA_EXAMPLE,
         resume_text=markdown_text,

--- a/apps/backend/tests/integration/test_resume_api.py
+++ b/apps/backend/tests/integration/test_resume_api.py
@@ -171,3 +171,26 @@ class TestRetryProcessing:
         async with client:
             resp = await client.post("/api/v1/resumes/res-123/retry-processing")
         assert resp.status_code == 400
+
+
+class TestUploadResume:
+    """POST /api/v1/resumes/upload"""
+
+    @patch("app.routers.resumes.parse_resume_to_json", new_callable=AsyncMock)
+    @patch("app.routers.resumes.parse_document", new_callable=AsyncMock)
+    @patch("app.routers.resumes.db")
+    async def test_upload_empty_extracted_text_returns_422(
+        self, mock_db, mock_parse_document, mock_parse_resume_to_json, client
+    ):
+        mock_parse_document.return_value = "   "
+
+        async with client:
+            resp = await client.post(
+                "/api/v1/resumes/upload",
+                files={"file": ("resume.pdf", b"fake pdf bytes", "application/pdf")},
+            )
+
+        assert resp.status_code == 422
+        assert "Failed to extract text from document" in resp.json()["detail"]
+        mock_db.create_resume_atomic_master.assert_not_called()
+        mock_parse_resume_to_json.assert_not_called()


### PR DESCRIPTION
# Pull Request Title
Reject empty extracted resume uploads

## Related Issue
#791

## Description
Prevent empty PDF/DOCX text extraction results from being stored and passed to AI parsing, which could otherwise generate a sample-style fallback resume.

## Type

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes

- Return `422` when uploaded files produce empty extracted text
- Add a parser-level guard for empty resume content
- Add an integration test covering empty extracted text uploads

## Screenshots / Code Snippets (if applicable)
N/A

## How to Test

1. Upload a scanned or non-text PDF that produces empty extracted text.
2. Confirm the API returns `422` with a text-extraction error.
3. Confirm no resume record is created and AI parsing is not invoked.

## Checklist

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [x] This pull request has been linked to the related issue (if applicable)

## Additional Information
A lightweight HTTP-level verification confirmed the endpoint returns `422` and does not create a resume record when extracted text is blank. The branch is prepared locally as `fix-reject-empty-resume-upload`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject uploads where text extraction returns empty content by returning 422 and skipping storage/parsing. Improves the error message with OCR guidance to prevent bogus resumes from scanned or non-text PDFs/DOCX.

- **Bug Fixes**
  - Return 422 with a clearer message and OCR guidance when extracted text is blank.
  - Add a parser guard that raises on empty resume content.
  - Add an integration test verifying 422, no DB write, and no parser call.

<sup>Written for commit 4208a295a52baf8b201851d8c097a4ed5c95163d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

