### PR TITLE
docs(i18n): document Portuguese (pt) locale in i18n.md

### DIFF
--- a/docs/agent/features/i18n.md
+++ b/docs/agent/features/i18n.md
@@ -4,12 +4,15 @@
 
 ## Supported Languages
 
-| Code | Language | Native Name |
-|------|----------|-------------|
-| `en` | English | English |
-| `es` | Spanish | Español |
-| `zh` | Chinese (Simplified) | 中文 |
-| `ja` | Japanese | 日本語 |
+| Code | Language | Native Name | Flag | Message File |
+|------|----------|-------------|------|--------------|
+| `en` | English | English | 🇺🇸 | `messages/en.json` |
+| `es` | Spanish | Español | 🇪🇸 | `messages/es.json` |
+| `zh` | Chinese (Simplified) | 中文 | 🇨🇳 | `messages/zh.json` |
+| `ja` | Japanese | 日本語 | 🇯🇵 | `messages/ja.json` |
+| `pt` | Portuguese (Brazilian) | Português | 🇧🇷 | `messages/pt-BR.json` |
+
+> Source of truth: `apps/frontend/i18n/config.ts` (`locales`, `localeNames`, `localeFlags`). Note `pt` loads from `messages/pt-BR.json` (imported as `pt` in `apps/frontend/lib/i18n/messages.ts`).
 
 ## Two Language Settings
 
@@ -28,7 +31,7 @@ Both are configured independently in the Settings page.
 
 | File | Purpose |
 |------|---------|
-| `apps/frontend/messages/*.json` | UI translation files (en, es, zh, ja) |
+| `apps/frontend/messages/*.json` | UI translation files (`en`, `es`, `zh`, `ja`, `pt-BR`) |
 | `apps/frontend/lib/i18n/translations.ts` | `useTranslations` hook |
 | `apps/frontend/lib/context/language-context.tsx` | LanguageProvider (UI + content) |
 | `apps/backend/app/prompts/templates.py` | LLM prompts with `{output_language}` |


### PR DESCRIPTION
## Problem

The frontend supports **5 UI locales**, but `docs/agent/features/i18n.md` only documented **4** — it omitted Portuguese (Brazilian).

The authoritative source confirms five locales:

- `apps/frontend/i18n/config.ts` → `locales = ['en', 'es', 'zh', 'ja', 'pt']`, plus `localeNames.pt = 'Português'` and `localeFlags.pt = '🇧🇷'`.
- `apps/frontend/lib/i18n/messages.ts` → imports `pt` from `messages/pt-BR.json`.

The doc's "Supported Languages" table and "Key Files" entry both predate the `pt` locale and were stale.

## Change

Scoped strictly to the locale gap in `docs/agent/features/i18n.md`:

- Added `pt` — Portuguese (Brazilian) / `Português` / 🇧🇷 / `messages/pt-BR.json` to the **Supported Languages** table, and extended the table with **Flag** and **Message File** columns to capture the real `localeFlags` and the `pt-BR.json` filename mapping.
- Added a source-of-truth note pointing at `i18n/config.ts` and explaining the `pt` → `pt-BR.json` import.
- Updated the **Key Files** row to list all five message files (`en`, `es`, `zh`, `ja`, `pt-BR`).

No other sections were rewritten.

### Note on `i18n-preparation.md`

`docs/agent/features/i18n-preparation.md` also lists only `en, es, zh, ja`, but it is a forward-looking planning doc with broader inaccuracies (e.g. it claims `next-intl` is used, and uses a hypothetical `'de'` locale in its "adding a locale" example). It is not the same authoritative "Supported Languages" reference, so it was left untouched per the scope of this fix.

## Verification

- Re-read the edited table — valid markdown, renders correctly, and exactly matches the locale set in `apps/frontend/i18n/config.ts`.
- Verified message files on disk: `en.json`, `es.json`, `zh.json`, `ja.json`, `pt-BR.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the Portuguese (pt) UI locale in `docs/agent/features/i18n.md` to match the five locales supported by the frontend. Added the `pt` row with 🇧🇷 and `messages/pt-BR.json`, expanded the table to include Flag and Message File columns, updated Key Files, and noted `apps/frontend/i18n/config.ts` as the source of truth.

<sup>Written for commit 08b0eddbad22b9aed9f5bda0f4a5fcfed6a9b8d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

