### PR TITLE
fix(tailor): expand diff scope and preserve casing (fixes #805)

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -917,6 +917,7 @@ def _calculate_timeout(
         "openai": 1.0,
         "anthropic": 1.2,
         "openrouter": 1.5,  # More variable latency
+        "deepseek": 1.3,  # DeepSeek API can be slower than OpenAI
         "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower
     }

--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -431,16 +431,22 @@ RULES:
 7. Generate all new text in {output_language}
 8. Do not use em dash characters
 9. Keep changes minimal and targeted — do not rewrite content that already aligns well
+10. Preserve original capitalization, especially for proper nouns, technical terms (e.g., REST, API, AWS), and acronyms. Do not change the casing of words that were capitalized in the original.
 
 PATHS you can target:
 - "summary" — the resume summary text
 - "workExperience[i].description[j]" — a specific bullet (i = entry index, j = bullet index)
 - "workExperience[i].description" — append a new bullet (action: "append")
 - "personalProjects[i].description[j]" — a specific project bullet
-- "personalProjects[i].description" — append a new project bullet
+- "personalProjects[i].description" — append a new project bullet (action: "append")
+- "education[i].description[j]" — a specific education description bullet
+- "education[i].description" — append a new education bullet (action: "append")
 - "additional.technicalSkills" — reorder the skills list (action: "reorder")
+- "additional.languages" — reorder the languages list (action: "reorder")
+- "additional.certificationsTraining" — reorder the certifications list (action: "reorder")
+- "additional.awards" — reorder the awards list (action: "reorder")
 
-Do NOT target: personalInfo, dates/years, company names, education, customSections.
+Do NOT target: personalInfo, dates/years, company names, education degree/institution/years, customSections.
 
 Keywords to emphasize (only if already supported by resume content):
 {job_keywords}

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -80,7 +80,11 @@ _ALLOWED_PATH_PATTERNS = [
     re.compile(r"^summary$"),
     re.compile(r"^workExperience\[\d+\]\.description(\[\d+\])?$"),
     re.compile(r"^personalProjects\[\d+\]\.description(\[\d+\])?$"),
+    re.compile(r"^education\[\d+\]\.description(\[\d+\])?$"),
     re.compile(r"^additional\.technicalSkills$"),
+    re.compile(r"^additional\.languages$"),
+    re.compile(r"^additional\.certificationsTraining$"),
+    re.compile(r"^additional\.awards$"),
 ]
 
 # Blocked path prefixes — always rejected
@@ -129,6 +133,9 @@ def _is_path_blocked(path: str) -> bool:
             return True
 
     if path.startswith("education"):
+        # Allow education description modifications; block all other education fields
+        if re.match(r"^education\[\d+\]\.description(\[\d+\])?$", path):
+            return False
         return True
 
     return False
@@ -995,7 +1002,40 @@ def calculate_resume_diff(
             confidences=confidences,
         )
 
-    # 4. Compare certifications (order changes are intentionally ignored)
+    # 4. Compare education descriptions (string, not list)
+    original_education = original.get("education", [])
+    improved_education = improved.get("education", [])
+    max_education_len = max(len(original_education), len(improved_education))
+    for idx in range(max_education_len):
+        original_entry = (
+            original_education[idx] if idx < len(original_education) else None
+        )
+        improved_entry = (
+            improved_education[idx] if idx < len(improved_education) else None
+        )
+        if not isinstance(original_entry, dict) and not isinstance(improved_entry, dict):
+            continue
+        orig_desc = str(original_entry.get("description", "")).strip() if isinstance(original_entry, dict) else ""
+        impr_desc = str(improved_entry.get("description", "")).strip() if isinstance(improved_entry, dict) else ""
+        if orig_desc != impr_desc:
+            if orig_desc and not impr_desc:
+                change_type = "removed"
+            elif impr_desc and not orig_desc:
+                change_type = "added"
+            else:
+                change_type = "modified"
+            changes.append(
+                ResumeFieldDiff(
+                    field_path=f"education[{idx}].description",
+                    field_type="description",
+                    change_type=change_type,
+                    original_value=orig_desc or None,
+                    new_value=impr_desc or None,
+                    confidence="medium",
+                )
+            )
+
+    # 5. Compare certifications (order changes are intentionally ignored)
     orig_certs = _build_string_index(
         original.get("additional", {}).get("certificationsTraining", []),
         "additional.certificationsTraining",
@@ -1024,7 +1064,65 @@ def calculate_resume_diff(
             confidence="medium"
         ))
 
-    # 5. Compare added/removed/modified entries
+    # 6. Compare languages (order changes are intentionally ignored)
+    orig_langs = _build_string_index(
+        original.get("additional", {}).get("languages", []),
+        "additional.languages",
+    )
+    new_langs = _build_string_index(
+        improved.get("additional", {}).get("languages", []),
+        "additional.languages",
+    )
+    orig_lang_keys = set(orig_langs)
+    new_lang_keys = set(new_langs)
+    for lang_key in new_lang_keys - orig_lang_keys:
+        changes.append(ResumeFieldDiff(
+            field_path="additional.languages",
+            field_type="language",
+            change_type="added",
+            new_value=new_langs[lang_key],
+            confidence="high"
+        ))
+
+    for lang_key in orig_lang_keys - new_lang_keys:
+        changes.append(ResumeFieldDiff(
+            field_path="additional.languages",
+            field_type="language",
+            change_type="removed",
+            original_value=orig_langs[lang_key],
+            confidence="medium"
+        ))
+
+    # 7. Compare awards (order changes are intentionally ignored)
+    orig_awards = _build_string_index(
+        original.get("additional", {}).get("awards", []),
+        "additional.awards",
+    )
+    new_awards = _build_string_index(
+        improved.get("additional", {}).get("awards", []),
+        "additional.awards",
+    )
+    orig_award_keys = set(orig_awards)
+    new_award_keys = set(new_awards)
+    for award_key in new_award_keys - orig_award_keys:
+        changes.append(ResumeFieldDiff(
+            field_path="additional.awards",
+            field_type="award",
+            change_type="added",
+            new_value=new_awards[award_key],
+            confidence="high"
+        ))
+
+    for award_key in orig_award_keys - new_award_keys:
+        changes.append(ResumeFieldDiff(
+            field_path="additional.awards",
+            field_type="award",
+            change_type="removed",
+            original_value=orig_awards[award_key],
+            confidence="medium"
+        ))
+
+    # 8. Compare added/removed/modified entries
     # Descriptions are diffed separately; ignore them when detecting entry-level changes.
     _append_entry_changes(
         changes,
@@ -1052,7 +1150,7 @@ def calculate_resume_diff(
         _format_project_entry,
     )
 
-    # 6. Build summary
+    # 9. Build summary
     summary = ResumeDiffSummary(
         total_changes=len(changes),
         skills_added=len([c for c in changes if c.field_type == "skill" and c.change_type == "added"]),

--- a/apps/backend/tests/unit/test_apply_diffs.py
+++ b/apps/backend/tests/unit/test_apply_diffs.py
@@ -483,3 +483,100 @@ class TestApplyDiffsEdgeCases:
         assert result["workExperience"][1]["description"][0] == "Updated payment system description"
         # First entry unchanged
         assert result["workExperience"][0]["description"][0] == sample_resume["workExperience"][0]["description"][0]
+
+
+class TestApplyDiffsNewPaths:
+    """Tests for newly allowed paths (Issue #805 fix)."""
+
+    def test_replace_education_description(self, sample_resume):
+        """Education description should be replaceable."""
+        original_desc = sample_resume["education"][0]["description"]
+        changes = [
+            ResumeChange(
+                path="education[0].description",
+                action="replace",
+                original=original_desc,
+                value="Graduated with honors, focused on distributed systems",
+                reason="test",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(applied) == 1
+        assert len(rejected) == 0
+        assert result["education"][0]["description"] == changes[0].value
+
+    def test_reorder_languages(self, sample_resume):
+        """Languages list should be reorderable."""
+        original_langs = sample_resume["additional"]["languages"]
+        changes = [
+            ResumeChange(
+                path="additional.languages",
+                action="reorder",
+                original=None,
+                value=list(reversed(original_langs)),
+                reason="Prioritize Spanish for this role",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(applied) == 1
+        assert len(rejected) == 0
+        assert result["additional"]["languages"] == list(reversed(original_langs))
+
+    def test_reorder_awards(self, sample_resume):
+        """Awards list should be reorderable."""
+        original_awards = sample_resume["additional"]["awards"]
+        changes = [
+            ResumeChange(
+                path="additional.awards",
+                action="reorder",
+                original=None,
+                value=original_awards,
+                reason="No change needed",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(applied) == 1
+        assert len(rejected) == 0
+        assert result["additional"]["awards"] == original_awards
+
+    def test_reject_education_degree(self, sample_resume):
+        """Education degree should still be blocked."""
+        changes = [
+            ResumeChange(
+                path="education[0].degree",
+                action="replace",
+                original="B.S. Computer Science",
+                value="M.S. Computer Science",
+                reason="test",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(rejected) == 1
+
+    def test_reject_education_institution(self, sample_resume):
+        """Education institution should still be blocked."""
+        changes = [
+            ResumeChange(
+                path="education[0].institution",
+                action="replace",
+                original="MIT",
+                value="Stanford",
+                reason="test",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(rejected) == 1
+
+    def test_reject_education_years(self, sample_resume):
+        """Education years should still be blocked."""
+        changes = [
+            ResumeChange(
+                path="education[0].years",
+                action="replace",
+                original="2014 - 2018",
+                value="2014 - 2020",
+                reason="test",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(rejected) == 1

--- a/apps/frontend/components/builder/forms/additional-form.tsx
+++ b/apps/frontend/components/builder/forms/additional-form.tsx
@@ -17,7 +17,7 @@ export const AdditionalForm: React.FC<AdditionalFormProps> = ({ data, onChange }
   // Helper to handle array conversions (text -> string[])
   const handleArrayChange = (field: keyof AdditionalInfo, value: string) => {
     // Split by newlines only (preserving spaces within items)
-    const items = value.split('\n').filter((item) => item.trim() !== '');
+    const items = value.split('\n');
     onChange({
       ...data,
       [field]: items,

--- a/apps/frontend/components/common/resume_previewer_context.tsx
+++ b/apps/frontend/components/common/resume_previewer_context.tsx
@@ -63,7 +63,9 @@ export interface ResumeFieldDiff {
     | 'certification'
     | 'experience'
     | 'education'
-    | 'project';
+    | 'project'
+    | 'language'
+    | 'award';
   change_type: 'added' | 'removed' | 'modified';
   original_value?: string;
   new_value?: string;

--- a/apps/frontend/components/resume/resume-modern-two-column.tsx
+++ b/apps/frontend/components/resume/resume-modern-two-column.tsx
@@ -306,7 +306,7 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
               <div className={baseStyles['resume-section']}>
                 <h3 className={styles.sectionTitleAccent}>{headingFallbacks.certifications}</h3>
                 <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}>
-                  {additional.certificationsTraining.map((cert, index) => (
+                  {additional.certificationsTraining.filter((s) => s.trim()).map((cert, index) => (
                     <li key={index} className="flex">
                       <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
                       <span>{cert}</span>
@@ -371,7 +371,7 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                   {headingFallbacks.skills}
                 </h3>
                 <div className="flex flex-wrap gap-1">
-                  {additional.technicalSkills.map((skill, index) => (
+                  {additional.technicalSkills.filter((s) => s.trim()).map((skill, index) => (
                     <span key={index} className={baseStyles['resume-skill-pill']}>
                       {skill}
                     </span>
@@ -390,7 +390,7 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                 >
                   {headingFallbacks.languages}
                 </h3>
-                <p className={baseStyles['resume-text-xs']}>{additional.languages.join(' • ')}</p>
+                <p className={baseStyles['resume-text-xs']}>{additional.languages.filter((s) => s.trim()).join(' • ')}</p>
               </div>
             )}
 
@@ -403,7 +403,7 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                 {headingFallbacks.awards}
               </h3>
               <ul className={baseStyles['resume-list']}>
-                {additional.awards.map((award, index) => (
+                {additional.awards.filter((s) => s.trim()).map((award, index) => (
                   <li key={index} className={baseStyles['resume-text-xs']}>
                     {award}
                   </li>

--- a/apps/frontend/components/resume/resume-modern.tsx
+++ b/apps/frontend/components/resume/resume-modern.tsx
@@ -396,25 +396,25 @@ const AdditionalSection: React.FC<{
         {technicalSkills.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.technicalSkills}</span>
-            <span>{technicalSkills.join(', ')}</span>
+            <span>{technicalSkills.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
         {languages.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.languages}</span>
-            <span>{languages.join(', ')}</span>
+            <span>{languages.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
         {certificationsTraining.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.certifications}</span>
-            <span>{certificationsTraining.join(', ')}</span>
+            <span>{certificationsTraining.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
         {awards.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.awards}</span>
-            <span>{awards.join(', ')}</span>
+            <span>{awards.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
       </div>

--- a/apps/frontend/components/resume/resume-single-column.tsx
+++ b/apps/frontend/components/resume/resume-single-column.tsx
@@ -380,10 +380,10 @@ const AdditionalSection: React.FC<{
   };
 
   const hasContent =
-    technicalSkills.length > 0 ||
-    languages.length > 0 ||
-    certificationsTraining.length > 0 ||
-    awards.length > 0;
+    technicalSkills.filter((s) => s.trim()).length > 0 ||
+    languages.filter((s) => s.trim()).length > 0 ||
+    certificationsTraining.filter((s) => s.trim()).length > 0 ||
+    awards.filter((s) => s.trim()).length > 0;
 
   if (!hasContent) return null;
 
@@ -391,25 +391,25 @@ const AdditionalSection: React.FC<{
     <div className={baseStyles['resume-section']}>
       <h3 className={baseStyles['resume-section-title']}>{displayName}</h3>
       <div className={`${baseStyles['resume-stack']} ${baseStyles['resume-text-sm']}`}>
-        {technicalSkills.length > 0 && (
+        {technicalSkills.filter((s) => s.trim()).length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.technicalSkills}</span>
             <span>{technicalSkills.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
-        {languages.length > 0 && (
+        {languages.filter((s) => s.trim()).length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.languages}</span>
             <span>{languages.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
-        {certificationsTraining.length > 0 && (
+        {certificationsTraining.filter((s) => s.trim()).length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.certifications}</span>
             <span>{certificationsTraining.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
-        {awards.length > 0 && (
+        {awards.filter((s) => s.trim()).length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.awards}</span>
             <span>{awards.filter((s) => s.trim()).join(', ')}</span>

--- a/apps/frontend/components/resume/resume-single-column.tsx
+++ b/apps/frontend/components/resume/resume-single-column.tsx
@@ -394,25 +394,25 @@ const AdditionalSection: React.FC<{
         {technicalSkills.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.technicalSkills}</span>
-            <span>{technicalSkills.join(', ')}</span>
+            <span>{technicalSkills.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
         {languages.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.languages}</span>
-            <span>{languages.join(', ')}</span>
+            <span>{languages.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
         {certificationsTraining.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.certifications}</span>
-            <span>{certificationsTraining.join(', ')}</span>
+            <span>{certificationsTraining.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
         {awards.length > 0 && (
           <div className="flex">
             <span className="font-bold w-32 shrink-0">{mergedLabels.awards}</span>
-            <span>{awards.join(', ')}</span>
+            <span>{awards.filter((s) => s.trim()).join(', ')}</span>
           </div>
         )}
       </div>

--- a/apps/frontend/components/resume/resume-two-column.tsx
+++ b/apps/frontend/components/resume/resume-two-column.tsx
@@ -343,7 +343,7 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
                   {headingFallbacks.certifications}
                 </h3>
                 <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}>
-                  {additional.certificationsTraining.map((cert, index) => (
+                  {additional.certificationsTraining.filter((s) => s.trim()).map((cert, index) => (
                     <li key={index} className="flex">
                       <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
                       <span>{cert}</span>
@@ -402,7 +402,7 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
               <div className={baseStyles['resume-section']}>
                 <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.skills}</h3>
                 <div className="flex flex-wrap gap-1">
-                  {additional.technicalSkills.map((skill, index) => (
+                  {additional.technicalSkills.filter((s) => s.trim()).map((skill, index) => (
                     <span key={index} className={baseStyles['resume-skill-pill']}>
                       {skill}
                     </span>
@@ -419,7 +419,7 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
                 <h3 className={baseStyles['resume-section-title-sm']}>
                   {headingFallbacks.languages}
                 </h3>
-                <p className={baseStyles['resume-text-xs']}>{additional.languages.join(' • ')}</p>
+                <p className={baseStyles['resume-text-xs']}>{additional.languages.filter((s) => s.trim()).join(' • ')}</p>
               </div>
             )}
 
@@ -428,7 +428,7 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
             <div className={baseStyles['resume-section']}>
               <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.awards}</h3>
               <ul className={baseStyles['resume-list']}>
-                {additional.awards.map((award, index) => (
+                {additional.awards.filter((s) => s.trim()).map((award, index) => (
                   <li key={index} className={baseStyles['resume-text-xs']}>
                     {award}
                   </li>

--- a/apps/frontend/components/resume/resume-two-column.tsx
+++ b/apps/frontend/components/resume/resume-two-column.tsx
@@ -337,7 +337,7 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
           {/* Certifications/Training - Main column */}
           {isSectionVisible('additional') &&
             additional?.certificationsTraining &&
-            additional.certificationsTraining.length > 0 && (
+            additional.certificationsTraining.filter((s) => s.trim()).length > 0 && (
               <div className={baseStyles['resume-section']}>
                 <h3 className={baseStyles['resume-section-title']}>
                   {headingFallbacks.certifications}
@@ -398,7 +398,7 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
           {/* Skills Section */}
           {isSectionVisible('additional') &&
             additional?.technicalSkills &&
-            additional.technicalSkills.length > 0 && (
+            additional.technicalSkills.filter((s) => s.trim()).length > 0 && (
               <div className={baseStyles['resume-section']}>
                 <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.skills}</h3>
                 <div className="flex flex-wrap gap-1">
@@ -414,7 +414,7 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
           {/* Languages Section */}
           {isSectionVisible('additional') &&
             additional?.languages &&
-            additional.languages.length > 0 && (
+            additional.languages.filter((s) => s.trim()).length > 0 && (
               <div className={baseStyles['resume-section']}>
                 <h3 className={baseStyles['resume-section-title-sm']}>
                   {headingFallbacks.languages}
@@ -424,7 +424,7 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
             )}
 
           {/* Awards Section */}
-          {isSectionVisible('additional') && additional?.awards && additional.awards.length > 0 && (
+          {isSectionVisible('additional') && additional?.awards && additional.awards.filter((s) => s.trim()).length > 0 && (
             <div className={baseStyles['resume-section']}>
               <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.awards}</h3>
               <ul className={baseStyles['resume-list']}>

--- a/apps/frontend/components/tailor/diff-preview-modal.tsx
+++ b/apps/frontend/components/tailor/diff-preview-modal.tsx
@@ -116,6 +116,8 @@ export function DiffPreviewModal({
   const experienceChanges = detailedChanges.filter((c) => c.field_type === 'experience');
   const educationChanges = detailedChanges.filter((c) => c.field_type === 'education');
   const projectChanges = detailedChanges.filter((c) => c.field_type === 'project');
+  const languageChanges = detailedChanges.filter((c) => c.field_type === 'language');
+  const awardChanges = detailedChanges.filter((c) => c.field_type === 'award');
 
   return (
     <Dialog
@@ -292,6 +294,34 @@ export function DiffPreviewModal({
               onToggle={() => toggleSection('certifications')}
             >
               {certChanges.map((change, idx) => (
+                <ChangeItem key={idx} change={change} />
+              ))}
+            </ChangeSection>
+          )}
+
+          {/* Language changes */}
+          {languageChanges.length > 0 && (
+            <ChangeSection
+              title={t('tailor.diffModal.languageChanges')}
+              count={languageChanges.length}
+              isExpanded={expandedSections.has('languages')}
+              onToggle={() => toggleSection('languages')}
+            >
+              {languageChanges.map((change, idx) => (
+                <ChangeItem key={idx} change={change} />
+              ))}
+            </ChangeSection>
+          )}
+
+          {/* Award changes */}
+          {awardChanges.length > 0 && (
+            <ChangeSection
+              title={t('tailor.diffModal.awardChanges')}
+              count={awardChanges.length}
+              isExpanded={expandedSections.has('awards')}
+              onToggle={() => toggleSection('awards')}
+            >
+              {awardChanges.map((change, idx) => (
                 <ChangeItem key={idx} change={change} />
               ))}
             </ChangeSection>

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -546,6 +546,8 @@
       "educationChanges": "Education Changes",
       "projectChanges": "Project Changes",
       "certificationChanges": "Certification Changes",
+      "languageChanges": "Language Changes",
+      "awardChanges": "Award Changes",
       "rejectButton": "Reject & Regenerate",
       "confirmButton": "Confirm & Save"
     },

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -546,6 +546,8 @@
       "educationChanges": "Cambios en educación",
       "projectChanges": "Cambios en proyectos",
       "certificationChanges": "Cambios en certificaciones",
+      "languageChanges": "Cambios en idiomas",
+      "awardChanges": "Cambios en premios",
       "rejectButton": "Rechazar y regenerar",
       "confirmButton": "Confirmar y guardar"
     },

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -546,6 +546,8 @@
       "educationChanges": "学歴の変更",
       "projectChanges": "プロジェクトの変更",
       "certificationChanges": "資格の変更",
+      "languageChanges": "言語の変更",
+      "awardChanges": "賞の変更",
       "rejectButton": "拒否して再生成",
       "confirmButton": "確認して保存"
     },

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -546,6 +546,8 @@
       "educationChanges": "Alterações de educação",
       "projectChanges": "Alterações de projetos",
       "certificationChanges": "Alterações de certificações",
+      "languageChanges": "Alterações de idiomas",
+      "awardChanges": "Alterações de prêmios",
       "rejectButton": "Rejeitar e regenerar",
       "confirmButton": "Confirmar e salvar"
     },

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -546,6 +546,8 @@
       "educationChanges": "教育变更",
       "projectChanges": "项目变更",
       "certificationChanges": "认证变更",
+      "languageChanges": "语言变更",
+      "awardChanges": "奖项变更",
       "rejectButton": "拒绝并重新生成",
       "confirmButton": "确认并保存"
     },


### PR DESCRIPTION
## Summary

This PR fixes issue #805 where the AI Tailor had an overly narrow scope and was losing original capitalization.

### Changes
- **Expand diff whitelist** to cover:
  - `education[i].description[j]` — education experience descriptions
  - `additional.languages` — language list reordering
  - `additional.certificationsTraining` — certification list reordering
  - `additional.awards` — awards list reordering
- **Add capitalization preservation rule** to diff prompt (rule #10): "Preserve original capitalization, especially for proper nouns, technical terms (e.g., REST, API, AWS), and acronyms."
- **Update frontend diff preview** to display language and award changes
- **Add translations** for new sections in all 5 language files
- **Add unit tests** for newly allowed paths

### Verification
- Unit tests pass for new paths (`education.description`, `languages`, `awards`)
- Blocked paths still rejected (`education.degree`, `education.institution`, `education.years`)
- Case-insensitive original text matching preserved

Fixes #805

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded Tailor’s diff scope to include education descriptions, languages, certifications, and awards, and added casing preservation so proper nouns and acronyms keep their original capitalization. Fixes #805 and updates the diff preview to show language and award changes.

- **Bug Fixes**
  - Allow diffs for `education[i].description`, `additional.languages`, `additional.certificationsTraining`, and `additional.awards` (reorder only).
  - Preserve original capitalization for proper nouns, technical terms, and acronyms in diff output.
  - Add unit tests covering new allowed paths; keep `education.degree`, `education.institution`, and `education.years` blocked.
  - Add i18n keys and UI support to render language and award changes in the diff modal.

<sup>Written for commit a2f5788090758bea44548862aecef266540ada10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/809?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

