### PR TITLE
"Fix: PDF rendering timeout on page.goto with networkidle"

### DIFF
--- a/apps/backend/app/pdf.py
+++ b/apps/backend/app/pdf.py
@@ -133,9 +133,13 @@ async def _render_page_to_pdf(
     pdf_format: str,
     pdf_margins: dict,
 ) -> bytes:
-    await page.goto(url, wait_until="networkidle")
-    await page.wait_for_selector(selector)
-    await page.evaluate("document.fonts.ready")
+    await page.goto(url, wait_until="domcontentloaded", timeout=15000)
+    await page.wait_for_selector(selector, timeout=10000)
+    try:
+        await page.evaluate("document.fonts.ready", timeout=10000)
+    except Exception:
+        # Font loading is not critical for PDF rendering
+        pass
     return await page.pdf(
         format=pdf_format,
         print_background=True,


### PR DESCRIPTION
## Description
Fixes #799 

## Changes
- Changed `wait_until="networkidle"` to `wait_until="domcontentloaded"` in `_render_page_to_pdf()`
- Added explicit timeouts for each operation
- Wrapped font loading in try/except since fonts aren't critical for PDF rendering

## Testing
- Tested resume PDF download successfully completes within 10-15 seconds
- PDF quality unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PDF rendering timeouts by switching navigation wait to `domcontentloaded` and adding per-step timeouts, so resume PDFs generate reliably in ~10–15s.

- **Bug Fixes**
  - Use `page.goto(..., wait_until="domcontentloaded", timeout=15000)` to avoid hangs on `networkidle`.
  - Add explicit timeouts: selector wait 10s; font load 10s.
  - Wrap `document.fonts.ready` in try/except so font issues don’t block PDF rendering.

<sup>Written for commit a29f216d712d91f8d3c881971dafc0f2c9c8fb30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

