### PR TITLE
fix(pdf): resolve rendering timeout by switching to domcontentloaded strategy

### DIFF
--- a/apps/backend/app/pdf.py
+++ b/apps/backend/app/pdf.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 from pathlib import Path
 from typing import Awaitable, NoReturn, Optional
+
+logger = logging.getLogger(__name__)
 
 from playwright.async_api import (
     Browser,
@@ -133,9 +136,12 @@ async def _render_page_to_pdf(
     pdf_format: str,
     pdf_margins: dict,
 ) -> bytes:
-    await page.goto(url, wait_until="networkidle")
-    await page.wait_for_selector(selector)
-    await page.evaluate("document.fonts.ready")
+    await page.goto(url, wait_until="domcontentloaded", timeout=15000)
+    await page.wait_for_selector(selector, timeout=10000)
+    try:
+        await page.evaluate("document.fonts.ready", timeout=10000)
+    except Exception as e:
+        logger.warning(f"Font loading failed for PDF generation (non-critical): {e}")
     return await page.pdf(
         format=pdf_format,
         print_background=True,


### PR DESCRIPTION
Fixes #799

## Problem
PDF download fails with a 30-second timeout when `page.goto()` waits for `networkidle` in Next.js dev mode. The `networkidle` strategy is too strict for static print pages — Web Fonts, HMR WebSocket connections, and other resources keep the network active, causing Playwright to hang until the default 30s timeout expires.

This is particularly problematic on Windows 11 with Turbopack, where font loading and dev-mode resources create sustained network activity.

## Changes
- `page.goto(url, wait_until="networkidle")` → `page.goto(url, wait_until="domcontentloaded", timeout=15000)`
- `page.wait_for_selector(selector)` → `page.wait_for_selector(selector, timeout=10000)`
- `document.fonts.ready` wrapped in `try/except` with `timeout=10000` and **warning log**

## Why `domcontentloaded`?
PDF rendering is a static snapshot operation. It only needs the DOM tree to be ready — it does not require all async resources (fonts, analytics, HMR) to finish loading. This aligns with the 10-15s target mentioned in #799.

## Comparison with #800
PR #800 (by @vinsmokejazz) proposed a similar fix. This PR builds on that approach with one additional improvement:

- **Added `logger.warning()` for font loading failures**: Silently swallowing font exceptions with `except Exception: pass` makes production debugging difficult. The warning log allows operators to detect font issues without blocking PDF generation.

## Testing
- [ ] Resume PDF download completes within 10-15 seconds
- [ ] PDF quality unchanged
- [ ] Font loading warning appears in logs when fonts fail (non-blocking)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch PDF rendering to wait for DOMContentLoaded to avoid 30s timeouts in dev (notably on Windows 11 with Turbopack). Fixes #799.

- **Bug Fixes**
  - Change `page.goto(..., wait_until="domcontentloaded", timeout=15000)` to avoid `networkidle` hangs.
  - Add `timeout=10000` to `page.wait_for_selector(...)` for fail-fast behavior.
  - Wrap `document.fonts.ready` with a 10s timeout and log a warning on failure (non-blocking).

<sup>Written for commit 6cf8ed309fea1763ec87723605426402130d5adb. Summary will update on new commits. <a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/804?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

