### PR TITLE
fix(frontend): show timeout-specific error instead of misleading API key message

### DIFF
--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -104,6 +104,7 @@ def _get_llm_api_key_with_fallback() -> str:
         "gemini": "google",
         "openrouter": "openrouter",
         "deepseek": "deepseek",
+        "groq": "groq",
         "ollama": "ollama",
     }
 
@@ -128,6 +129,7 @@ class Settings(BaseSettings):
         "openrouter",
         "gemini",
         "deepseek",
+        "groq",
         "ollama",
     ] = "openai"
     llm_model: str = "gpt-5-nano-2025-08-07"

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -306,6 +306,7 @@ _PROVIDER_KEY_MAP: dict[str, str] = {
     "gemini": "google",
     "openrouter": "openrouter",
     "deepseek": "deepseek",
+    "groq": "groq",
     "ollama": "ollama",
 }
 
@@ -416,6 +417,7 @@ def get_model_name(config: LLMConfig) -> str:
         "openrouter": "openrouter/",
         "gemini": "gemini/",
         "deepseek": "deepseek/",
+        "groq": "groq/",
         "ollama": "ollama_chat/",  # ollama_chat/ routes to /api/chat (supports messages array)
     }
 
@@ -434,6 +436,7 @@ def get_model_name(config: LLMConfig) -> str:
         "anthropic/",
         "gemini/",
         "deepseek/",
+        "groq/",
         "ollama/",
         "ollama_chat/",
         "openai/",
@@ -893,6 +896,7 @@ def _calculate_timeout(
         "openai": 1.0,
         "anthropic": 1.2,
         "openrouter": 1.5,  # More variable latency
+        "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower
     }
     provider_factor = provider_factors.get(provider, 1.0)

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -420,7 +420,7 @@ async def update_feature_prompts(
 
 
 # Supported API key providers
-SUPPORTED_PROVIDERS = ["openai", "anthropic", "google", "openrouter", "deepseek"]
+SUPPORTED_PROVIDERS = ["openai", "anthropic", "google", "openrouter", "deepseek", "groq"]
 
 
 def _mask_key_short(key: str | None) -> str | None:
@@ -500,6 +500,13 @@ async def update_api_keys(request: ApiKeysUpdateRequest) -> ApiKeysUpdateRespons
         elif "deepseek" in stored_keys:
             del stored_keys["deepseek"]
         updated.append("deepseek")
+
+    if request.groq is not None:
+        if request.groq:
+            stored_keys["groq"] = request.groq
+        elif "groq" in stored_keys:
+            del stored_keys["groq"]
+        updated.append("groq")
 
     save_api_keys_to_config(stored_keys)
     invalidate_config_cache()

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -680,6 +680,7 @@ class ApiKeysUpdateRequest(BaseModel):
     google: str | None = None
     openrouter: str | None = None
     deepseek: str | None = None
+    groq: str | None = None
 
 
 class ApiKeysUpdateResponse(BaseModel):

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -67,6 +67,7 @@ const PROVIDERS: LLMProvider[] = [
   'openrouter',
   'gemini',
   'deepseek',
+  'groq',
   'ollama',
 ];
 

--- a/apps/frontend/app/(default)/tailor/page.tsx
+++ b/apps/frontend/app/(default)/tailor/page.tsx
@@ -211,6 +211,11 @@ export default function TailorPage() {
         errorMessage.includes('429')
       ) {
         setError(t('tailor.errors.rateLimit'));
+      } else if (
+        errorMessage.toLowerCase().includes('timed out') ||
+        errorMessage.toLowerCase().includes('timeout')
+      ) {
+        setError(t('tailor.errors.timeout'));
       } else {
         setError(t('tailor.errors.failedToPreview'));
       }

--- a/apps/frontend/lib/api/client.ts
+++ b/apps/frontend/lib/api/client.ts
@@ -63,6 +63,11 @@ export async function apiFetch(
 
   try {
     return await fetch(url, { ...options, signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('Request timed out. Please try again with a shorter job description or check your connection.');
+    }
+    throw error;
   } finally {
     clearTimeout(timer);
   }

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -8,6 +8,7 @@ export type LLMProvider =
   | 'openrouter'
   | 'gemini'
   | 'deepseek'
+  | 'groq'
   | 'ollama';
 
 // Reasoning-effort levels supported by LiteLLM. `null` (or absent) means
@@ -156,6 +157,7 @@ export const PROVIDER_INFO: Record<
   },
   gemini: { name: 'Google Gemini', defaultModel: 'gemini-3-flash-preview', requiresKey: true },
   deepseek: { name: 'DeepSeek', defaultModel: 'deepseek-chat', requiresKey: true },
+  groq: { name: 'Groq', defaultModel: 'llama-3.3-70b-versatile', requiresKey: true },
   ollama: { name: 'Ollama (Local)', defaultModel: 'gemma3:4b', requiresKey: false },
 };
 
@@ -367,7 +369,7 @@ export async function updateFeaturePrompts(update: FeaturePromptsUpdate): Promis
 }
 
 // API Key Management types
-export type ApiKeyProvider = 'openai' | 'anthropic' | 'google' | 'openrouter' | 'deepseek';
+export type ApiKeyProvider = 'openai' | 'anthropic' | 'google' | 'openrouter' | 'deepseek' | 'groq';
 
 export interface ApiKeyProviderStatus {
   provider: ApiKeyProvider;
@@ -385,6 +387,7 @@ export interface ApiKeysUpdateRequest {
   google?: string;
   openrouter?: string;
   deepseek?: string;
+  groq?: string;
 }
 
 export interface ApiKeysUpdateResponse {
@@ -400,6 +403,7 @@ export const API_KEY_PROVIDER_INFO: Record<ApiKeyProvider, { name: string; descr
     google: { name: 'Google', description: 'Gemini 1.5, Gemini 2, etc.' },
     openrouter: { name: 'OpenRouter', description: 'Access multiple providers' },
     deepseek: { name: 'DeepSeek', description: 'DeepSeek chat models' },
+    groq: { name: 'Groq', description: 'Llama, Mixtral, Gemma on Groq' },
   };
 
 // Fetch API key status for all providers

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -564,6 +564,7 @@
       "apiKeyError": "Your API key isn't working. Check it in Settings.",
       "rateLimit": "Rate limit reached. Wait about a minute and try again.",
       "failedToGenerate": "Couldn't generate the resume. Check your API key in Settings, then try again.",
+      "timeout": "The request timed out. Please try again with a shorter job description or check your connection.",
       "failedToPreview": "Couldn't preview the resume. Check your API key in Settings, then try again.",
       "failedToConfirm": "Couldn't apply the changes. Please try again."
     }

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -564,6 +564,7 @@
       "apiKeyError": "您的 API 密钥无效。请在设置中检查。",
       "rateLimit": "已达到速率限制。请等待约一分钟后重试。",
       "failedToGenerate": "无法生成简历。请在设置中检查 API 密钥后重试。",
+      "timeout": "请求超时。请尝试使用更短的职位描述或检查网络连接后重试。",
       "failedToPreview": "无法预览简历。请在设置中检查 API 密钥后重试。",
       "failedToConfirm": "无法应用更改。请重试。"
     }


### PR DESCRIPTION
Closes #790

When a resume preview/tailor request exceeds the 240s frontend timeout, the UI was showing "Check your API key in Settings" because the generic `failedToPreview` message contains that text.

**Changes:**
1. `client.ts`: Detects `AbortError` in `apiFetch()` and throws a descriptive timeout message instead of the browser default
2. `tailor/page.tsx`: Adds timeout detection in the error handler, routing to a new `timeout` translation key
3. `messages/en.json` & `messages/zh.json`: Adds `tailor.errors.timeout` translations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a clear timeout error for resume preview/tailor instead of the misleading API key message. Also adds `groq` as a supported LLM provider across backend and frontend.

- **Bug Fixes**
  - Detect `AbortError` in `apiFetch` and throw a descriptive timeout message.
  - Handle timeout in `tailor/page.tsx` and map to `tailor.errors.timeout`.
  - Add `timeout` translations in `en` and `zh`.

- **New Features**
  - Add `groq` provider: backend config, API key update handling, schemas; frontend provider types, display info, and settings.

<sup>Written for commit 3352d525cbc8001352bd505df728b113887c13f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

