### PR TITLE
fix(upload): reject resumes with empty extracted text

### DIFF
--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -104,6 +104,7 @@ def _get_llm_api_key_with_fallback() -> str:
         "gemini": "google",
         "openrouter": "openrouter",
         "deepseek": "deepseek",
+        "groq": "groq",
         "ollama": "ollama",
     }
 
@@ -128,6 +129,7 @@ class Settings(BaseSettings):
         "openrouter",
         "gemini",
         "deepseek",
+        "groq",
         "ollama",
     ] = "openai"
     llm_model: str = "gpt-5-nano-2025-08-07"

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -306,6 +306,7 @@ _PROVIDER_KEY_MAP: dict[str, str] = {
     "gemini": "google",
     "openrouter": "openrouter",
     "deepseek": "deepseek",
+    "groq": "groq",
     "ollama": "ollama",
 }
 
@@ -416,6 +417,7 @@ def get_model_name(config: LLMConfig) -> str:
         "openrouter": "openrouter/",
         "gemini": "gemini/",
         "deepseek": "deepseek/",
+        "groq": "groq/",
         "ollama": "ollama_chat/",  # ollama_chat/ routes to /api/chat (supports messages array)
     }
 
@@ -434,6 +436,7 @@ def get_model_name(config: LLMConfig) -> str:
         "anthropic/",
         "gemini/",
         "deepseek/",
+        "groq/",
         "ollama/",
         "ollama_chat/",
         "openai/",
@@ -893,6 +896,7 @@ def _calculate_timeout(
         "openai": 1.0,
         "anthropic": 1.2,
         "openrouter": 1.5,  # More variable latency
+        "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower
     }
     provider_factor = provider_factors.get(provider, 1.0)

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -420,7 +420,7 @@ async def update_feature_prompts(
 
 
 # Supported API key providers
-SUPPORTED_PROVIDERS = ["openai", "anthropic", "google", "openrouter", "deepseek"]
+SUPPORTED_PROVIDERS = ["openai", "anthropic", "google", "openrouter", "deepseek", "groq"]
 
 
 def _mask_key_short(key: str | None) -> str | None:
@@ -500,6 +500,13 @@ async def update_api_keys(request: ApiKeysUpdateRequest) -> ApiKeysUpdateRespons
         elif "deepseek" in stored_keys:
             del stored_keys["deepseek"]
         updated.append("deepseek")
+
+    if request.groq is not None:
+        if request.groq:
+            stored_keys["groq"] = request.groq
+        elif "groq" in stored_keys:
+            del stored_keys["groq"]
+        updated.append("groq")
 
     save_api_keys_to_config(stored_keys)
     invalidate_config_cache()

--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -47,8 +47,10 @@ from app.services.improver import (
     apply_diffs,
     extract_job_keywords,
     generate_improvements,
+    generate_skill_target_plan,
     generate_resume_diffs,
     improve_resume,
+    verify_skill_target_plan,
     verify_diff_result,
 )
 from app.services.refiner import refine_resume, calculate_keyword_match
@@ -541,6 +543,13 @@ async def upload_resume(file: UploadFile = File(...)) -> ResumeUploadResponse:
             detail="Failed to parse document. Please ensure it's a valid PDF or DOCX file.",
         )
 
+    # Validate extracted text is not empty (image-based PDFs / scanned documents)
+    if not markdown_content or not markdown_content.strip():
+        raise HTTPException(
+            status_code=422,
+            detail="Could not extract text from the uploaded file. The document may be image-based or scanned. Please upload a file with selectable text.",
+        )
+
     # Store in database first with "processing" status (atomic master assignment)
     # original_markdown is preserved permanently for date reference even after
     # builder saves overwrite `content` with JSON.
@@ -744,6 +753,36 @@ async def _improve_preview_flow(
 
     # Diff-based improvement: generate targeted changes, apply with verification
     if original_resume_data:
+        skill_targets: list[dict[str, Any]] = []
+        try:
+            raw_skill_plan = await generate_skill_target_plan(
+                original_resume_data=original_resume_data,
+                job_description=job["content"],
+                job_keywords=job_keywords,
+                language=language,
+            )
+            verified_skill_plan = verify_skill_target_plan(
+                raw_skill_plan,
+                original_resume_data=original_resume_data,
+                job_keywords=job_keywords,
+                job_description=job["content"],
+            )
+            accepted_targets = verified_skill_plan.get("accepted", [])
+            if isinstance(accepted_targets, list):
+                skill_targets = [
+                    target
+                    for target in accepted_targets
+                    if isinstance(target, dict)
+                ]
+            rejected_targets = verified_skill_plan.get("rejected", [])
+            if isinstance(rejected_targets, list) and rejected_targets:
+                response_warnings.append(
+                    f"{len(rejected_targets)} unsupported skill target(s) rejected"
+                )
+        except Exception as e:
+            logger.warning("Skill target planning failed, continuing without it: %s", e)
+            response_warnings.append("Skill target planning failed")
+
         diff_result = await generate_resume_diffs(
             original_resume=resume["content"],
             job_description=job["content"],
@@ -751,11 +790,13 @@ async def _improve_preview_flow(
             language=language,
             prompt_id=prompt_id,
             original_resume_data=original_resume_data,
+            skill_targets=skill_targets,
         )
 
         improved_data, applied_changes, rejected_changes = apply_diffs(
             original=original_resume_data,
             changes=diff_result.changes,
+            allowed_skill_targets=skill_targets,
         )
 
         diff_warnings = verify_diff_result(

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -680,6 +680,7 @@ class ApiKeysUpdateRequest(BaseModel):
     google: str | None = None
     openrouter: str | None = None
     deepseek: str | None = None
+    groq: str | None = None
 
 
 class ApiKeysUpdateResponse(BaseModel):

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -67,6 +67,7 @@ const PROVIDERS: LLMProvider[] = [
   'openrouter',
   'gemini',
   'deepseek',
+  'groq',
   'ollama',
 ];
 

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -8,6 +8,7 @@ export type LLMProvider =
   | 'openrouter'
   | 'gemini'
   | 'deepseek'
+  | 'groq'
   | 'ollama';
 
 // Reasoning-effort levels supported by LiteLLM. `null` (or absent) means
@@ -156,6 +157,7 @@ export const PROVIDER_INFO: Record<
   },
   gemini: { name: 'Google Gemini', defaultModel: 'gemini-3-flash-preview', requiresKey: true },
   deepseek: { name: 'DeepSeek', defaultModel: 'deepseek-chat', requiresKey: true },
+  groq: { name: 'Groq', defaultModel: 'llama-3.3-70b-versatile', requiresKey: true },
   ollama: { name: 'Ollama (Local)', defaultModel: 'gemma3:4b', requiresKey: false },
 };
 
@@ -367,7 +369,7 @@ export async function updateFeaturePrompts(update: FeaturePromptsUpdate): Promis
 }
 
 // API Key Management types
-export type ApiKeyProvider = 'openai' | 'anthropic' | 'google' | 'openrouter' | 'deepseek';
+export type ApiKeyProvider = 'openai' | 'anthropic' | 'google' | 'openrouter' | 'deepseek' | 'groq';
 
 export interface ApiKeyProviderStatus {
   provider: ApiKeyProvider;
@@ -385,6 +387,7 @@ export interface ApiKeysUpdateRequest {
   google?: string;
   openrouter?: string;
   deepseek?: string;
+  groq?: string;
 }
 
 export interface ApiKeysUpdateResponse {
@@ -400,6 +403,7 @@ export const API_KEY_PROVIDER_INFO: Record<ApiKeyProvider, { name: string; descr
     google: { name: 'Google', description: 'Gemini 1.5, Gemini 2, etc.' },
     openrouter: { name: 'OpenRouter', description: 'Access multiple providers' },
     deepseek: { name: 'DeepSeek', description: 'DeepSeek chat models' },
+    groq: { name: 'Groq', description: 'Llama, Mixtral, Gemma on Groq' },
   };
 
 // Fetch API key status for all providers


### PR DESCRIPTION
Closes #791

When a scanned/image-based PDF is uploaded, `parse_document` returns an empty string. Previously this empty text was passed to the LLM for JSON parsing, which could generate sample/template resumes (e.g., "John Doe") instead of failing cleanly.

This change validates that extracted markdown content is non-empty before storing it in the database, returning a clear 422 error to the user.

**Changes:**
- Added empty-text validation after `parse_document()` in `upload_resume()`
- Returns `422` with descriptive message for image-based/scanned documents

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject uploads with no extracted text to prevent fake resume parsing, and return a clear 422 to users. Adds `groq` as a supported LLM provider and improves the preview diff flow with skill target planning. Fixes #791.

- **Bug Fixes**
  - Validate parsed text in `upload_resume`; if empty, reject with 422 and guidance for scanned/image PDFs.

- **New Features**
  - Add `groq` provider across backend and frontend, including API key management and provider defaults.
  - Plan and verify skill targets during preview; pass accepted targets to diff generation and application, with warnings for rejected/failed plans.

<sup>Written for commit af753112dca2ab34aec1e35f8d21026fe071f08f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

