### PR TITLE
docs(claude): add app-level CLAUDE.md context files (backend + frontend)

### DIFF
--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -1,0 +1,153 @@
+# CLAUDE.md - Backend (`apps/backend`)
+
+> FastAPI backend for Resume Matcher. This file goes **deeper on the backend**.
+> For project-wide context see the root [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md) and [`docs/agent/README.md`](../../docs/agent/README.md).
+
+Stack: FastAPI 0.128 · Python **3.13+** · Pydantic v2 / pydantic-settings · TinyDB (JSON file) · LiteLLM (multi-provider AI) · markitdown (DOCX/PDF→Markdown) · Playwright/Chromium (PDF). Managed with **uv** (`pyproject.toml`, version `1.2.0`).
+
+---
+
+## Architecture / Module Map
+
+| Module | Responsibility | Key files |
+|--------|----------------|-----------|
+| Entry / wiring | App, lifespan, CORS, router mounting (all under `/api/v1`) | `app/main.py` |
+| Settings | Env vars via `pydantic-settings`; `settings` singleton; API-key fallback to `config.json` | `app/config.py` |
+| Config cache | Shared, TTL-cached (5 min) read of `data/config.json`; `get_content_language()` | `app/config_cache.py` |
+| Database | TinyDB wrapper; tables `resumes`/`jobs`/`improvements`; global `db` singleton | `app/database.py` |
+| LLM | LiteLLM wrapper: Router, retries, JSON extraction, timeouts, provider quirks | `app/llm.py` |
+| PDF | Headless Chromium render of frontend `/print/*` pages; lazy browser init | `app/pdf.py` |
+| Routers | HTTP endpoints (see below) | `app/routers/*.py` |
+| Services | Business logic (parse, improve/diff, refine, cover-letter) | `app/services/*.py` |
+| Prompts | All LLM prompt templates + placeholder validation | `app/prompts/*.py` |
+| Schemas | Pydantic request/response + `ResumeData` models | `app/schemas/*.py` |
+
+`data/` (gitignored: `data/*.json`) holds `database.json`, `config.json`, `prompts.json`, and an `uploads/` dir. `db.reset_database()` truncates tables and wipes `uploads/`.
+
+### Routers (all prefixed `/api/v1`)
+- `health.py` — `GET /health` (liveness, no LLM call), `GET /status` (LLM health + DB stats).
+- `config.py` — `/config/llm-api-key` (GET/PUT), `/config/llm-test` (POST live health check), `/config/features`, `/config/language`, `/config/prompts`, `/config/feature-prompts`, `/config/api-keys` (per-provider CRUD), `/config/reset` (needs `confirm=RESET_ALL_DATA`).
+- `resumes.py` — the biggest router: `/resumes/upload`, `GET /resumes`, `/resumes/list`, `/resumes/improve` + `/improve/preview` + `/improve/confirm`, `PATCH /resumes/{id}`, `/{id}/pdf`, `/{id}/retry-processing`, cover-letter/outreach/title PATCH + on-demand generate, `/{id}/job-description`, `/{id}/cover-letter/pdf`.
+- `jobs.py` — `/jobs/upload` (batch JD text → job_ids), `GET /jobs/{id}`.
+- `enrichment.py` — `/enrichment/analyze/{id}`, `/enhance`, `/apply/{id}`, `/regenerate`, `/apply-regenerated/{id}`.
+
+### Services
+- `parser.py` — `parse_document` (markitdown bytes→Markdown), `parse_resume_to_json` (LLM→`ResumeData`), `restore_dates_from_markdown` (re-inserts months the LLM drops).
+- `improver.py` (largest) — keyword extraction, **diff-based** improvement (`generate_resume_diffs` → `apply_diffs` with path allow/block-lists → `verify_diff_result`), skill-target planning (`generate_skill_target_plan`/`verify_skill_target_plan`), legacy full-output `improve_resume`, `calculate_resume_diff`. Sanitizes prompt-injection patterns in user input.
+- `refiner.py` — multi-pass polish: keyword injection (LLM), AI-phrase removal (local, via `refinement.py` blacklist), master-alignment validation. Driven by `RefinementConfig`.
+- `cover_letter.py` — `generate_cover_letter`, `generate_outreach_message`, `generate_resume_title`; resolves custom-vs-default feature prompts at runtime.
+
+---
+
+## Request / Data Flow (improve = core pipeline)
+
+`POST /resumes/improve/preview` is the canonical path:
+1. Load resume + job from `db`; resolve content language (`config_cache`) and `prompt_id`.
+2. `extract_job_keywords(jd)` (LLM, cached on the job by content hash).
+3. If structured `processed_data` exists → **diff mode**: skill-target plan → `generate_resume_diffs` → `apply_diffs` → `verify_diff_result`. Else → fallback `improve_resume` (full-output).
+4. **Local safety nets** (always run, defense-in-depth): `_preserve_personal_info`, `_restore_original_dates`, `restore_dates_from_markdown`, `_preserve_original_skills`, `_protect_custom_sections`.
+5. `refine_resume` (keyword injection + AI-phrase scrub + alignment check).
+6. Persist a `preview_hash` on the job. `/improve/confirm` re-validates that hash (and that `personalInfo` is unchanged) before persisting the tailored resume + an `improvements` record.
+
+Routers call services; services call `app/llm.py`; persistence goes through the `db` singleton. The whole preview is wrapped in a 240s `asyncio.wait_for`.
+
+---
+
+## Prompt Management (read this before touching prompts)
+
+Prompts are **plain Python string constants** — no Jinja, no external prompt files at runtime (`data/prompts.json` is *not* loaded by the app code paths reviewed). Layout:
+
+| File | Holds |
+|------|-------|
+| `app/prompts/templates.py` | Resume parse, keyword extraction, the 3 improve variants, diff prompt, skill-target plan, cover-letter / outreach / title, `RESUME_SCHEMA_EXAMPLE`, `CRITICAL_TRUTHFULNESS_RULES`, `LANGUAGE_NAMES` + `get_language_name()` |
+| `app/prompts/enrichment.py` | `ANALYZE_RESUME_PROMPT`, `ENHANCE_DESCRIPTION_PROMPT`, `REGENERATE_ITEM_PROMPT`, `REGENERATE_SKILLS_PROMPT` |
+| `app/prompts/refinement.py` | `KEYWORD_INJECTION_PROMPT`, `VALIDATION_POLISH_PROMPT`, `AI_PHRASE_BLACKLIST`, `AI_PHRASE_REPLACEMENTS` |
+| `app/prompts/__init__.py` | Re-exports template constants; placeholder validation |
+
+**Loading / parameterization:** services `from app.prompts import ...` then call `PROMPT.format(**vars)`. So `{placeholder}` = a real format key, and any *literal* `{}` (e.g. JSON examples) **must be doubled `{{ }}`** — see `EXTRACT_KEYWORDS_PROMPT`, `DIFF_IMPROVE_PROMPT`, the enrichment prompts. `PARSE_RESUME_PROMPT` is the exception: it embeds the schema via `{schema}` so it does *not* double-brace.
+
+**Improve prompt selection:** `IMPROVE_RESUME_PROMPTS` = `{nudge, keywords, full}`; `IMPROVE_PROMPT_OPTIONS` is the UI list; `DEFAULT_IMPROVE_PROMPT_ID = "keywords"`. The active id comes from `config.json` `default_prompt_id` (validated against option ids) or the request's `prompt_id`. `CRITICAL_TRUTHFULNESS_RULES[id]` is injected into each improve prompt via `{critical_truthfulness_rules}`.
+
+**Custom feature prompts (user-editable):** cover-letter & outreach prompts can be overridden in `config.json` (`cover_letter_prompt`, `outreach_message_prompt`). On save (`PUT /config/feature-prompts`) they are validated by `validate_prompt_placeholders()` to contain all of `REQUIRED_FEATURE_PROMPT_PLACEHOLDERS` = `{job_description}`, `{resume_data}`, `{output_language}`; missing → HTTP 422. Empty string = "use default". At runtime `cover_letter.py::_resolve_feature_prompt` picks custom-or-default and falls back to the built-in default (with a warning) if a custom prompt fails `.format()`.
+
+**Language:** every generative prompt takes `{output_language}` (full name from `get_language_name(code)`), so all output is produced in the configured content language (`en`/`es`/`zh`/`ja`/`pt`).
+
+---
+
+## LLM Integration (`app/llm.py`)
+
+- **Provider abstraction:** LiteLLM. Providers: `openai`, `openai_compatible` (llama.cpp/vLLM/LM Studio), `anthropic`, `openrouter`, `gemini`, `deepseek`, `groq`, `ollama`. `get_model_name()` maps provider→LiteLLM prefix; `_normalize_api_base()` fixes `/v1/v1` duplication per provider.
+- **Router:** a cached `litellm.Router` (`get_router`) rebuilt only when a config fingerprint changes. `num_retries=3` with a `RetryPolicy` (auth/bad-request/content-policy = 0 retries; timeout/500 = 2; rate-limit = 3). Cooldowns disabled (single deployment). **Transport retries live in the Router; do not re-retry them in callers.**
+- **`complete()` / `complete_json()`:** `complete_json` adds app-level *content-quality* retries (malformed JSON, truncation) with temperature escalation and a JSON-mode→prompt-only fallback. JSON is parsed by the brace-balancing `_extract_json`; `_appears_truncated` is `schema_type`-aware (`resume`/`enrichment`/`diff`/`keywords`).
+- **Capabilities via registry, not hardcoded:** `_supports_json_mode`, `_supports_temperature`, `get_safe_max_tokens` query `litellm.get_model_info` (with Ollama/local fallbacks). `litellm.drop_params = True` lets unsupported params (e.g. `reasoning_effort`) be dropped silently.
+- **Timeouts:** adaptive (`_calculate_timeout`): base 30s health / 120s completion / 180s JSON, scaled by token count and a provider factor (ollama 2x, openrouter 1.5x...).
+- **Reasoning models:** `<think>` tags stripped; `reasoning_content`/`thinking` used as content fallback. gpt-5 configs auto-migrate to `reasoning_effort="minimal"` once.
+- **Key resolution:** single source of truth is `resolve_api_key(stored, provider)`. `openai_compatible`/`ollama` deliberately **skip** the env-level `LLM_API_KEY` fallback so a paid key can't leak to a local server. Error text is scrubbed of key-like tokens (`_scrub_secrets`) before reaching clients.
+- API keys are passed directly to LiteLLM calls (never via `os.environ`) to avoid async races.
+
+---
+
+## Essential Commands
+
+```bash
+cd apps/backend
+uv sync                                              # install deps (creates .venv)
+uv run uvicorn app.main:app --reload --port 8000     # dev server on :8000
+uv run app                                           # console script (app.main:main, uses HOST/PORT/RELOAD)
+uv run playwright install chromium                   # one-time, required for PDF endpoints
+```
+Config via `.env` (see `.env.example`). Interactive API docs at `/docs`.
+
+---
+
+## Non-Negotiable Backend Rules
+
+1. **Type hints on every function** (params + return), incl. helpers.
+2. **Log details server-side, return generic client messages.** Pattern:
+   ```python
+   except Exception as e:
+       logger.error(f"Operation failed: {e}")
+       raise HTTPException(status_code=500, detail="Operation failed. Please try again.")
+   ```
+3. **`copy.deepcopy()` for any mutable default / before mutating shared/cached data** (e.g. `config_cache.load_config` returns a deep copy; the resume safety-net helpers deepcopy before editing).
+4. New endpoints mount under `/api/v1` via `app/routers/__init__.py`.
+5. Schema/prompt changes must be reflected in the relevant `docs/agent/` doc.
+
+---
+
+## Key Gotchas
+
+- **uv.lock is gitignored** (`.gitignore`), so dependency resolution isn't reproducible from VCS — rely on the exact pins in `pyproject.toml` / `requirements.txt`.
+- **litellm ↔ python-dotenv trap:** litellm `<1.84.0` hard-pinned `python-dotenv==1.0.1`, which used to fight other pins. Resolved at the current pins (`litellm==1.86.2`, `python-dotenv==1.2.2`); do **not** downgrade litellm below 1.84 without re-checking dotenv.
+- **`config.json` vs `.env`:** API keys/provider/model can come from either; `config.json` (written by the Settings UI) takes priority over env for stored keys. After any write to `config.json`, call `invalidate_config_cache()` (config router does this).
+- **Master resume invariant:** exactly one resume has `is_master=True`. Concurrent uploads use `create_resume_atomic_master` (an `asyncio.Lock`, not threading) and auto-promote if the current master is stuck `failed`/`processing`.
+- **Dates lose months:** LLMs drop month precision; `restore_dates_from_markdown` + `_restore_original_dates` re-insert them. Preserve this when editing the parse/improve flow.
+- **Single-worker assumption:** caches and locks assume one uvicorn worker / cooperative async. Don't add cross-worker shared mutable state without revisiting `config_cache` and the master lock.
+- **PDF needs the frontend running** (`FRONTEND_BASE_URL`, default `http://localhost:3000`) — Chromium renders `/print/*` pages. Browser is lazily initialized on first PDF request.
+- **Improve/confirm requires a prior preview** — it validates `preview_hash`; arbitrary payloads are rejected (400).
+
+---
+
+## Documentation by Task
+
+| Topic | Doc |
+|-------|-----|
+| Project orientation | [`docs/agent/README.md`](../../docs/agent/README.md) |
+| Backend architecture / modules | [`backend-guide.md`](../../docs/agent/architecture/backend-guide.md) · [`backend-architecture.md`](../../docs/agent/architecture/backend-architecture.md) |
+| LLM / multi-provider | [`llm-integration.md`](../../docs/agent/llm-integration.md) |
+| Prompt pipeline (diff/retry design) | [`prompt-workflow-design.md`](../../docs/agent/architecture/prompt-workflow-design.md) |
+| API contracts | [`apis/front-end-apis.md`](../../docs/agent/apis/front-end-apis.md) · [`apis/api-flow-maps.md`](../../docs/agent/apis/api-flow-maps.md) · [`apis/backend-requirements.md`](../../docs/agent/apis/backend-requirements.md) |
+| Coding standards | [`coding-standards.md`](../../docs/agent/coding-standards.md) |
+| Scope / principles | [`scope-and-principles.md`](../../docs/agent/scope-and-principles.md) · [`workflow.md`](../../docs/agent/workflow.md) |
+| AI enrichment | [`features/enrichment.md`](../../docs/agent/features/enrichment.md) |
+| JD matching | [`features/jd-match.md`](../../docs/agent/features/jd-match.md) |
+| Custom sections | [`features/custom-sections.md`](../../docs/agent/features/custom-sections.md) |
+| i18n | [`features/i18n.md`](../../docs/agent/features/i18n.md) |
+| PDF / templates | [`design/pdf-template-guide.md`](../../docs/agent/design/pdf-template-guide.md) · [`design/template-system.md`](../../docs/agent/design/template-system.md) |
+
+---
+
+## Testing & Out of Scope
+
+- **Tests exist** (`tests/`, pytest + pytest-asyncio; markers `unit`/`service`/`integration`; config in `[tool.pytest.ini_options]`). Run with `uv run pytest`. Do **not** run/modify tests unless explicitly asked.
+- Out of scope without explicit request: `.github/workflows/`, CI/CD, Docker behavior, removing/disabling existing tests.

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -22,11 +22,11 @@ Stack: FastAPI 0.128 · Python **3.13+** · Pydantic v2 / pydantic-settings · T
 | Prompts | All LLM prompt templates + placeholder validation | `app/prompts/*.py` |
 | Schemas | Pydantic request/response + `ResumeData` models | `app/schemas/*.py` |
 
-`data/` (gitignored: `data/*.json`) holds `database.json`, `config.json`, `prompts.json`, and an `uploads/` dir. `db.reset_database()` truncates tables and wipes `uploads/`.
+`data/` holds `database.json`, `config.json`, an `uploads/` dir, and a legacy/unused `prompts.json` (not loaded by any code path — see Prompt Management). `apps/backend/.gitignore` ignores `data/*.json` (so DB + config files never get committed), but **`uploads/` is NOT git-ignored** — don't commit user uploads. `db.reset_database()` truncates tables and wipes `uploads/`.
 
 ### Routers (all prefixed `/api/v1`)
 - `health.py` — `GET /health` (liveness, no LLM call), `GET /status` (LLM health + DB stats).
-- `config.py` — `/config/llm-api-key` (GET/PUT), `/config/llm-test` (POST live health check), `/config/features`, `/config/language`, `/config/prompts`, `/config/feature-prompts`, `/config/api-keys` (per-provider CRUD), `/config/reset` (needs `confirm=RESET_ALL_DATA`).
+- `config.py` — `/config/llm-api-key` (GET/PUT), `/config/llm-test` (POST live health check), `/config/features`, `/config/language`, `/config/prompts`, `/config/feature-prompts`, `/config/api-keys` (per-provider CRUD), `/config/reset` (POST; confirmation token `{"confirm": "RESET_ALL_DATA"}` in the JSON **body**, not a query param).
 - `resumes.py` — the biggest router: `/resumes/upload`, `GET /resumes`, `/resumes/list`, `/resumes/improve` + `/improve/preview` + `/improve/confirm`, `PATCH /resumes/{id}`, `/{id}/pdf`, `/{id}/retry-processing`, cover-letter/outreach/title PATCH + on-demand generate, `/{id}/job-description`, `/{id}/cover-letter/pdf`.
 - `jobs.py` — `/jobs/upload` (batch JD text → job_ids), `GET /jobs/{id}`.
 - `enrichment.py` — `/enrichment/analyze/{id}`, `/enhance`, `/apply/{id}`, `/regenerate`, `/apply-regenerated/{id}`.

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -1,0 +1,206 @@
+# CLAUDE.md - Frontend (apps/frontend)
+
+> Frontend deep-dive for Claude Code. Read the repo-root [`.claude/CLAUDE.md`](../../.claude/CLAUDE.md) and [`docs/agent/README.md`](../../docs/agent/README.md) first for project-wide context. This file goes deeper on the Next.js app only.
+
+**Stack:** Next.js 16 (App Router, Turbopack) · React 19 · TypeScript (strict) · Tailwind CSS v4 · no UI framework (hand-rolled `components/ui`). Import alias `@/*` → `apps/frontend/*`.
+
+---
+
+## Route / Page Map
+
+App Router under `app/`. A `(default)` route group wraps the main app in providers; `print/*` is provider-free (server-rendered for headless-Chromium PDF capture).
+
+| Route | File | Type | Purpose |
+|-------|------|------|---------|
+| `/` | `app/(default)/page.tsx` | Server | Landing — renders `<Hero/>` |
+| `/dashboard` | `app/(default)/dashboard/page.tsx` | Client | Resume list, upload, delete, retry, status grid |
+| `/builder` | `app/(default)/builder/page.tsx` | Client wrapper → `components/builder/resume-builder.tsx` | Master-resume editor (forms, drag-drop sections, templates, AI regenerate, cover letter / outreach) |
+| `/tailor` | `app/(default)/tailor/page.tsx` | Client | Paste JD → preview/confirm tailored resume (diff modal) |
+| `/settings` | `app/(default)/settings/page.tsx` | Client | LLM provider/model/key, API keys, features, prompts, language, reset DB |
+| `/resumes/[id]` | `app/(default)/resumes/[id]/page.tsx` | Client | View one resume, download PDF, rename, enrichment modal |
+| `/print/resumes/[id]` | `app/print/resumes/[id]/page.tsx` | **Server** | Print-only resume render for PDF (reads `searchParams` for template settings + `lang`) |
+| `/print/cover-letter/[id]` | `app/print/cover-letter/[id]/page.tsx` | **Server** | Print-only cover-letter render for PDF |
+
+`app/layout.tsx` (root) wires fonts (Geist + Space Grotesk) and global CSS. `app/(default)/layout.tsx` nests providers: `StatusCacheProvider` → `LanguageProvider` → `ResumePreviewProvider` → `LocalizedErrorBoundary`.
+
+> Most pages are `'use client'`. The `print/*` pages are intentionally server components and fetch from the backend directly via `API_BASE` + `lib/i18n/server.ts` (`translate`). Do not add `'use client'` to them.
+
+---
+
+## Directory Layout
+
+```
+app/                 # routes (see table)
+components/
+  ui/                # primitives: button, input, textarea, dialog, dropdown,
+                     #   card, retro-tabs, toggle-switch, confirm-dialog,
+                     #   rich-text-editor (Tiptap), link-dialog, label
+  builder/           # builder page UI + forms/ (per-section form components)
+  dashboard/         # resume list/card, upload dialog
+  tailor/            # diff-preview-modal
+  enrichment/        # AI enrichment wizard modal/steps
+  resume/            # resume render templates (single/two-column, modern) + styles/*.module.css
+  preview/           # paginated A4/Letter preview (use-pagination.ts)
+  home/              # hero, swiss-grid
+  settings/          # api-key-menu
+  common/            # error-boundary, resume_previewer_context
+lib/
+  api/               # backend client (see Data Flow)
+  i18n/              # translation engine (see i18n)
+  context/           # status-cache, language-context
+  utils/             # download, html-sanitizer, keyword-matcher, section-helpers
+  types/             # template-settings, lucide.d.ts
+  config/version.ts  # APP_VERSION / codename
+  constants/page-dimensions.ts
+hooks/               # use-file-upload, use-regenerate-wizard, use-enrichment-wizard
+i18n/config.ts       # locale list + names/flags (NOTE: distinct from lib/i18n)
+messages/            # en/es/zh/ja/pt-BR JSON (see i18n)
+tests/               # vitest (see Testing)
+```
+
+---
+
+## Data Flow (page → hook → lib/api → backend)
+
+All backend calls go through **`lib/api/`** — never call `fetch` to the backend directly from a component.
+
+- `lib/api/client.ts` — single source of truth. Exports `apiFetch / apiPost / apiPatch / apiPut / apiDelete`, `API_URL`, `API_BASE`, `getUploadUrl()`.
+  - Base URL: `NEXT_PUBLIC_API_URL` (default `'/'`) → `API_BASE` becomes `/api/v1`. On the **server** a `/`-relative base is rewritten to `http://127.0.0.1:8000/api/v1` (`INTERNAL_API_ORIGIN`); browser uses the relative path (proxied by `next.config.ts` rewrites to `BACKEND_ORIGIN`).
+  - Default request timeout **240_000ms** (matches backend `wait_for` hard limit). `AbortError` → friendly "Request timed out" message.
+- `lib/api/resume.ts` — resumes/jobs: upload, improve / improve.preview / improve.confirm, fetch, list, update (PATCH), PDF URLs + blob download, delete, cover-letter / outreach generate+update, rename, retry-processing, fetch JD.
+- `lib/api/config.ts` — LLM config, `testLlmConnection`, system `/status`, feature flags, prompt config, **feature prompts** (`FeaturePromptsError` for 422 `missing_placeholders`), API-key management, language config, `resetDatabase`. `PROVIDER_INFO` lists supported providers + default models.
+- `lib/api/enrichment.ts` — AI enrichment (analyze/enhance/apply) and AI regenerate (regenerate/apply-regenerated).
+- `lib/api/index.ts` — barrel re-export (note: not everything is re-exported; some functions are imported from `./resume` / `./config` / `./enrichment` directly).
+
+**Contracts:** `lib/api/*` interfaces mirror backend Pydantic schemas. See [front-end-apis.md](../../docs/agent/apis/front-end-apis.md) and [api-flow-maps.md](../../docs/agent/apis/api-flow-maps.md).
+
+**Shared client state (React Context, not a fetch lib):**
+- `StatusCacheProvider` (`lib/context/status-cache.tsx`) — caches `/status` (LLM health 30min, DB stats 5min stale), with optimistic counter updates. Use `useStatusCache()` / `useIsStatusStale()`.
+- `LanguageProvider` (`lib/context/language-context.tsx`) — UI + content language, localStorage + backend sync. Use `useLanguage()`.
+
+---
+
+## i18n — READ THIS BEFORE TOUCHING TRANSLATIONS
+
+Two distinct settings, configured independently in Settings:
+- **UI language** — interface text, client-only (`uiLanguage`, localStorage).
+- **Content language** — language the LLM writes resumes/cover letters in (`contentLanguage`, persisted to backend).
+
+**Supported locales (source of truth = `i18n/config.ts`):** `en`, `es`, `zh`, `ja`, `pt` (the file is `messages/pt-BR.json`, imported as `pt`). The `docs/agent/features/i18n.md` table is stale — it omits `pt`; trust the code.
+
+Engine (no external i18n lib, plain JSON):
+- `i18n/config.ts` — `locales`, `defaultLocale='en'`, `localeNames`, `localeFlags`.
+- `lib/i18n/messages.ts` — static-imports every locale JSON; the critical types live here.
+- `lib/i18n/translations.ts` — `useTranslations()` returns `{ t, messages, locale }`; `t('a.b.c', params)` does dot-path lookup + `{placeholder}` substitution. Missing key returns the key string (no throw).
+- `lib/i18n/server.ts` — `translate(locale, key, params)` for server/print pages.
+
+### ⚠️ CRITICAL build-breaking constraint
+
+`lib/i18n/messages.ts`:
+```ts
+export type Messages = typeof en;                       // shape derived from en.json
+const allMessages: Record<Locale, Messages> = { en, es, zh, ja, pt };
+```
+Because every locale is typed as `Messages` (= the exact shape of `en.json`), **every locale JSON must structurally match `en.json` exactly.** Add a key to `en.json` and the production `tsc` / `next build` FAILS until that same key path exists in `es`, `zh`, `ja`, and `pt-BR`. (A real build break was caused by exactly this.)
+
+**When editing translations:** any key you add/remove/rename in `en.json` MUST be mirrored in all 5 files (`en`, `es`, `zh`, `ja`, `pt-BR`) with identical structure. `npm run dev` may tolerate drift; the build will not.
+
+See [i18n.md](../../docs/agent/features/i18n.md), [i18n-preparation.md](../../docs/agent/features/i18n-preparation.md).
+
+---
+
+## Styling — Swiss International Style (MANDATORY)
+
+All UI changes MUST follow the Swiss design system. Pack: [README](../../docs/portable/swiss-design-system/README.md) · [tokens](../../docs/portable/swiss-design-system/tokens.md) · [components](../../docs/portable/swiss-design-system/components.md) · [anti-patterns](../../docs/portable/swiss-design-system/anti-patterns.md) · [layouts](../../docs/portable/swiss-design-system/layouts.md).
+
+Tailwind v4, configured **in CSS** (`app/(default)/css/globals.css`, `@theme inline`) — there is no `tailwind.config`. PostCSS uses `@tailwindcss/postcss`. Light theme only.
+
+| Token | Value | Tailwind |
+|-------|-------|----------|
+| Canvas / background | `#F0F0E8` | `bg-background`, `bg-canvas` |
+| Ink (text) | `#000000` | `text-ink`, `text-ink-soft` |
+| Hyper Blue (primary/links) | `#1D4ED8` | `text-primary`, `bg-primary`, ring |
+| Signal Green (success) | `#15803D` | `text-success` |
+| Alert Orange (warning) | `#F97316` | `text-warning` |
+| Alert Red (error) | `#DC2626` | `text-destructive` |
+| Neutrals | `paper-tint`, `steel-grey`, `ink-soft` (OKLCH) | use these, not ad-hoc grays |
+
+Conventions: `rounded-none` everywhere (no radius tokens exist — square corners are intentional). 1px black borders (`border border-black`). **Hard offset shadows** `shadow-sw-xs … shadow-sw-xl` (solid ink, no blur). Fonts: serif headers / `font-sans` (Geist) body / `font-mono` (Space Grotesk) metadata.
+
+Resume render templates have their own CSS modules in `components/resume/styles/` (`_tokens.css`, `swiss-single`, `swiss-two-column`, `modern`, `modern-two-column`). Template types/settings: `lib/types/template-settings.ts`. See [resume-templates.md](../../docs/agent/features/resume-templates.md), [template-system.md](../../docs/agent/design/template-system.md), [pdf-template-guide.md](../../docs/agent/design/pdf-template-guide.md), [adding-resume-templates.md](../../docs/agent/features/adding-resume-templates.md).
+
+---
+
+## Essential Commands
+
+```bash
+# from apps/frontend
+npm install
+npm run dev       # next dev --turbopack (:3000)
+npm run build     # next build  (runs tsc — i18n shape drift fails HERE)
+npm run start
+npm run lint      # eslint .
+npm run format    # prettier --write .
+npm run test      # vitest run
+```
+
+Backend must run separately on :8000 (see root CLAUDE.md). Frontend proxies `/api/*`, `/docs`, `/redoc`, `/openapi.json` to `BACKEND_ORIGIN` via `next.config.ts` rewrites. **Do not create `app/api/` routes** — filesystem routes shadow the proxy.
+
+---
+
+## Non-Negotiable Frontend Rules
+
+1. All UI MUST follow Swiss International Style (links above). `rounded-none`, 1px black borders, hard shadows, brand tokens.
+2. Run `npm run lint` and `npm run format` before committing frontend changes.
+3. Any `en.json` key change MUST be mirrored across all 5 locale files (see i18n) or the build breaks.
+4. **Textarea Enter-key pattern** — confirmed in code (e.g. `app/(default)/tailor/page.tsx`): when a textarea sits inside a dialog/form that submits on Enter, stop propagation:
+   ```tsx
+   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+     if (e.key === 'Enter') e.stopPropagation();
+   };
+   ```
+5. All backend access via `lib/api/*` (never raw `fetch` to the backend in components).
+6. Sanitize user/LLM HTML with `sanitizeHtml` (`lib/utils/html-sanitizer.ts`, DOMPurify, whitelist `strong/em/u/a`) before `dangerouslySetInnerHTML`.
+7. Next.js perf patterns are required reading: [nextjs-performance pack](../../docs/portable/nextjs-performance/README.md) + [checklist](../../docs/portable/nextjs-performance/checklist.md).
+
+---
+
+## Key Gotchas
+
+- **Lucide imports:** hot-path/page code imports icons from the deep path (`lucide-react/dist/esm/icons/x`) to avoid the barrel; `optimizePackageImports` in `next.config.ts` also tree-shakes lucide/tiptap/dnd-kit. Stay consistent.
+- **240s timeout** on AI calls (`apiFetch` default) — matches backend; don't shorten for improve/regenerate flows.
+- **`print/*` pages are server components** that read template settings from `searchParams` and call the backend via internal origin — keep them server-side.
+- Two i18n locations exist: `i18n/` (config) and `lib/i18n/` (engine). Don't confuse them.
+- ESLint disables `react-hooks/set-state-in-effect` (existing effects sync props/DOM measurements). Prettier rules run via ESLint (`prettier/prettier: error`).
+
+---
+
+## Testing
+
+`vitest` (jsdom) + Testing Library. Config `vitest.config.ts`, setup `vitest.setup.ts`. Existing specs: `tests/diff-preview-modal.test.tsx`, `tests/download-utils.test.ts`, `tests/regenerate-wizard.test.tsx`. Run with `npm run test`. (Per project norms, do not add or run tests unless asked.)
+
+---
+
+## Documentation by Task
+
+| Task | Docs |
+|------|------|
+| Frontend architecture / user flow | [frontend-architecture.md](../../docs/agent/architecture/frontend-architecture.md), [frontend-workflow.md](../../docs/agent/architecture/frontend-workflow.md) |
+| Coding conventions | [coding-standards.md](../../docs/agent/coding-standards.md) |
+| API contracts | [front-end-apis.md](../../docs/agent/apis/front-end-apis.md), [api-flow-maps.md](../../docs/agent/apis/api-flow-maps.md) |
+| Scope / principles / process | [scope-and-principles.md](../../docs/agent/scope-and-principles.md), [workflow.md](../../docs/agent/workflow.md) |
+| Swiss design system (MANDATORY) | [pack README](../../docs/portable/swiss-design-system/README.md), [tokens](../../docs/portable/swiss-design-system/tokens.md), [components](../../docs/portable/swiss-design-system/components.md), [anti-patterns](../../docs/portable/swiss-design-system/anti-patterns.md), [layouts](../../docs/portable/swiss-design-system/layouts.md) |
+| Next.js performance (REQUIRED) | [pack README](../../docs/portable/nextjs-performance/README.md), [checklist](../../docs/portable/nextjs-performance/checklist.md) |
+| i18n | [i18n.md](../../docs/agent/features/i18n.md), [i18n-preparation.md](../../docs/agent/features/i18n-preparation.md) |
+| Resume templates / PDF | [resume-templates.md](../../docs/agent/features/resume-templates.md), [template-system.md](../../docs/agent/design/template-system.md), [pdf-template-guide.md](../../docs/agent/design/pdf-template-guide.md), [adding-resume-templates.md](../../docs/agent/features/adding-resume-templates.md) |
+| Custom sections | [custom-sections.md](../../docs/agent/features/custom-sections.md) |
+| AI enrichment | [enrichment.md](../../docs/agent/features/enrichment.md) |
+| JD matching | [jd-match.md](../../docs/agent/features/jd-match.md) |
+
+---
+
+## Out of Scope (do not modify without explicit request)
+
+- `.github/workflows/`, CI/CD, Docker behavior
+- Existing tests (no removal/disabling)
+- `next.config.ts` rewrites / proxy behavior unless the task is about it


### PR DESCRIPTION
## What

Adds two deep, code-grounded **Claude Code context files** so future work in each app starts from reliable, app-specific context (the root `.claude/CLAUDE.md` stays the high-level entry point):

- **`apps/backend/CLAUDE.md`** — module map; the improve → preview → confirm request pipeline + local safety nets; a dedicated **Prompt Management** section; LiteLLM integration (Router/RetryPolicy, `complete_json` retries, registry-based capability checks, adaptive timeouts, key-leak guards); non-negotiable rules; gotchas; docs-by-task index.
- **`apps/frontend/CLAUDE.md`** — route/page map; directory layout; data flow (page → hook → `lib/api` → backend); a dedicated **i18n** section flagging the `Record<Locale, Messages>` build-breaking constraint; Swiss design-system tokens/rules; commands; gotchas; docs-by-task index.

## How

Two subagents explored `apps/backend/` and `apps/frontend/` respectively (reading real code, not guessing) and cross-referenced `docs/`. Both files match the style of the root `.claude/CLAUDE.md` and link into `docs/agent/**` and `docs/portable/**` for depth.

## Verification

- **All 30 referenced `docs/` links verified to exist** (0 broken).
- Files reviewed for accuracy against the code.

## Notable findings surfaced during exploration (not fixed here)

- **Backend:** `apps/backend/data/prompts.json` exists on disk but is **not loaded** by any code path — active prompts live in `app/prompts/*.py`. Looks like a legacy/leftover artifact.
- **Frontend:** the codebase supports **5 locales** (`en, es, zh, ja, pt`), but `docs/agent/features/i18n.md` only documents 4 (omits `pt`/Portuguese). The new file notes code as source of truth; the doc could be updated separately.

These are flagged for awareness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds app-level `CLAUDE.md` guides for backend and frontend to give deep, code-grounded context that complements the root `.claude/CLAUDE.md`. This helps contributors start with accurate module maps, data flows, prompt rules, and i18n/design constraints.

- **New Features**
  - `apps/backend/CLAUDE.md`: module map; improve → preview → confirm pipeline and safety nets; prompt management (Python strings, double-brace rules, custom feature prompts); `LiteLLM` integration (Router/retries/JSON/timeouts/key handling); `/config/reset` requires `{"confirm":"RESET_ALL_DATA"}` in the JSON body; storage notes (`data/*.json` gitignored, `uploads/` not ignored); docs index.
  - `apps/frontend/CLAUDE.md`: route/page map; directory layout; data flow via `lib/api` with 240s timeout and base-URL rewrite; strict i18n `Record<Locale, Messages>` constraint (all locales must match `en.json` shape); Swiss design tokens/rules; commands, gotchas, docs index.

Verified 30/30 referenced `docs/` links. Follow-up: docs omit `pt` while code supports it.

<sup>Written for commit 8c2606638362203e87f43294de30b7bff7e799f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

