### PR TITLE
fix(deps): patch 5 security advisories (python-multipart, python-dotenv, postcss, brace-expansion)

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -6,16 +6,16 @@ requires-python = ">=3.13"
 dependencies = [
     "fastapi==0.128.4",
     "uvicorn==0.40.0",
-    "python-multipart==0.0.26",
+    "python-multipart==0.0.27",
     "pydantic==2.12.5",
     "pydantic-settings==2.12.0",
     "tinydb==4.8.2",
-    "litellm==1.83.10",
+    "litellm==1.86.2",
     "markitdown[docx]==0.1.4",
     "pdfminer.six==20260107",
     "playwright==1.58.0",
     "python-docx==1.2.0",
-    "python-dotenv==1.0.1",
+    "python-dotenv==1.2.2",
 ]
 
 [project.scripts]

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -1,10 +1,10 @@
 fastapi==0.128.4
 uvicorn==0.40.0
-python-multipart==0.0.26
+python-multipart==0.0.27
 pydantic==2.12.5
 pydantic-settings==2.12.0
 tinydb==4.8.2
-litellm==1.83.10
+litellm==1.86.2
 markitdown[docx]==0.1.4
 python-docx==1.2.0
 playwright==1.58.0

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7801,7 +7801,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -7389,9 +7389,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -7480,34 +7480,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-releases": {
@@ -7826,9 +7798,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -7846,7 +7818,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -46,6 +46,7 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "undici": "^7.24.1"
+    "undici": "^7.24.1",
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Patches all open Dependabot security advisories plus two related cleanups. Supersedes #797 and #781.

| Dependabot alert | Package | Severity | Change |
|---|---|---|---|
| #207, #208 | python-multipart | 🔴 High | `0.0.26 → 0.0.27` — CVE-2026-42561 (DoS via unbounded multipart part headers) |
| #199 | python-dotenv | 🟠 Moderate | `1.0.1 → 1.2.2` — CVE-2026-28684 (symlink following in `set_key`) |
| #204 | postcss | 🟠 Moderate | `→ 8.5.15` via `overrides` pin `^8.5.10` — CVE-2026-41305 (XSS via unescaped `</style>`) |
| — | brace-expansion | 🟠 Moderate | `5.0.5 → 5.0.6` — GHSA-jxxr-4gwj-5jf2 (DoS) |

## The LiteLLM blocker

`python-dotenv` could not be upgraded on its own: **litellm `<1.84.0` hard-pins `python-dotenv==1.0.1`**, making the upgrade an unsatisfiable resolution (the existing `requirements.txt` already listed `1.2.2`, hiding the conflict behind an unresolved flat list). litellm `1.84.0+` relaxes this to `python-dotenv<2.0,>=1.0.0`, so **litellm is bumped `1.83.10 → 1.86.2`** (latest). litellm has no known CVEs (OSV clean for both 1.83.10 and 1.86.2).

## Verification

- Backend: `uv lock` + `uv sync` resolve and install cleanly with litellm 1.86.2, python-dotenv 1.2.2, python-multipart 0.0.27. (Also moved transitive `numpy` off the yanked `2.4.0` → `2.4.6` locally; `uv.lock` is gitignored so not in this diff.)
- Frontend: `npm audit` reports **0 vulnerabilities**. The postcss `overrides` pin forces Next.js's bundled copy (was `8.4.31`) onto the patched line without downgrading Next 16.

## Notes

- Dependabot alerts #207/#208/#199/#204 will auto-dismiss once this lands on `main` and Dependabot re-scans.
- Alert #198 (python-dotenv / `requirements.txt`) was already stale — `requirements.txt` had drifted to `1.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches security advisories in backend and frontend to clear Dependabot alerts and npm audit issues. Updates core packages and pins `postcss` to a safe line; bumps `litellm` to unblock the `python-dotenv` upgrade.

- **Dependencies**
  - Backend: `python-multipart` 0.0.26 → 0.0.27, `python-dotenv` 1.0.1 → 1.2.2, `litellm` 1.83.10 → 1.86.2.
  - Frontend: override `postcss` to `^8.5.10` (resolved to 8.5.15); bump transitive `brace-expansion` to 5.0.6.

<sup>Written for commit 19bed116e90d1778f1159b8fc8e87f4c3902fa2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

