### PR TITLE
test: testing initiative — backend (pytest+evals) & frontend (vitest) coverage, local pre-push gate, context docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -178,10 +178,12 @@ Both apps have real test suites, and **tests are in scope** (deliberate testing 
 Before completing a task:
 
 - [ ] Code compiles without errors
+- [ ] Backend tests pass (`uv run pytest`); frontend tests pass (`npm run test`)
 - [ ] `npm run lint` passes
 - [ ] UI changes follow Swiss International Style
 - [ ] Python functions have type hints
 - [ ] Schema/prompt changes documented
+- [ ] New behavior covered by a deterministic test (it must fail if the behavior breaks)
 
 ---
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -141,6 +141,21 @@ data = copy.deepcopy(DEFAULT_DATA)  # Correct
 
 ---
 
+## Testing
+
+Both apps have real test suites, and **tests are in scope** (deliberate testing initiative — full plan in [docs/agent/testing-strategy.md](../docs/agent/testing-strategy.md)).
+
+| Suite | Stack | Run |
+|-------|-------|-----|
+| Backend | pytest + pytest-asyncio + httpx + respx | `cd apps/backend && uv run pytest` |
+| Frontend | vitest + Testing Library (jsdom) | `cd apps/frontend && npm run test` |
+
+- **Backend layers:** `tests/unit` (pure logic), `tests/service` (mocked LLM), `tests/integration` (real routers via httpx ASGI), `tests/evals` (prompt-quality scorers + a gated LLM-judge — excluded by default; run with `uv run pytest -m eval`).
+- **Local push gate (not CI):** a `pre-push` hook (`.githooks/pre-push`) runs the backend suite + a locale-parity check and **blocks red pushes**. Activate once per clone: `git config core.hooksPath .githooks`. We deliberately avoid a GitHub Actions PR gate (high external-PR volume) — see [`.githooks/README.md`](../.githooks/README.md).
+- Keep tests **deterministic and anti-theater**: a test must fail when its target breaks, and the default suites make no real network/LLM calls.
+
+---
+
 ## Design System Quick Reference
 
 | Element | Value |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -39,13 +39,15 @@ Before exploring code, read [docs/agent/README.md](../docs/agent/README.md) for 
 ```bash
 # Backend (from repo root)
 cd apps/backend
-uv sync                                              # Install Python dependencies
+uv sync --extra dev                                  # Install Python deps (incl. test deps)
 uv run uvicorn app.main:app --reload --port 8000     # FastAPI on :8000
+uv run pytest                                        # Run backend tests (~320; LLM evals excluded)
 
 # Frontend (from repo root, in a separate terminal)
 cd apps/frontend
 npm install                                          # Install Node.js dependencies
 npm run dev                                          # Next.js on :3000
+npm run test                                         # Run frontend tests (vitest)
 
 # Quality checks (from apps/frontend)
 npm run lint          # Lint frontend

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,7 +80,7 @@ apps/
     ├── components/          # UI components
     ├── lib/                 # Utilities, API client
     ├── hooks/               # Custom React hooks
-    └── messages/            # i18n translations (en, es, zh, ja)
+    └── messages/            # i18n translations (en, es, zh, ja, pt)
 ```
 
 ---

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -98,6 +98,9 @@ apps/
 3. [Next.js performance pack](../docs/portable/nextjs-performance/README.md) - **REQUIRED** Next.js 15 perf patterns (portable pack)
 4. [Coding standards](../docs/agent/coding-standards.md) - Frontend conventions
 
+### For Testing
+1. [Testing strategy](../docs/agent/testing-strategy.md) - Current-state assessment, framework, phased plan, how to run + how we verify (anti-theater)
+
 ### For Template/PDF Changes
 1. [PDF template guide](../docs/agent/design/pdf-template-guide.md) - PDF rendering
 2. [Template system](../docs/agent/design/template-system.md) - Resume templates

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -17,8 +17,12 @@ keeps `main`/`dev` green without touching contributor PRs.
    `apps/frontend/messages/*.json` has the same key structure as `en.json`.
    Pure Python (no Node/npm/nvm). This guards the exact i18n mismatch that once
    broke `next build` and only surfaced post-merge in the Docker job.
+3. **Frontend test suite** — `vitest run` in `apps/frontend`, but only when Node
+   and the local vitest binary are present (git hooks may run without nvm's
+   `node` on `PATH`); otherwise skipped with a warning. A full `tsc`/`next build`
+   is intentionally not run here.
 
-Both checks always run, so you see **all** failures at once.
+All checks always run, so you see **all** failures at once.
 
 ## Activate (once per clone)
 
@@ -46,6 +50,7 @@ git config --unset core.hooksPath   # disable the hooks entirely
 ```bash
 cd apps/backend && uv run pytest          # backend suite
 python3 scripts/check_locale_parity.py    # locale parity (from repo root)
+cd apps/frontend && npm run test          # frontend suite (vitest)
 ```
 
 See [`docs/agent/testing-strategy.md`](../docs/agent/testing-strategy.md) for the

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,52 @@
+# Local git hooks (`.githooks/`)
+
+Version-controlled git hooks for Resume-Matcher. We **do not** run a
+PR-triggered GitHub Actions test workflow (the repo gets a high volume of
+external contributor PRs, and CI would run on every one of them). Instead, the
+maintainer's local clone gates pushes with a `pre-push` hook — a "local CI" that
+keeps `main`/`dev` green without touching contributor PRs.
+
+## What runs
+
+`pre-push` runs before every `git push` and **blocks the push if anything is red**:
+
+1. **Backend test suite** — `uv run pytest` in `apps/backend` (~8s). Deterministic;
+   the LLM-as-judge evals are excluded by default (`addopts -m "not eval"`), so
+   it makes **no network/LLM calls**.
+2. **Frontend locale parity** — `scripts/check_locale_parity.py` verifies every
+   `apps/frontend/messages/*.json` has the same key structure as `en.json`.
+   Pure Python (no Node/npm/nvm). This guards the exact i18n mismatch that once
+   broke `next build` and only surfaced post-merge in the Docker job.
+
+Both checks always run, so you see **all** failures at once.
+
+## Activate (once per clone)
+
+```bash
+git config core.hooksPath .githooks
+```
+
+That's it — hooks are now active for this clone. (It's a local git setting; it
+does not affect anyone else who clones the repo, by design.)
+
+## Everyday use
+
+- Commit freely — the gate runs at **push**, not on every commit.
+- If the gate fails, the push is aborted and the failures are printed. Fix them and push again.
+
+## Escape hatches
+
+```bash
+git push --no-verify          # bypass the gate once (docs-only / WIP branches)
+git config --unset core.hooksPath   # disable the hooks entirely
+```
+
+## Run the checks manually
+
+```bash
+cd apps/backend && uv run pytest          # backend suite
+python3 scripts/check_locale_parity.py    # locale parity (from repo root)
+```
+
+See [`docs/agent/testing-strategy.md`](../docs/agent/testing-strategy.md) for the
+full testing strategy this gate enforces.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Local pre-push gate for Resume-Matcher — the "local CI" that replaces a
+# PR-triggered GitHub Actions workflow (we deliberately avoid CI on PRs because
+# the repo gets a high volume of external contributor PRs).
+#
+# Runs BEFORE every `git push` and BLOCKS the push if anything is red:
+#   1. backend test suite        (uv run pytest — LLM/eval tests excluded by default)
+#   2. frontend locale parity     (pure-Python check; guards the i18n build break)
+#
+# Activate once per clone:   git config core.hooksPath .githooks
+# Bypass intentionally:      git push --no-verify     (e.g. docs-only / WIP branch)
+# Disable entirely:          git config --unset core.hooksPath
+#
+# Notes:
+#  - Both checks always run so you see ALL failures, not just the first.
+#  - The backend suite is ~8s and makes NO network/LLM calls (evals are opt-in).
+#  - Frontend type/build checks needing Node are intentionally NOT run here
+#    (nvm-in-hook fragility); the locale-parity check covers the known break.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+status=0
+
+printf '\n── pre-push gate ────────────────────────────────────────\n'
+
+# 1) Backend test suite ----------------------------------------------------
+if command -v uv >/dev/null 2>&1; then
+  echo "▶ backend  : uv run pytest"
+  if ! ( cd "$REPO_ROOT/apps/backend" && uv run pytest -q -p no:cacheprovider ); then
+    echo "  ✗ backend tests failed" >&2
+    status=1
+  fi
+else
+  echo "  ✗ 'uv' not found — cannot run backend tests (install uv, or push with --no-verify)" >&2
+  status=1
+fi
+
+# 2) Frontend locale parity (no Node required) -----------------------------
+if command -v python3 >/dev/null 2>&1; then
+  echo "▶ frontend : locale parity (messages/*.json vs en.json)"
+  if ! python3 "$REPO_ROOT/scripts/check_locale_parity.py"; then
+    status=1
+  fi
+else
+  echo "  ⚠ python3 not found — skipping locale parity check" >&2
+fi
+
+printf '─────────────────────────────────────────────────────────\n'
+if [ "$status" -ne 0 ]; then
+  echo "✗ pre-push gate FAILED — push aborted. Fix the above, or bypass with: git push --no-verify" >&2
+  exit 1
+fi
+echo "✓ pre-push gate passed — pushing."
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,7 @@
 # Runs BEFORE every `git push` and BLOCKS the push if anything is red:
 #   1. backend test suite        (uv run pytest — LLM/eval tests excluded by default)
 #   2. frontend locale parity     (pure-Python check; guards the i18n build break)
+#   3. frontend test suite        (vitest — runs when Node is available, else skipped)
 #
 # Activate once per clone:   git config core.hooksPath .githooks
 # Bypass intentionally:      git push --no-verify     (e.g. docs-only / WIP branch)
@@ -15,8 +16,8 @@
 # Notes:
 #  - Both checks always run so you see ALL failures, not just the first.
 #  - The backend suite is ~8s and makes NO network/LLM calls (evals are opt-in).
-#  - Frontend type/build checks needing Node are intentionally NOT run here
-#    (nvm-in-hook fragility); the locale-parity check covers the known break.
+#  - The frontend vitest suite runs only when Node is on PATH (git hooks may run
+#    without nvm's node); a full `tsc`/`next build` is intentionally NOT run here.
 
 set -uo pipefail
 
@@ -45,6 +46,19 @@ if command -v python3 >/dev/null 2>&1; then
   fi
 else
   echo "  ⚠ python3 not found — skipping locale parity check" >&2
+fi
+
+# 3) Frontend test suite (vitest) — only when Node + the local binary are present
+#    (git hooks may run without nvm's node on PATH; skip rather than hard-fail).
+VITEST="$REPO_ROOT/apps/frontend/node_modules/.bin/vitest"
+if command -v node >/dev/null 2>&1 && [ -x "$VITEST" ]; then
+  echo "▶ frontend : vitest run"
+  if ! ( cd "$REPO_ROOT/apps/frontend" && "$VITEST" run ); then
+    echo "  ✗ frontend tests failed" >&2
+    status=1
+  fi
+else
+  echo "  ⚠ node or vitest not available — skipping frontend tests" >&2
 fi
 
 printf '─────────────────────────────────────────────────────────\n'

--- a/apps/backend/CLAUDE.md
+++ b/apps/backend/CLAUDE.md
@@ -147,7 +147,23 @@ Config via `.env` (see `.env.example`). Interactive API docs at `/docs`.
 
 ---
 
-## Testing & Out of Scope
+## Testing
 
-- **Tests exist** (`tests/`, pytest + pytest-asyncio; markers `unit`/`service`/`integration`; config in `[tool.pytest.ini_options]`). Run with `uv run pytest`. Do **not** run/modify tests unless explicitly asked.
-- Out of scope without explicit request: `.github/workflows/`, CI/CD, Docker behavior, removing/disabling existing tests.
+**Tests are in scope** (deliberate testing initiative — see [`testing-strategy.md`](../../docs/agent/testing-strategy.md) for the full assessment + roadmap). Stack: pytest + pytest-asyncio + httpx + respx; config in `[tool.pytest.ini_options]`. Run `uv run pytest` (the LLM-judge evals are excluded by default via `addopts -m "not eval"`). Coverage: `uv run --with pytest-cov pytest --cov=app --cov-report=term-missing` (ephemeral plugin, no pyproject change).
+
+Layout (`apps/backend/tests/`):
+
+| Dir | What | Notes |
+|-----|------|-------|
+| `unit/` | pure functions | diffs, `llm` provider/key helpers, parser date-restore, real-TinyDB CRUD |
+| `service/` | service layer, **LLM mocked** | improver diff flow, prompt construction |
+| `integration/` | endpoints via httpx `ASGITransport` | config/health/jobs/resume/upload, plus `test_llm_contract.py` (real `llm.py` over `respx`) and `test_pipeline_e2e.py` (upload→tailor→render, real routers + real temp DB) |
+| `evals/` | prompt quality | pure structural scorers (always run) + a gated LLM-judge (`@pytest.mark.eval`, uses the dev's own key; run with `uv run pytest -m eval`) |
+
+Key fixtures/tools: `conftest.py::isolated_db` swaps the global `db` singleton for a disposable temp-file TinyDB across **all** router modules (for real-DB endpoint/e2e tests); `respx` mocks the HTTP transport so `llm.py`'s real routing runs against a fake Ollama / OpenAI server (gotcha: litellm 1.86 needs `disable_aiohttp_transport=True` for respx to intercept). Keep every test **anti-theater** — it must fail when its target breaks.
+
+**Local push gate:** `.githooks/pre-push` runs this suite + a locale-parity check and blocks red pushes (`git config core.hooksPath .githooks`; see [`.githooks/README.md`](../../.githooks/README.md)). We avoid a GitHub Actions PR gate (high external-PR volume).
+
+## Out of Scope
+
+Without an explicit request: `.github/workflows/`, CI/CD, Docker behavior, and **removing/disabling existing tests** (adding/fixing tests is encouraged).

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -46,6 +46,10 @@ asyncio_mode = "auto"
 addopts = [
     "--strict-markers",
     "-v",
+    # Exclude LLM-as-judge evals from the default run (they may call a real
+    # provider and are non-deterministic). Run them on demand with `-m eval`.
+    "-m",
+    "not eval",
 ]
 markers = [
     "unit: pure function tests, no external dependencies",

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "httpx>=0.28.0",
+    "respx>=0.21.1",
 ]
 
 [build-system]
@@ -50,4 +51,5 @@ markers = [
     "unit: pure function tests, no external dependencies",
     "service: service layer tests with mocked LLM",
     "integration: API endpoint tests with httpx AsyncClient",
+    "eval: prompt-quality evaluations; may call a real LLM, skipped without a configured key",
 ]

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared test fixtures for Resume Matcher backend tests."""
 
 import copy
+import importlib
 
 import pytest
 
@@ -176,3 +177,32 @@ def sample_changes():
             reason="Already in good order, no change needed",
         ),
     ]
+
+
+# ---------------------------------------------------------------------------
+# Isolated database — swap the global TinyDB singleton for a temp-file DB
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    """Replace the global ``db`` singleton with a disposable temp-file TinyDB
+    across ``app.database`` and every router module that imported it.
+
+    Lets endpoint / e2e tests run against a REAL (but isolated) database instead
+    of a MagicMock, so persistence, the master-resume invariant, and CRUD are
+    actually exercised — without touching the developer's real
+    ``data/database.json``.
+    """
+    import app.database as database_module
+    from app.database import Database
+
+    test_db = Database(db_path=tmp_path / "isolated_db.json")
+    monkeypatch.setattr(database_module, "db", test_db)
+    for router_name in ("resumes", "jobs", "enrichment", "config", "health"):
+        module = importlib.import_module(f"app.routers.{router_name}")
+        if hasattr(module, "db"):
+            monkeypatch.setattr(module, "db", test_db)
+    try:
+        yield test_db
+    finally:
+        test_db.close()

--- a/apps/backend/tests/evals/README.md
+++ b/apps/backend/tests/evals/README.md
@@ -1,0 +1,95 @@
+# Eval harness — "did the prompt change make tailoring _better_?"
+
+Deterministic tests answer *"is the plumbing correct?"* They can't answer
+*"did this prompt edit make the tailored resume better or worse?"* — that needs
+**evals**. This directory holds the eval harness for the Resume-Matcher
+backend, in two deliberately separate layers.
+
+See [`docs/agent/testing-strategy.md`](../../../../docs/agent/testing-strategy.md)
+§3 (Phase 5) for the full rationale.
+
+---
+
+## The two layers
+
+### 1. Structural scorers — deterministic, free, run everywhere
+
+Pure functions in [`scorers.py`](./scorers.py) that check invariants which must
+hold no matter how the LLM worded things. **No LLM, no network, no disk.** They
+form the cheap first line of defence: most "a prompt change broke something"
+regressions are caught here for free.
+
+| Scorer | What it checks |
+|--------|----------------|
+| `sections_preserved(original, tailored) -> bool` | No populated top-level section (work experience, education, …) vanishes during tailoring. |
+| `no_fabricated_employers(original, tailored) -> list[str]` | Company names in the tailored work history that were **not** in the original — i.e. invented employers. Empty list = truthful. |
+| `jd_keywords_present(tailored, keywords) -> float` | Fraction (0–1) of the JD's keywords that actually appear (case-insensitive) in the tailored resume. |
+| `is_valid_resume(data) -> bool` | The result still validates against `ResumeData`. |
+| `personal_info_unchanged(original, tailored) -> bool` | The candidate's identity block (`personalInfo`) is byte-for-byte unchanged. |
+
+Their tests live in [`test_scorers.py`](./test_scorers.py) and prove **each
+scorer fires on a known-bad input** (drop a section → `False`, invent a company
+→ it's returned, change the name → `False`, …). That's the anti-theater proof
+that the scorers detect real violations rather than always saying "OK".
+
+### 2. LLM-as-judge — real model, scores quality, run on demand
+
+[`test_tailoring_eval.py`](./test_tailoring_eval.py) sends a golden tailored
+resume + its JD to a **real LLM** and asks it to grade tailoring quality on a
+rubric (relevance / truthfulness / formatting), returning
+`{"score": 1-5, "reasons": "…"}`, then asserts `score >= 3`.
+
+- Marked `@pytest.mark.eval` (the `eval` marker is declared in `pyproject.toml`).
+- Uses the **developer's own configured key/provider** via `app.llm`.
+- **Skips cleanly when no key is configured** — the key check (`_needs_key()`)
+  is the first line of the test, so a keyless environment never makes an
+  ungated real call. It is never part of a keyless CI gate.
+
+---
+
+## How to run
+
+From `apps/backend`:
+
+```bash
+# Structural scorers only — runs everywhere, no key needed, free & fast.
+uv run pytest tests/evals
+
+# Add the LLM-as-judge eval — only meaningful with a configured key.
+# Skips (does not error) when no key is present.
+uv run pytest tests/evals -m eval
+```
+
+A clean keyless run shows the scorer tests passing and the one judge test
+**skipped**. To actually exercise the judge, configure a provider/key (env or
+the Settings UI → `data/config.json`) the same way you would to run the app,
+then re-run with `-m eval`.
+
+---
+
+## Adding a golden fixture
+
+Golden fixtures live in [`golden/cases.py`](./golden/cases.py) as the
+`GOLDEN_CASES` list. Each entry is a plain dict:
+
+```python
+{
+    "name": "short_id",
+    "original": { ... },          # master resume (ResumeData-compatible)
+    "job_description": "…",        # the target JD text
+    "jd_keywords": ["…", "…"],     # keywords the tailoring should surface
+    "tailored_good": { ... },      # faithful tailoring — passes every scorer
+    "tailored_bad": { ... },       # broken tailoring — must trip the scorers
+}
+```
+
+Guidelines:
+
+- Keep `original` and `tailored_good` **valid against `ResumeData`** (so
+  `is_valid_resume` stays meaningful) and make sure every `jd_keywords` entry
+  truly appears in `tailored_good` (the structural test asserts a perfect 1.0).
+- Make `tailored_bad` violate at least one invariant on purpose — drop a
+  section, invent an employer, or rewrite the name — so the scorer tests keep
+  proving detection works.
+- Append; don't rewrite existing cases. The parametrized tests in
+  `test_scorers.py` pick up new cases automatically.

--- a/apps/backend/tests/evals/golden/cases.py
+++ b/apps/backend/tests/evals/golden/cases.py
@@ -1,0 +1,395 @@
+"""Golden fixtures for the eval harness.
+
+Each entry in :data:`GOLDEN_CASES` bundles everything the two eval layers need
+for one realistic tailoring scenario:
+
+* ``name``            — a short, human-readable id.
+* ``original``        — the master resume dict (ResumeData-compatible).
+* ``job_description`` — the target JD text.
+* ``jd_keywords``     — keywords the tailored resume is expected to surface
+                        (used by ``jd_keywords_present``).
+* ``tailored_good``   — a faithful, JD-aware tailoring of ``original``. Every
+                        section is preserved, no employers are invented, and
+                        the JD keywords appear. Structural scorers should give
+                        this a clean bill of health, and the LLM judge should
+                        score it >= 3.
+* ``tailored_bad``    — a deliberately broken tailoring (drops a section,
+                        invents an employer, rewrites the candidate's name).
+                        Structural scorers MUST flag it. It exists so the
+                        scorer tests can prove they detect real violations
+                        rather than always returning "OK".
+
+These are plain Python constants — no I/O, no LLM. To add a new golden case,
+append another dict with the same keys to ``GOLDEN_CASES``. Keep ``original``
+and ``tailored_good`` valid against ``app.schemas.ResumeData`` so
+``is_valid_resume`` stays meaningful.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Case 1 — backend engineer targeting a senior platform role
+# ---------------------------------------------------------------------------
+
+_CASE1_ORIGINAL: dict[str, Any] = {
+    "personalInfo": {
+        "name": "Jane Doe",
+        "title": "Senior Backend Engineer",
+        "email": "jane@example.com",
+        "phone": "+1-555-0100",
+        "location": "San Francisco, CA",
+        "website": "https://janedoe.dev",
+        "linkedin": "linkedin.com/in/janedoe",
+        "github": "github.com/janedoe",
+    },
+    "summary": (
+        "Backend engineer with 6 years of experience building scalable "
+        "Python APIs and microservices."
+    ),
+    "workExperience": [
+        {
+            "id": 1,
+            "title": "Senior Backend Engineer",
+            "company": "Acme Corp",
+            "location": "San Francisco, CA",
+            "years": "Jan 2021 - Present",
+            "description": [
+                "Built REST APIs serving 50K requests/day using Python and FastAPI",
+                "Led migration from monolith to microservices architecture",
+                "Mentored 3 junior developers on backend best practices",
+            ],
+        },
+        {
+            "id": 2,
+            "title": "Software Engineer",
+            "company": "StartupCo",
+            "location": "New York, NY",
+            "years": "Jun 2018 - Dec 2020",
+            "description": [
+                "Developed payment processing system handling $2M monthly",
+                "Wrote unit and integration tests improving coverage from 40% to 85%",
+            ],
+        },
+    ],
+    "education": [
+        {
+            "id": 1,
+            "institution": "MIT",
+            "degree": "B.S. Computer Science",
+            "years": "2014 - 2018",
+            "description": "Graduated with honors, Dean's List",
+        }
+    ],
+    "personalProjects": [
+        {
+            "id": 1,
+            "name": "OpenAPI Generator",
+            "role": "Creator & Maintainer",
+            "years": "Mar 2021 - Present",
+            "description": [
+                "CLI tool generating API clients from OpenAPI specs",
+                "500+ GitHub stars, used by 30+ companies",
+            ],
+        }
+    ],
+    "additional": {
+        "technicalSkills": [
+            "Python",
+            "FastAPI",
+            "Docker",
+            "AWS",
+            "PostgreSQL",
+            "Redis",
+        ],
+        "languages": ["English (Native)", "Spanish (Conversational)"],
+        "certificationsTraining": ["AWS Solutions Architect Associate"],
+        "awards": ["Employee of the Year 2022"],
+    },
+    "customSections": {},
+    "sectionMeta": [],
+}
+
+_CASE1_JD: str = (
+    "Senior Backend Engineer at TechCorp\n\n"
+    "We are looking for a Senior Backend Engineer to join our platform team. "
+    "You will design and build scalable APIs using Python and FastAPI. "
+    "Experience with Docker, Kubernetes, and AWS is required. "
+    "Terraform and GraphQL experience is a plus.\n\n"
+    "Requirements:\n"
+    "- 5+ years backend development experience\n"
+    "- Strong Python skills with FastAPI or similar frameworks\n"
+    "- Experience with microservices architecture\n"
+    "- Familiarity with CI/CD pipelines and agile methodologies\n"
+    "- Bachelor's degree in CS or equivalent\n"
+)
+
+# A faithful tailoring: same employers, same identity, JD keywords woven in
+# only where they are already true (Kubernetes/CI/CD added to summary + the
+# Acme bullets, which is defensible given the migration work).
+_CASE1_TAILORED_GOOD: dict[str, Any] = {
+    "personalInfo": dict(_CASE1_ORIGINAL["personalInfo"]),
+    "summary": (
+        "Senior backend engineer with 6 years building scalable Python and "
+        "FastAPI APIs and microservices, with hands-on Docker, Kubernetes, "
+        "and AWS experience and a track record of shipping via CI/CD."
+    ),
+    "workExperience": [
+        {
+            "id": 1,
+            "title": "Senior Backend Engineer",
+            "company": "Acme Corp",
+            "location": "San Francisco, CA",
+            "years": "Jan 2021 - Present",
+            "description": [
+                "Built REST APIs serving 50K requests/day using Python, FastAPI, and Docker",
+                "Led migration from a monolith to a microservices architecture deployed on Kubernetes",
+                "Implemented CI/CD pipelines and mentored 3 junior developers on backend best practices",
+            ],
+        },
+        {
+            "id": 2,
+            "title": "Software Engineer",
+            "company": "StartupCo",
+            "location": "New York, NY",
+            "years": "Jun 2018 - Dec 2020",
+            "description": [
+                "Developed an AWS-hosted payment processing system handling $2M monthly",
+                "Wrote unit and integration tests improving coverage from 40% to 85%",
+            ],
+        },
+    ],
+    "education": list(_CASE1_ORIGINAL["education"]),
+    "personalProjects": list(_CASE1_ORIGINAL["personalProjects"]),
+    "additional": {
+        "technicalSkills": [
+            "Python",
+            "FastAPI",
+            "Kubernetes",
+            "Docker",
+            "AWS",
+            "PostgreSQL",
+            "Redis",
+        ],
+        "languages": ["English (Native)", "Spanish (Conversational)"],
+        "certificationsTraining": ["AWS Solutions Architect Associate"],
+        "awards": ["Employee of the Year 2022"],
+    },
+    "customSections": {},
+    "sectionMeta": [],
+}
+
+# A broken tailoring: identity rewritten, work history dropped, and a
+# fabricated employer ("Globex Industries") inserted in projects-as-work.
+_CASE1_TAILORED_BAD: dict[str, Any] = {
+    "personalInfo": {
+        **_CASE1_ORIGINAL["personalInfo"],
+        "name": "John Smith",  # identity changed — must be flagged
+    },
+    "summary": (
+        "Senior backend engineer with Python, FastAPI, Kubernetes, Docker, "
+        "AWS, and CI/CD experience."
+    ),
+    # workExperience emptied AND populated with a never-held employer.
+    "workExperience": [
+        {
+            "id": 99,
+            "title": "Principal Engineer",
+            "company": "Globex Industries",  # fabricated employer
+            "location": "Remote",
+            "years": "Jan 2015 - Present",
+            "description": ["Owned the entire platform on Kubernetes and AWS"],
+        }
+    ],
+    "education": [],  # education dropped — must be flagged
+    "personalProjects": list(_CASE1_ORIGINAL["personalProjects"]),
+    "additional": {
+        "technicalSkills": ["Python", "FastAPI", "Kubernetes", "Docker", "AWS"],
+    },
+    "customSections": {},
+    "sectionMeta": [],
+}
+
+# ---------------------------------------------------------------------------
+# Case 2 — data analyst pivoting toward a data-engineering role
+# ---------------------------------------------------------------------------
+
+_CASE2_ORIGINAL: dict[str, Any] = {
+    "personalInfo": {
+        "name": "Carlos Reyes",
+        "title": "Data Analyst",
+        "email": "carlos@example.com",
+        "phone": "+1-555-0199",
+        "location": "Austin, TX",
+        "website": None,
+        "linkedin": "linkedin.com/in/carlosreyes",
+        "github": None,
+    },
+    "summary": (
+        "Data analyst with 4 years turning messy datasets into dashboards and "
+        "reports that drive product decisions."
+    ),
+    "workExperience": [
+        {
+            "id": 1,
+            "title": "Data Analyst",
+            "company": "RetailWorks",
+            "location": "Austin, TX",
+            "years": "Feb 2022 - Present",
+            "description": [
+                "Built weekly KPI dashboards in SQL and Tableau for 200+ stakeholders",
+                "Automated recurring reports, cutting manual effort by 12 hours/week",
+            ],
+        },
+        {
+            "id": 2,
+            "title": "Junior Analyst",
+            "company": "Insight Labs",
+            "location": "Austin, TX",
+            "years": "Aug 2020 - Jan 2022",
+            "description": [
+                "Cleaned and modeled survey data for 30+ client studies",
+                "Wrote Python scripts to validate data quality before analysis",
+            ],
+        },
+    ],
+    "education": [
+        {
+            "id": 1,
+            "institution": "University of Texas at Austin",
+            "degree": "B.A. Economics",
+            "years": "2016 - 2020",
+            "description": "Minor in Statistics",
+        }
+    ],
+    "personalProjects": [],
+    "additional": {
+        "technicalSkills": ["SQL", "Python", "Tableau", "Excel", "pandas"],
+        "languages": ["English (Native)", "Spanish (Native)"],
+        "certificationsTraining": [],
+        "awards": [],
+    },
+    "customSections": {},
+    "sectionMeta": [],
+}
+
+_CASE2_JD: str = (
+    "Data Engineer at DataFlow Inc.\n\n"
+    "We need a Data Engineer to build and maintain our analytics pipelines. "
+    "You will write SQL and Python, build ETL workflows with Airflow, and "
+    "model data in a cloud warehouse such as Snowflake or BigQuery.\n\n"
+    "Requirements:\n"
+    "- Strong SQL and Python\n"
+    "- Experience building ETL/data pipelines\n"
+    "- Comfort with data modeling and data quality\n"
+    "- Bonus: dbt, Airflow, Snowflake\n"
+)
+
+# Faithful tailoring: same employers/identity, reframes the existing SQL/Python
+# and data-quality work toward pipelines/ETL without inventing tools.
+_CASE2_TAILORED_GOOD: dict[str, Any] = {
+    "personalInfo": dict(_CASE2_ORIGINAL["personalInfo"]),
+    "summary": (
+        "Analytics-minded engineer with 4 years of SQL and Python, building "
+        "ETL workflows, modeling data, and enforcing data quality to power "
+        "reporting and product decisions."
+    ),
+    "workExperience": [
+        {
+            "id": 1,
+            "title": "Data Analyst",
+            "company": "RetailWorks",
+            "location": "Austin, TX",
+            "years": "Feb 2022 - Present",
+            "description": [
+                "Built weekly KPI dashboards backed by SQL data models for 200+ stakeholders",
+                "Automated recurring ETL reporting in Python, cutting manual effort by 12 hours/week",
+            ],
+        },
+        {
+            "id": 2,
+            "title": "Junior Analyst",
+            "company": "Insight Labs",
+            "location": "Austin, TX",
+            "years": "Aug 2020 - Jan 2022",
+            "description": [
+                "Modeled and transformed survey data for 30+ client studies",
+                "Wrote Python scripts to enforce data quality before analysis",
+            ],
+        },
+    ],
+    "education": list(_CASE2_ORIGINAL["education"]),
+    "personalProjects": [],
+    "additional": {
+        "technicalSkills": [
+            "SQL",
+            "Python",
+            "ETL",
+            "data modeling",
+            "Tableau",
+            "Excel",
+            "pandas",
+        ],
+        "languages": ["English (Native)", "Spanish (Native)"],
+        "certificationsTraining": [],
+        "awards": [],
+    },
+    "customSections": {},
+    "sectionMeta": [],
+}
+
+# Broken tailoring: real employers replaced by a fabricated one, work history
+# effectively wiped, identity name altered.
+_CASE2_TAILORED_BAD: dict[str, Any] = {
+    "personalInfo": {
+        **_CASE2_ORIGINAL["personalInfo"],
+        "name": "Carlos R. Mendez",  # identity changed
+    },
+    "summary": "Data engineer with SQL, Python, Airflow, dbt, and Snowflake experience.",
+    "workExperience": [
+        {
+            "id": 1,
+            "title": "Senior Data Engineer",
+            "company": "DataFlow Systems",  # fabricated employer (never held)
+            "location": "Remote",
+            "years": "Jan 2019 - Present",
+            "description": ["Owned ETL pipelines on Snowflake with Airflow and dbt"],
+        }
+    ],
+    "education": list(_CASE2_ORIGINAL["education"]),
+    "personalProjects": [],
+    "additional": {
+        "technicalSkills": ["SQL", "Python", "Airflow", "dbt", "Snowflake"],
+    },
+    "customSections": {},
+    "sectionMeta": [],
+}
+
+
+GOLDEN_CASES: list[dict[str, Any]] = [
+    {
+        "name": "backend_engineer_platform_role",
+        "original": _CASE1_ORIGINAL,
+        "job_description": _CASE1_JD,
+        "jd_keywords": [
+            "Python",
+            "FastAPI",
+            "Docker",
+            "Kubernetes",
+            "AWS",
+            "microservices",
+            "CI/CD",
+        ],
+        "tailored_good": _CASE1_TAILORED_GOOD,
+        "tailored_bad": _CASE1_TAILORED_BAD,
+    },
+    {
+        "name": "data_analyst_to_data_engineer",
+        "original": _CASE2_ORIGINAL,
+        "job_description": _CASE2_JD,
+        "jd_keywords": ["SQL", "Python", "ETL", "data quality", "data modeling"],
+        "tailored_good": _CASE2_TAILORED_GOOD,
+        "tailored_bad": _CASE2_TAILORED_BAD,
+    },
+]

--- a/apps/backend/tests/evals/scorers.py
+++ b/apps/backend/tests/evals/scorers.py
@@ -1,0 +1,167 @@
+"""Structural scorers for the eval harness.
+
+These are **pure, deterministic** functions: given an original resume and a
+tailored one, they check invariants that must hold regardless of the exact
+wording the LLM produced. They never call an LLM, never touch the network, and
+never read from disk — so they run for free in the normal test suite and form
+the cheap first line of defence against "a prompt change broke something."
+
+The invariants encoded here mirror the truthfulness / preservation rules the
+tailoring pipeline is supposed to honour:
+
+* every resume section that was populated must survive tailoring,
+* the candidate's employment history may be re-worded but not fabricated,
+* the JD's keywords should actually appear in the output,
+* the result must still validate against ``ResumeData``,
+* and the candidate's identity (``personalInfo``) must be left untouched.
+
+All functions take/return concrete types (backend rule: type hints on every
+function). The LLM-as-judge layer lives separately in
+``tests/evals/test_tailoring_eval.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import ValidationError
+
+from app.schemas import ResumeData
+
+# Top-level resume sections whose presence we care about. ``workExperience``
+# and ``education`` are the load-bearing ones a tailoring must never drop.
+_TRACKED_SECTIONS: tuple[str, ...] = (
+    "summary",
+    "workExperience",
+    "education",
+    "personalProjects",
+    "additional",
+)
+
+
+def _is_nonempty(value: Any) -> bool:
+    """Return True when ``value`` carries real content.
+
+    Empty strings, empty lists/dicts, ``None``, and dicts whose values are all
+    themselves empty (e.g. an ``additional`` block of empty lists) count as
+    empty. Everything else is considered present.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set)):
+        return len(value) > 0
+    if isinstance(value, dict):
+        return any(_is_nonempty(v) for v in value.values())
+    return True
+
+
+def _iter_text_fragments(value: Any) -> list[str]:
+    """Recursively collect every string fragment inside ``value``."""
+    fragments: list[str] = []
+    if value is None:
+        return fragments
+    if isinstance(value, str):
+        if value:
+            fragments.append(value)
+    elif isinstance(value, dict):
+        for item in value.values():
+            fragments.extend(_iter_text_fragments(item))
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            fragments.extend(_iter_text_fragments(item))
+    else:
+        fragments.append(str(value))
+    return fragments
+
+
+def flatten_resume_text(data: dict) -> str:
+    """Flatten an entire resume dict into one lowercased text blob.
+
+    Used for case-insensitive keyword search across every field — summary,
+    bullets, skills, custom sections, the lot.
+    """
+    return " ".join(_iter_text_fragments(data)).lower()
+
+
+def _employer_names(data: dict) -> list[str]:
+    """Return the (stripped, non-empty) company names in ``workExperience``."""
+    names: list[str] = []
+    for entry in data.get("workExperience", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        company = entry.get("company")
+        if isinstance(company, str) and company.strip():
+            names.append(company.strip())
+    return names
+
+
+def sections_preserved(original: dict, tailored: dict) -> bool:
+    """No populated top-level section may vanish during tailoring.
+
+    For each tracked section that was non-empty in ``original``, the same
+    section must still be non-empty in ``tailored``. Sections that were empty
+    to begin with are ignored (tailoring is allowed to leave them empty).
+
+    Returns True when every originally-populated section survives, else False.
+    """
+    for section in _TRACKED_SECTIONS:
+        if _is_nonempty(original.get(section)) and not _is_nonempty(
+            tailored.get(section)
+        ):
+            return False
+    return True
+
+
+def no_fabricated_employers(original: dict, tailored: dict) -> list[str]:
+    """Detect company names that appear in ``tailored`` but not in ``original``.
+
+    Tailoring may re-word bullets but must never invent an employer the
+    candidate never worked for. Comparison is case-insensitive and
+    whitespace-trimmed.
+
+    Returns the list of fabricated company names (in the casing they appear in
+    ``tailored``). An empty list means the work history is truthful.
+    """
+    original_names = {name.lower() for name in _employer_names(original)}
+    fabricated: list[str] = []
+    seen: set[str] = set()
+    for name in _employer_names(tailored):
+        key = name.lower()
+        if key not in original_names and key not in seen:
+            fabricated.append(name)
+            seen.add(key)
+    return fabricated
+
+
+def jd_keywords_present(tailored: dict, keywords: list[str]) -> float:
+    """Fraction (0.0–1.0) of ``keywords`` that appear in the tailored resume.
+
+    Matching is case-insensitive substring search over the flattened resume
+    text. With an empty ``keywords`` list there is nothing to miss, so the
+    score is 1.0.
+    """
+    if not keywords:
+        return 1.0
+    haystack = flatten_resume_text(tailored)
+    hits = sum(1 for kw in keywords if kw and kw.lower() in haystack)
+    return hits / len(keywords)
+
+
+def is_valid_resume(data: dict) -> bool:
+    """Return True iff ``data`` validates against the ``ResumeData`` schema."""
+    try:
+        ResumeData.model_validate(data)
+    except ValidationError:
+        return False
+    return True
+
+
+def personal_info_unchanged(original: dict, tailored: dict) -> bool:
+    """Return True iff the ``personalInfo`` block is byte-for-byte identical.
+
+    The candidate's identity (name, contact details) must never be rewritten by
+    tailoring. A missing block is treated as an empty dict on either side.
+    """
+    return original.get("personalInfo", {}) == tailored.get("personalInfo", {})

--- a/apps/backend/tests/evals/test_scorers.py
+++ b/apps/backend/tests/evals/test_scorers.py
@@ -1,0 +1,205 @@
+"""Deterministic tests for the structural scorers.
+
+This is the anti-theater proof for the eval harness: every scorer is exercised
+with BOTH a known-good and a known-bad input, so we know it actually detects
+violations instead of always returning "OK". None of these tests touch an LLM
+or the network — they run for free in the normal suite.
+
+The ``tailored_good`` / ``tailored_bad`` golden fixtures double as realistic
+end-to-end checks: the good tailoring must pass every scorer, the bad one must
+trip the relevant scorers.
+"""
+
+import copy
+
+import pytest
+
+from tests.evals.golden.cases import GOLDEN_CASES
+from tests.evals.scorers import (
+    flatten_resume_text,
+    is_valid_resume,
+    jd_keywords_present,
+    no_fabricated_employers,
+    personal_info_unchanged,
+    sections_preserved,
+)
+
+
+class TestSectionsPreserved:
+    def test_identical_resume_preserves_all_sections(self, sample_resume):
+        assert sections_preserved(sample_resume, sample_resume) is True
+
+    def test_dropping_work_experience_fails(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["workExperience"] = []
+        assert sections_preserved(sample_resume, tailored) is False
+
+    def test_dropping_education_fails(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        del tailored["education"]
+        assert sections_preserved(sample_resume, tailored) is False
+
+    def test_emptying_summary_fails(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["summary"] = "   "
+        assert sections_preserved(sample_resume, tailored) is False
+
+    def test_originally_empty_section_is_not_required(self, sample_resume):
+        original = copy.deepcopy(sample_resume)
+        original["personalProjects"] = []
+        tailored = copy.deepcopy(original)
+        # personalProjects was empty to begin with, so staying empty is fine.
+        assert sections_preserved(original, tailored) is True
+
+    def test_rewording_bullets_still_preserves_sections(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["workExperience"][0]["description"] = ["Completely reworded bullet"]
+        assert sections_preserved(sample_resume, tailored) is True
+
+
+class TestNoFabricatedEmployers:
+    def test_same_employers_returns_empty_list(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        assert no_fabricated_employers(sample_resume, tailored) == []
+
+    def test_reworded_bullets_same_companies_is_truthful(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        for exp in tailored["workExperience"]:
+            exp["description"] = ["reworded for the JD"]
+        assert no_fabricated_employers(sample_resume, tailored) == []
+
+    def test_invented_company_is_detected(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["workExperience"].append(
+            {
+                "id": 99,
+                "title": "Principal Engineer",
+                "company": "Globex Industries",
+                "years": "2015 - Present",
+                "description": ["never happened"],
+            }
+        )
+        fabricated = no_fabricated_employers(sample_resume, tailored)
+        assert fabricated == ["Globex Industries"]
+
+    def test_case_and_whitespace_insensitive(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["workExperience"][0]["company"] = "  acme corp  "
+        # Same employer, different casing/whitespace — not a fabrication.
+        assert no_fabricated_employers(sample_resume, tailored) == []
+
+    def test_each_fabricated_employer_listed_once(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["workExperience"] = [
+            {"company": "Globex Industries", "title": "x", "years": "y"},
+            {"company": "Globex Industries", "title": "z", "years": "w"},
+        ]
+        assert no_fabricated_employers(sample_resume, tailored) == ["Globex Industries"]
+
+
+class TestJdKeywordsPresent:
+    def test_all_keywords_present_scores_one(self, sample_resume):
+        keywords = ["Python", "FastAPI", "Docker", "AWS"]
+        assert jd_keywords_present(sample_resume, keywords) == 1.0
+
+    def test_no_keywords_present_scores_zero(self, sample_resume):
+        keywords = ["Rust", "Kubernetes", "Elixir", "COBOL"]
+        assert jd_keywords_present(sample_resume, keywords) == 0.0
+
+    def test_partial_match_is_fractional(self, sample_resume):
+        # 2 of 4 present.
+        keywords = ["Python", "FastAPI", "Rust", "Elixir"]
+        assert jd_keywords_present(sample_resume, keywords) == pytest.approx(0.5)
+
+    def test_match_is_case_insensitive(self, sample_resume):
+        assert jd_keywords_present(sample_resume, ["python", "fastapi"]) == 1.0
+
+    def test_empty_keyword_list_scores_one(self, sample_resume):
+        assert jd_keywords_present(sample_resume, []) == 1.0
+
+    def test_searches_nested_fields(self, sample_resume):
+        # "microservices" only appears inside a work-experience bullet.
+        assert jd_keywords_present(sample_resume, ["microservices"]) == 1.0
+
+
+class TestIsValidResume:
+    def test_well_formed_resume_is_valid(self, sample_resume):
+        assert is_valid_resume(sample_resume) is True
+
+    def test_empty_dict_is_valid_due_to_defaults(self):
+        # Every ResumeData field has a default, so {} is a valid (empty) resume.
+        assert is_valid_resume({}) is True
+
+    def test_wrong_type_for_work_experience_is_invalid(self, sample_resume):
+        broken = copy.deepcopy(sample_resume)
+        broken["workExperience"] = "not a list"
+        assert is_valid_resume(broken) is False
+
+    def test_wrong_type_for_personal_info_is_invalid(self, sample_resume):
+        broken = copy.deepcopy(sample_resume)
+        broken["personalInfo"] = "nope"
+        assert is_valid_resume(broken) is False
+
+
+class TestPersonalInfoUnchanged:
+    def test_identical_personal_info_is_unchanged(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        assert personal_info_unchanged(sample_resume, tailored) is True
+
+    def test_changed_name_is_flagged(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["personalInfo"]["name"] = "Someone Else"
+        assert personal_info_unchanged(sample_resume, tailored) is False
+
+    def test_changed_email_is_flagged(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["personalInfo"]["email"] = "attacker@example.com"
+        assert personal_info_unchanged(sample_resume, tailored) is False
+
+    def test_editing_other_sections_does_not_trip_it(self, sample_resume):
+        tailored = copy.deepcopy(sample_resume)
+        tailored["summary"] = "totally different summary"
+        assert personal_info_unchanged(sample_resume, tailored) is True
+
+
+class TestFlattenResumeText:
+    def test_includes_nested_bullet_text(self, sample_resume):
+        text = flatten_resume_text(sample_resume)
+        assert "rest apis" in text
+        assert "jane doe" in text
+
+    def test_output_is_lowercased(self, sample_resume):
+        text = flatten_resume_text(sample_resume)
+        assert text == text.lower()
+
+
+class TestGoldenCasesStructural:
+    """The golden good/bad tailorings must score exactly as designed."""
+
+    @pytest.mark.parametrize("case", GOLDEN_CASES, ids=lambda c: c["name"])
+    def test_good_tailoring_passes_every_scorer(self, case):
+        original = case["original"]
+        good = case["tailored_good"]
+        assert is_valid_resume(original) is True
+        assert is_valid_resume(good) is True
+        assert sections_preserved(original, good) is True
+        assert no_fabricated_employers(original, good) == []
+        assert personal_info_unchanged(original, good) is True
+        assert jd_keywords_present(good, case["jd_keywords"]) == 1.0
+
+    @pytest.mark.parametrize("case", GOLDEN_CASES, ids=lambda c: c["name"])
+    def test_bad_tailoring_is_caught(self, case):
+        original = case["original"]
+        bad = case["tailored_bad"]
+        # The bad fixture violates at least one truthfulness/preservation rule:
+        # it drops a section, invents an employer, OR rewrites the identity.
+        violated = (
+            not sections_preserved(original, bad)
+            or bool(no_fabricated_employers(original, bad))
+            or not personal_info_unchanged(original, bad)
+        )
+        assert violated is True
+        # Specifically, every bad fixture fabricates an employer and changes
+        # the candidate's name.
+        assert no_fabricated_employers(original, bad) != []
+        assert personal_info_unchanged(original, bad) is False

--- a/apps/backend/tests/evals/test_scorers.py
+++ b/apps/backend/tests/evals/test_scorers.py
@@ -127,7 +127,11 @@ class TestIsValidResume:
         assert is_valid_resume(sample_resume) is True
 
     def test_empty_dict_is_valid_due_to_defaults(self):
-        # Every ResumeData field has a default, so {} is a valid (empty) resume.
+        # Canary: every ResumeData field currently has a default, so {} validates
+        # as an empty resume. If a future schema change makes a field REQUIRED
+        # (no default), is_valid_resume({}) flips to False and this test fails
+        # LOUDLY — by design — flagging that the scorers' "empty is valid"
+        # assumption no longer holds.
         assert is_valid_resume({}) is True
 
     def test_wrong_type_for_work_experience_is_invalid(self, sample_resume):

--- a/apps/backend/tests/evals/test_tailoring_eval.py
+++ b/apps/backend/tests/evals/test_tailoring_eval.py
@@ -36,7 +36,10 @@ def _needs_key() -> None:
     one (``ollama``, ``openai_compatible``). This mirrors the gate used
     throughout the backend.
     """
-    cfg = get_llm_config()
+    try:
+        cfg = get_llm_config()
+    except Exception as exc:  # corrupt/unreadable config.json — skip, don't hard-fail
+        pytest.skip(f"could not read LLM config ({exc}); skipping LLM-judge eval")
     if not cfg.api_key and cfg.provider not in ("ollama", "openai_compatible"):
         pytest.skip("no LLM key configured; set one to run LLM-judge evals")
 

--- a/apps/backend/tests/evals/test_tailoring_eval.py
+++ b/apps/backend/tests/evals/test_tailoring_eval.py
@@ -1,0 +1,97 @@
+"""LLM-as-judge eval for tailoring quality.
+
+This is the layer the structural scorers cannot provide: it asks a *real* LLM
+whether a tailored resume is actually good against its job description, scored
+on a rubric (relevance, truthfulness, formatting). It is non-deterministic and
+costs a model call, so:
+
+* it is marked ``@pytest.mark.eval`` (excluded from the default selection in
+  CI / quick runs), and
+* it SKIPS unless the developer has an LLM key configured, using their own
+  key/provider via ``app.llm`` — exactly the policy in
+  ``docs/agent/testing-strategy.md`` §3.1.
+
+CRITICAL: in a keyless environment this test must skip *before* it ever builds
+or sends a request. ``_needs_key()`` is called as the very first statement in
+the test body, so no real LLM call can happen ungated.
+
+Run it on demand with a key configured::
+
+    uv run pytest tests/evals -m eval
+"""
+
+import json
+
+import pytest
+
+from app.llm import complete_json, get_llm_config
+from tests.evals.golden.cases import GOLDEN_CASES
+
+
+def _needs_key() -> None:
+    """Skip the calling test unless a usable LLM key/provider is configured.
+
+    A key is considered "absent" only when there is no api_key AND the provider
+    is not one of the local/self-hosted providers that legitimately run without
+    one (``ollama``, ``openai_compatible``). This mirrors the gate used
+    throughout the backend.
+    """
+    cfg = get_llm_config()
+    if not cfg.api_key and cfg.provider not in ("ollama", "openai_compatible"):
+        pytest.skip("no LLM key configured; set one to run LLM-judge evals")
+
+
+_JUDGE_RUBRIC = (
+    "You are a strict but fair technical recruiter grading how well a resume "
+    "was tailored to a job description. Grade on three axes:\n"
+    "1. RELEVANCE — does the resume emphasize skills/experience the JD asks for?\n"
+    "2. TRUTHFULNESS — does it avoid inventing employers, titles, or facts not "
+    "implied by the candidate's history?\n"
+    "3. FORMATTING — is it coherent, well-structured, and free of obvious "
+    "artifacts?\n\n"
+    "Return ONLY JSON of the form "
+    '{{"score": <integer 1-5>, "reasons": "<one or two sentences>"}}. '
+    "5 = excellent on all axes, 1 = poor. Be honest."
+)
+
+
+def _build_judge_prompt(job_description: str, tailored: dict) -> str:
+    """Assemble the judge prompt for one (JD, tailored-resume) pair."""
+    return (
+        f"{_JUDGE_RUBRIC}\n\n"
+        f"=== JOB DESCRIPTION ===\n{job_description}\n\n"
+        f"=== TAILORED RESUME (JSON) ===\n"
+        f"{json.dumps(tailored, ensure_ascii=False, indent=2)}\n"
+    )
+
+
+@pytest.mark.eval
+async def test_llm_judge_scores_good_tailoring_highly():
+    """A real LLM judge should rate a faithful, JD-aware tailoring >= 3/5.
+
+    In keyless environments this skips at ``_needs_key()`` before any request
+    is constructed or sent — it must NEVER make an ungated real call.
+    """
+    _needs_key()  # MUST be first — gates every line below behind a real key.
+
+    case = GOLDEN_CASES[0]
+    prompt = _build_judge_prompt(case["job_description"], case["tailored_good"])
+
+    # One cheap call. schema_type="enrichment" keeps truncation heuristics
+    # lenient for this small free-form JSON (not a full resume payload).
+    result = await complete_json(
+        prompt,
+        system_prompt="You are an impartial resume-tailoring evaluator.",
+        max_tokens=512,
+        schema_type="enrichment",
+    )
+
+    assert isinstance(result, dict), f"judge returned non-dict: {result!r}"
+    assert "score" in result, f"judge response missing 'score': {result!r}"
+
+    score = int(result["score"])
+    assert 1 <= score <= 5, f"score out of rubric range: {score}"
+    assert score >= 3, (
+        f"LLM judge scored the good tailoring below threshold: "
+        f"score={score}, reasons={result.get('reasons')!r}"
+    )

--- a/apps/backend/tests/integration/test_health_api.py
+++ b/apps/backend/tests/integration/test_health_api.py
@@ -16,34 +16,30 @@ def client():
 
 
 class TestHealthEndpoint:
-    """GET /api/v1/health"""
+    """GET /api/v1/health — lightweight liveness probe (does NOT call the LLM)."""
 
-    @patch("app.routers.health.check_llm_health", new_callable=AsyncMock)
-    async def test_health_returns_healthy(self, mock_health, client):
-        mock_health.return_value = {
-            "healthy": True,
-            "provider": "openai",
-            "model": "gpt-4",
-        }
+    async def test_health_returns_healthy(self, client):
+        """Liveness probe always reports healthy and needs no LLM call."""
         async with client:
             resp = await client.get("/api/v1/health")
         assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "healthy"
+        assert resp.json()["status"] == "healthy"
 
     @patch("app.routers.health.check_llm_health", new_callable=AsyncMock)
-    async def test_health_returns_degraded(self, mock_health, client):
-        mock_health.return_value = {
-            "healthy": False,
-            "provider": "openai",
-            "model": "gpt-4",
-            "error_code": "api_key_missing",
-        }
+    async def test_health_is_independent_of_llm(self, mock_health, client):
+        """/health is a liveness probe: it stays healthy even when the LLM is
+        unhealthy, and must NOT call the provider. Readiness lives at /status.
+
+        Regression guard for the liveness-vs-readiness split — the previous
+        version of this test asserted the deleted '/health returns degraded'
+        behavior and failed silently because nothing ran the suite.
+        """
+        mock_health.return_value = {"healthy": False, "error_code": "api_key_missing"}
         async with client:
             resp = await client.get("/api/v1/health")
         assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "degraded"
+        assert resp.json()["status"] == "healthy"
+        mock_health.assert_not_awaited()
 
 
 class TestStatusEndpoint:

--- a/apps/backend/tests/integration/test_llm_contract.py
+++ b/apps/backend/tests/integration/test_llm_contract.py
@@ -336,7 +336,10 @@ class TestCheckHealthTransport:
         res = await check_llm_health(config=cfg, include_details=True)
 
         assert res["healthy"] is False
-        assert res["error_code"]  # some non-empty failure code is set
+        # A provider auth failure (401) falls through to the generic failure
+        # code — assert the specific value, not just "truthy", so a silent
+        # rename of the code is caught.
+        assert res["error_code"] == "health_check_failed"
         # The raw key must never reach the client, even partially.
         detail = res.get("error_detail") or ""
         assert leaking_key not in detail

--- a/apps/backend/tests/integration/test_llm_contract.py
+++ b/apps/backend/tests/integration/test_llm_contract.py
@@ -1,0 +1,344 @@
+"""Transport-level contract tests for app.llm.
+
+These exercise the REAL request path in app/llm.py (``complete`` /
+``complete_json`` / ``check_llm_health``) instead of mocking
+``router.acompletion``. We stand up a fake HTTP server with ``respx`` and let
+litellm's real client issue the request over the wire, so we finally have
+regression coverage for the long-standing "Ollama doesn't work" reports and the
+local ``openai_compatible`` server path (issue #751).
+
+EVERY test in this module is a TRUE respx HTTP test: litellm's client actually
+serialises a request, sends it through httpx's transport, and parses the mocked
+HTTP response. No ``router.acompletion`` / ``litellm.acompletion`` boundary
+mocks are used.
+
+Why the autouse ``_litellm_httpx_transport`` fixture exists: litellm 1.86
+defaults to an aiohttp-based transport (``LiteLLMAiohttpTransport``) for its
+HTTP handler. respx hooks httpx's ``AsyncHTTPTransport``, so aiohttp requests
+sail straight past it to the real network. Setting
+``litellm.disable_aiohttp_transport = True`` forces litellm back onto httpx,
+which respx can intercept. We also flush litellm's in-memory client cache so a
+client built under the aiohttp transport in an earlier test can't be reused.
+"""
+
+import httpx
+import pytest
+import respx
+
+from app.llm import LLMConfig, check_llm_health, complete, complete_json
+
+
+@pytest.fixture(autouse=True)
+def _reset_router(monkeypatch):
+    """Reset the module-global Router cache between tests.
+
+    ``get_router`` caches ``_router`` / ``_router_config_key`` globally, so
+    without this an explicit config from one test would bleed into the next.
+    """
+    import app.llm as llm
+
+    monkeypatch.setattr(llm, "_router", None)
+    monkeypatch.setattr(llm, "_router_config_key", "")
+
+
+@pytest.fixture(autouse=True)
+def _litellm_httpx_transport(monkeypatch):
+    """Force litellm onto httpx so respx can intercept the request.
+
+    See the module docstring for the aiohttp-vs-httpx rationale. ``monkeypatch``
+    restores the original flag after the test; the client-cache flush is a
+    harmless one-way reset.
+    """
+    import litellm
+
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True, raising=False)
+    try:
+        litellm.in_memory_llm_clients_cache.flush_cache()
+    except Exception:  # noqa: BLE001 - cache is best-effort; never fail setup on it
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Response-body builders mirroring each provider's wire format
+# ---------------------------------------------------------------------------
+
+
+def _openai_chat_completion(content, model="llama-3.1-8b"):
+    """An OpenAI Chat Completions response body (openai / openai_compatible)."""
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _ollama_chat_response(content, model="llama3"):
+    """An Ollama /api/chat (non-streaming) response body."""
+    return {
+        "model": model,
+        "created_at": "2024-01-01T00:00:00Z",
+        "message": {"role": "assistant", "content": content},
+        "done": True,
+        "done_reason": "stop",
+    }
+
+
+def _ollama_show_response():
+    """A minimal Ollama /api/show response.
+
+    litellm's ollama_chat path probes ``{default_host}/api/show`` to learn the
+    model's capabilities before the real completion. We stub it so the probe
+    doesn't reach a real daemon.
+    """
+    return {
+        "license": "",
+        "modelfile": "",
+        "parameters": "",
+        "template": "",
+        "details": {"family": "llama", "parameter_size": "8B"},
+        "model_info": {},
+        "capabilities": ["completion"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# openai_compatible (llama.cpp / vLLM / LM Studio) — TRUE respx HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAICompatibleTransport:
+    """complete() against a fake OpenAI-compatible server over real HTTP."""
+
+    @respx.mock
+    async def test_complete_happy_path_roundtrips_v1_base(self):
+        """A /v1 base URL round-trips intact and content flows back.
+
+        Regression guard for issue #751: the OpenAI client must hit
+        ``{api_base}/chat/completions`` with the pasted ``/v1`` preserved
+        exactly once (no ``/v1/v1`` duplication, no stripped ``/v1``).
+        """
+        route = respx.post(
+            "http://local-llm.test/v1/chat/completions"
+        ).mock(return_value=httpx.Response(200, json=_openai_chat_completion("hello world")))
+
+        cfg = LLMConfig(
+            provider="openai_compatible",
+            model="llama-3.1-8b",
+            api_key="",
+            api_base="http://local-llm.test/v1",
+        )
+        out = await complete("Hello", config=cfg)
+
+        assert out == "hello world"
+        assert route.called
+        # The normalized URL must be the pasted /v1 base + /chat/completions.
+        assert str(route.calls.last.request.url) == (
+            "http://local-llm.test/v1/chat/completions"
+        )
+
+    @respx.mock
+    async def test_complete_strips_thinking_tags_over_the_wire(self):
+        """<think>...</think> reasoning is stripped from the transport output.
+
+        deepseek-r1 / qwq style models emit reasoning wrapped in <think> tags
+        before the real answer; complete() must return only the answer.
+        """
+        respx.post("http://local-llm.test/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json=_openai_chat_completion("<think>reasoning here</think>actual answer")
+            )
+        )
+
+        cfg = LLMConfig(
+            provider="openai_compatible",
+            model="deepseek-r1",
+            api_key="",
+            api_base="http://local-llm.test/v1",
+        )
+        out = await complete("Hello", config=cfg)
+
+        assert out == "actual answer"
+
+    @respx.mock
+    async def test_complete_json_parses_fenced_json_over_the_wire(self):
+        """complete_json runs the real _extract_json on transport output.
+
+        The model returns JSON wrapped in a ```json code fence (a common LLM
+        habit). complete_json must strip the fence and return the parsed dict.
+        """
+        fenced = '```json\n{"required_skills": ["Python"], "keywords": ["fastapi"]}\n```'
+        route = respx.post("http://local-llm.test/v1/chat/completions").mock(
+            return_value=httpx.Response(200, json=_openai_chat_completion(fenced))
+        )
+
+        cfg = LLMConfig(
+            provider="openai_compatible",
+            model="llama-3.1-8b",
+            api_key="",
+            api_base="http://local-llm.test/v1",
+        )
+        out = await complete_json("Extract keywords", config=cfg, schema_type="keywords")
+
+        assert out == {"required_skills": ["Python"], "keywords": ["fastapi"]}
+        assert route.called
+
+
+# ---------------------------------------------------------------------------
+# ollama — TRUE respx HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaTransport:
+    """complete() against a fake Ollama daemon over real HTTP.
+
+    litellm's ollama_chat path issues TWO requests: a capability probe to
+    ``{default_host}/api/show`` (always localhost:11434), then the real
+    completion to ``{configured_api_base}/api/chat``. Both are mocked.
+    """
+
+    @respx.mock
+    async def test_complete_happy_path(self):
+        """Ollama returns content via /api/chat and complete() surfaces it."""
+        # Capability probe litellm fires before the completion (localhost host).
+        respx.post("http://localhost:11434/api/show").mock(
+            return_value=httpx.Response(200, json=_ollama_show_response())
+        )
+        chat_route = respx.post("http://ollama.test:11434/api/chat").mock(
+            return_value=httpx.Response(200, json=_ollama_chat_response("ollama says hi"))
+        )
+
+        cfg = LLMConfig(
+            provider="ollama",
+            model="llama3",
+            api_key="",
+            api_base="http://ollama.test:11434",
+        )
+        out = await complete("Hello", config=cfg)
+
+        assert out == "ollama says hi"
+        assert chat_route.called
+        # The completion must target the user-configured host's /api/chat,
+        # not the localhost default used only for the capability probe.
+        assert str(chat_route.calls.last.request.url) == (
+            "http://ollama.test:11434/api/chat"
+        )
+
+    @respx.mock
+    async def test_complete_json_over_the_wire(self):
+        """complete_json works against Ollama's /api/chat wire format."""
+        respx.post("http://localhost:11434/api/show").mock(
+            return_value=httpx.Response(200, json=_ollama_show_response())
+        )
+        body = '{"required_skills": ["Go"], "keywords": ["k8s"]}'
+        chat_route = respx.post("http://ollama.test:11434/api/chat").mock(
+            return_value=httpx.Response(200, json=_ollama_chat_response(body))
+        )
+
+        cfg = LLMConfig(
+            provider="ollama",
+            model="llama3",
+            api_key="",
+            api_base="http://ollama.test:11434",
+        )
+        out = await complete_json("Extract", config=cfg, schema_type="keywords")
+
+        assert out == {"required_skills": ["Go"], "keywords": ["k8s"]}
+        assert chat_route.called
+
+
+# ---------------------------------------------------------------------------
+# check_llm_health — TRUE respx HTTP (calls litellm.acompletion directly)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckHealthTransport:
+    """check_llm_health over real HTTP (bypasses the Router, hits litellm)."""
+
+    @respx.mock
+    async def test_health_success(self):
+        """A 200 with content marks the provider healthy."""
+        route = respx.post("http://local-llm.test/v1/chat/completions").mock(
+            return_value=httpx.Response(200, json=_openai_chat_completion("pong"))
+        )
+
+        cfg = LLMConfig(
+            provider="openai_compatible",
+            model="llama-3.1-8b",
+            api_key="",
+            api_base="http://local-llm.test/v1",
+        )
+        res = await check_llm_health(config=cfg)
+
+        assert res["healthy"] is True
+        assert res["provider"] == "openai_compatible"
+        assert route.called
+
+    @respx.mock
+    async def test_health_empty_content_is_unhealthy(self):
+        """A 200 with empty content is reported unhealthy (error_code set)."""
+        respx.post("http://local-llm.test/v1/chat/completions").mock(
+            return_value=httpx.Response(200, json=_openai_chat_completion(""))
+        )
+
+        cfg = LLMConfig(
+            provider="openai_compatible",
+            model="llama-3.1-8b",
+            api_key="",
+            api_base="http://local-llm.test/v1",
+        )
+        res = await check_llm_health(config=cfg)
+
+        assert res["healthy"] is False
+        assert res["error_code"] == "empty_content"
+
+    @respx.mock
+    async def test_health_failure_scrubs_api_key_from_error_detail(self):
+        """A 401 yields healthy=False, an error_code, and a key-scrubbed detail.
+
+        The fake provider echoes the configured ``sk-`` key in its error body
+        (as the real OpenAI API does). With ``include_details=True`` the
+        upstream message is surfaced as ``error_detail`` — but every ``sk-``
+        token MUST be redacted so a Settings-page viewer can't read the key
+        back out.
+        """
+        leaking_key = "sk-abcd1234efgh5678ijkl9012"
+        respx.post("http://api.openai.test/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                401,
+                json={
+                    "error": {
+                        "message": (
+                            f"Incorrect API key provided: {leaking_key}. "
+                            "You can find your API key at ..."
+                        ),
+                        "type": "invalid_request_error",
+                        "code": "invalid_api_key",
+                    }
+                },
+            )
+        )
+
+        cfg = LLMConfig(
+            provider="openai",
+            model="gpt-4",
+            api_key=leaking_key,
+            api_base="http://api.openai.test/v1",
+        )
+        res = await check_llm_health(config=cfg, include_details=True)
+
+        assert res["healthy"] is False
+        assert res["error_code"]  # some non-empty failure code is set
+        # The raw key must never reach the client, even partially.
+        detail = res.get("error_detail") or ""
+        assert leaking_key not in detail
+        assert "sk-abcd1234" not in detail
+        assert "<redacted>" in detail

--- a/apps/backend/tests/integration/test_pdf_render.py
+++ b/apps/backend/tests/integration/test_pdf_render.py
@@ -41,10 +41,20 @@ RESUME_PRINT_DATA_URL = (
 def _refused_url():
     """Return a URL on a closed, connection-refusing localhost port.
 
-    Bind an ephemeral port to reserve it, then release it: nothing listens, so
-    Chromium navigation fails with net::ERR_CONNECTION_REFUSED. (The discard
-    port 9 is on Chromium's unsafe-ports blocklist and yields ERR_UNSAFE_PORT
-    instead, which does not exercise the connection-refused mapping.)
+    Bind an ephemeral port to claim a free number, read it, then CLOSE the
+    socket: with nothing bound, the kernel answers a connect with RST, so
+    Chromium navigation fails fast with net::ERR_CONNECTION_REFUSED — the signal
+    this test needs.
+
+    We deliberately close rather than hold the socket bound-but-unlistening:
+    that was tried, and on macOS a bound, non-listening socket does NOT refuse —
+    the SYN is dropped and Chromium hangs until its 30s navigation timeout (a
+    different, slower failure path), so the test would stop exercising
+    connection-refused. The residual window between close() and connect() is
+    sub-millisecond on a loopback ephemeral port, and a collision would only
+    *delay* the same failure, never mask it. (Port 9/discard is on Chromium's
+    unsafe-ports blocklist and yields ERR_UNSAFE_PORT, which also doesn't
+    exercise this mapping.)
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(("127.0.0.1", 0))

--- a/apps/backend/tests/integration/test_pdf_render.py
+++ b/apps/backend/tests/integration/test_pdf_render.py
@@ -1,0 +1,198 @@
+"""Render smoke tests for app/pdf.py — the 'resume won't render' incident class.
+
+A live demo of Resume-Matcher once broke a YouTuber's stream because PDF
+rendering failed. These tests give real coverage to the render path:
+
+* Pure helpers (format/margins) always run — no browser required.
+* A real headless-Chromium render proves the happy path actually emits PDF
+  bytes (magic header + non-trivial size), not just "no exception".
+
+The real frontend is not available under test, so the render targets a
+self-contained ``data:`` URL that already contains the ``.resume-print``
+selector. ``networkidle`` and ``wait_for_selector`` both resolve on a static
+data: URL, exercising the same goto → wait → page.pdf flow as production.
+
+Real-render tests skip cleanly (never hard-fail) when no Chromium binary can
+be launched.
+"""
+
+import socket
+
+import pytest
+from playwright.async_api import Error as PlaywrightError
+
+from app.pdf import (
+    PDFRenderError,
+    _resolve_pdf_format,
+    _resolve_pdf_margins,
+    close_pdf_renderer,
+    render_resume_pdf,
+)
+
+
+# A self-contained page that satisfies wait_for_selector(".resume-print")
+# without needing the real frontend running.
+RESUME_PRINT_DATA_URL = (
+    "data:text/html,"
+    "<html><body><div class='resume-print'>Hello PDF</div></body></html>"
+)
+
+
+def _refused_url():
+    """Return a URL on a closed, connection-refusing localhost port.
+
+    Bind an ephemeral port to reserve it, then release it: nothing listens, so
+    Chromium navigation fails with net::ERR_CONNECTION_REFUSED. (The discard
+    port 9 is on Chromium's unsafe-ports blocklist and yields ERR_UNSAFE_PORT
+    instead, which does not exercise the connection-refused mapping.)
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return f"http://127.0.0.1:{port}/"
+
+
+async def _render_or_skip(url, **kwargs):
+    """Render ``url`` to PDF, or skip the test if Chromium is unavailable.
+
+    Distinguishes "Chromium can't launch" (skip — environment limitation) from
+    a genuine render/navigation failure (re-raise — that's the bug we test for).
+    A missing-browser failure surfaces as a PDFRenderError mentioning the
+    executable, or as a raw PlaywrightError about a missing executable.
+    """
+    try:
+        return await render_resume_pdf(url, **kwargs)
+    except PDFRenderError as exc:
+        if "executable" in str(exc).lower():
+            pytest.skip(f"chromium unavailable: {exc}")
+        raise
+    except PlaywrightError as exc:
+        if "Executable doesn't exist" in str(exc):
+            pytest.skip(f"chromium unavailable: {exc}")
+        raise
+    except NotImplementedError as exc:
+        # Subprocess launch unsupported on this event loop policy.
+        pytest.skip(f"chromium subprocess launch unsupported: {exc}")
+
+
+class TestResolvePdfFormat:
+    """_resolve_pdf_format — page-size string → Playwright PDF format."""
+
+    def test_a4_maps_to_a4(self):
+        assert _resolve_pdf_format("A4") == "A4"
+
+    def test_letter_maps_to_letter(self):
+        # Note the case change: input "LETTER" → Playwright's "Letter".
+        assert _resolve_pdf_format("LETTER") == "Letter"
+
+    def test_unknown_defaults_to_a4(self):
+        assert _resolve_pdf_format("TABLOID") == "A4"
+
+    def test_empty_string_defaults_to_a4(self):
+        assert _resolve_pdf_format("") == "A4"
+
+
+class TestResolvePdfMargins:
+    """_resolve_pdf_margins — margin dict → mm-suffixed Playwright margins."""
+
+    def test_none_returns_ten_mm_on_all_sides(self):
+        assert _resolve_pdf_margins(None) == {
+            "top": "10mm",
+            "right": "10mm",
+            "bottom": "10mm",
+            "left": "10mm",
+        }
+
+    def test_empty_dict_falls_back_to_defaults(self):
+        # Empty dict is falsy, so it takes the same default path as None.
+        assert _resolve_pdf_margins({}) == {
+            "top": "10mm",
+            "right": "10mm",
+            "bottom": "10mm",
+            "left": "10mm",
+        }
+
+    def test_custom_values_are_formatted_as_mm(self):
+        result = _resolve_pdf_margins(
+            {"top": 20, "right": 15, "bottom": 25, "left": 5}
+        )
+        assert result == {
+            "top": "20mm",
+            "right": "15mm",
+            "bottom": "25mm",
+            "left": "5mm",
+        }
+
+    def test_partial_dict_fills_missing_sides_with_ten(self):
+        # Provided keys win; absent keys default to 10mm.
+        result = _resolve_pdf_margins({"top": 30})
+        assert result == {
+            "top": "30mm",
+            "right": "10mm",
+            "bottom": "10mm",
+            "left": "10mm",
+        }
+
+
+class TestRenderResumePdf:
+    """render_resume_pdf — real headless-Chromium render of a self-contained page.
+
+    These require a launchable Chromium and skip cleanly when one is absent.
+    Teardown tears down the module-global browser so a leaked process can't
+    bleed into other tests.
+    """
+
+    @pytest.fixture(autouse=True)
+    async def _teardown_renderer(self):
+        # Yield first; close the shared browser after every test in this class.
+        yield
+        await close_pdf_renderer()
+
+    async def test_renders_valid_pdf_bytes(self):
+        """THE proof rendering works: real PDF magic header + non-trivial size."""
+        pdf = await _render_or_skip(RESUME_PRINT_DATA_URL)
+        assert isinstance(pdf, (bytes, bytearray))
+        assert pdf[:4] == b"%PDF"
+        assert len(pdf) > 1000
+
+    async def test_renders_letter_size_with_custom_margins(self):
+        """Format + margins flow through into a valid render (LETTER, custom mm)."""
+        pdf = await _render_or_skip(
+            RESUME_PRINT_DATA_URL,
+            page_size="LETTER",
+            margins={"top": 20, "right": 15, "bottom": 20, "left": 15},
+        )
+        assert pdf[:4] == b"%PDF"
+        assert len(pdf) > 1000
+
+
+class TestRenderResumePdfErrors:
+    """render_resume_pdf error mapping — connection failures become PDFRenderError."""
+
+    @pytest.fixture(autouse=True)
+    async def _teardown_renderer(self):
+        yield
+        await close_pdf_renderer()
+
+    async def test_connection_refused_raises_pdf_render_error(self):
+        """A refused target must surface as PDFRenderError, not a raw Playwright
+        error — this is the 'cannot connect to frontend' incident path.
+
+        Skips only when Chromium itself can't launch (it still needs a browser
+        to *attempt* the connection); a genuine connection failure must raise.
+        """
+        try:
+            with pytest.raises(PDFRenderError) as exc_info:
+                await render_resume_pdf(_refused_url())
+        except PlaywrightError as exc:
+            if "Executable doesn't exist" in str(exc):
+                pytest.skip(f"chromium unavailable: {exc}")
+            raise
+        # The browser launched but couldn't reach the frontend — but if the only
+        # failure was a missing executable surfaced as PDFRenderError, treat that
+        # as a skip rather than a false-positive pass.
+        message = str(exc_info.value).lower()
+        if "executable" in message:
+            pytest.skip(f"chromium unavailable: {exc_info.value}")
+        assert "cannot connect to frontend" in message

--- a/apps/backend/tests/integration/test_pipeline_e2e.py
+++ b/apps/backend/tests/integration/test_pipeline_e2e.py
@@ -119,7 +119,14 @@ class TestPipelineCore:
         self, isolated_db, client
     ):
         """POST /jobs/upload stores the JD text and returns a job_id that is
-        actually retrievable from the real db; stats reflect one job."""
+        actually retrievable from the real db; stats reflect one job.
+
+        Fixture safety: ``isolated_db`` is listed before ``client`` (pytest
+        resolves same-scope fixtures left-to-right), and the routers look up the
+        module-global ``db`` at REQUEST time — so the monkeypatched isolated db
+        is always the one the ASGI app reads, independent of when ``client`` was
+        constructed.
+        """
         async with client:
             resp = await client.post(
                 "/api/v1/jobs/upload",

--- a/apps/backend/tests/integration/test_pipeline_e2e.py
+++ b/apps/backend/tests/integration/test_pipeline_e2e.py
@@ -1,0 +1,365 @@
+"""End-to-end pipeline test through the REAL routers + a REAL (isolated) TinyDB.
+
+Every existing integration test mocks the database away (``patch("...db")``), so
+nothing proves that the core user journey actually persists through the routers.
+This module fills that gap: it drives the genuine FastAPI app against the
+disposable ``isolated_db`` fixture (a temp-file ``Database`` swapped into every
+router module) and asserts real persisted state via the yielded db — not just
+status codes. Only the LLM boundaries are mocked; the routers, schemas,
+validation, and TinyDB persistence are all real.
+
+Pipeline stages covered:
+    upload  -> POST /api/v1/resumes/upload (parse_document + parse_resume_to_json mocked)
+    jobs    -> POST /api/v1/jobs/upload
+    fetch   -> GET  /api/v1/resumes?resume_id=...
+    improve -> POST /api/v1/resumes/improve/preview then /improve/confirm
+               (every LLM-touching service in the diff flow mocked)
+
+The real LLM is NEVER called: parse_resume_to_json, extract_job_keywords,
+generate_skill_target_plan, generate_resume_diffs, refine_resume, and the
+auxiliary cover-letter/outreach/title generators are all replaced with
+Mock/AsyncMock returning canned data.
+"""
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.schemas.models import ResumeData
+
+
+def _new_client():
+    """A fresh ASGI-in-process client.
+
+    httpx.AsyncClient cannot be reopened once its ``async with`` block exits, so
+    multi-request flows construct one client per request rather than reusing a
+    single fixture instance.
+    """
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.fixture
+def client():
+    """Async HTTP client bound to the real FastAPI app (ASGI in-process)."""
+    return _new_client()
+
+
+async def _upload_resume(isolated_db, sample_resume):
+    """Upload a fake PDF through the real router with the parse boundary mocked.
+
+    Returns the upload response. parse_document yields markdown and
+    parse_resume_to_json yields the structured ``sample_resume`` dict, so the
+    upload should end in ``processing_status == "ready"`` with ``sample_resume``
+    persisted as ``processed_data``.
+    """
+    markdown = "# Jane Doe\nSenior Backend Engineer\njane@example.com\n"
+    with (
+        patch(
+            "app.routers.resumes.parse_document",
+            new_callable=AsyncMock,
+            return_value=markdown,
+        ),
+        patch(
+            "app.routers.resumes.parse_resume_to_json",
+            new_callable=AsyncMock,
+            return_value=copy.deepcopy(sample_resume),
+        ),
+    ):
+        async with _new_client() as client:
+            resp = await client.post(
+                "/api/v1/resumes/upload",
+                files={"file": ("resume.pdf", b"%PDF-1.4 fake", "application/pdf")},
+            )
+    return resp
+
+
+class TestPipelineCore:
+    """The minimum bar: upload -> store -> jobs -> fetch, end to end."""
+
+    async def test_upload_persists_master_resume_through_router(
+        self, isolated_db, sample_resume
+    ):
+        """Upload a fake PDF; assert the resume is the persisted master, marked
+        ``ready``, with ``processed_data`` round-tripped through real TinyDB.
+
+        This proves the upload handler actually wires parse_document ->
+        parse_resume_to_json -> create_resume_atomic_master -> update_resume
+        against a real database, which the DB-mocking tests cannot.
+        """
+        resp = await _upload_resume(isolated_db, sample_resume)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["processing_status"] == "ready"
+        assert body["is_master"] is True
+        resume_id = body["resume_id"]
+        assert resume_id
+
+        # Inspect REAL persisted state via the yielded isolated db.
+        master = isolated_db.get_master_resume()
+        assert master is not None
+        assert master["resume_id"] == resume_id
+        assert master["processing_status"] == "ready"
+        assert master["is_master"] is True
+        # processed_data round-tripped through TinyDB JSON storage.
+        assert master["processed_data"] is not None
+        assert master["processed_data"]["personalInfo"]["name"] == "Jane Doe"
+        assert (
+            master["processed_data"]["summary"] == sample_resume["summary"]
+        )
+        # Exactly one resume exists, and it is the master.
+        assert len(isolated_db.list_resumes()) == 1
+
+    async def test_jobs_upload_persists_job_through_router(
+        self, isolated_db, client
+    ):
+        """POST /jobs/upload stores the JD text and returns a job_id that is
+        actually retrievable from the real db; stats reflect one job."""
+        async with client:
+            resp = await client.post(
+                "/api/v1/jobs/upload",
+                json={
+                    "job_descriptions": [
+                        "Senior Python role building scalable FastAPI services. "
+                        "Docker and AWS required."
+                    ]
+                },
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        job_ids = body["job_id"]
+        assert isinstance(job_ids, list)
+        assert len(job_ids) == 1
+        job_id = job_ids[0]
+
+        # Real persistence check via the yielded db.
+        stored_job = isolated_db.get_job(job_id)
+        assert stored_job is not None
+        assert "FastAPI" in stored_job["content"]
+        assert isolated_db.get_stats()["total_jobs"] == 1
+
+    async def test_full_journey_upload_jobs_then_fetch(
+        self, isolated_db, sample_resume
+    ):
+        """The cohesive core journey in one flow: upload a resume, upload a job,
+        then fetch the resume back by id — all through real routers + real db.
+
+        Asserts the fetched ``processed_resume`` (a fully validated ResumeData)
+        carries the expected summary, proving the stored data survives the
+        round trip out through the GET handler. Also confirms both the resume
+        and the job coexist in the same isolated database.
+        """
+        # 1. Upload.
+        upload_resp = await _upload_resume(isolated_db, sample_resume)
+        assert upload_resp.status_code == 200
+        resume_id = upload_resp.json()["resume_id"]
+
+        # The resume_id is recoverable from the db too (anti-theater).
+        listed = isolated_db.list_resumes()
+        assert resume_id in {r["resume_id"] for r in listed}
+
+        # 2. Jobs upload.
+        async with _new_client() as client:
+            jobs_resp = await client.post(
+                "/api/v1/jobs/upload",
+                json={"job_descriptions": ["Senior Python role at TechCorp."]},
+            )
+        assert jobs_resp.status_code == 200
+        job_id = jobs_resp.json()["job_id"][0]
+        assert isolated_db.get_job(job_id) is not None
+
+        # 3. Fetch the resume back through the real GET handler.
+        async with _new_client() as client:
+            fetch_resp = await client.get(
+                "/api/v1/resumes", params={"resume_id": resume_id}
+            )
+        assert fetch_resp.status_code == 200
+        data = fetch_resp.json()["data"]
+        assert data["resume_id"] == resume_id
+        assert data["raw_resume"]["processing_status"] == "ready"
+        processed = data["processed_resume"]
+        assert processed is not None
+        assert processed["personalInfo"]["name"] == "Jane Doe"
+        assert processed["summary"] == sample_resume["summary"]
+
+        # Both resume and job live in the same isolated db.
+        stats = isolated_db.get_stats()
+        assert stats["total_resumes"] == 1
+        assert stats["total_jobs"] == 1
+        assert stats["has_master_resume"] is True
+
+    async def test_fetch_unknown_resume_returns_404(self, isolated_db, client):
+        """Fetching a non-existent id is a real 404 from the GET handler against
+        an empty isolated db (sanity guard that the fixture starts clean)."""
+        async with client:
+            resp = await client.get(
+                "/api/v1/resumes", params={"resume_id": "does-not-exist"}
+            )
+        assert resp.status_code == 404
+        assert isolated_db.list_resumes() == []
+
+
+class TestTailoringPipeline:
+    """Stretch: the preview -> confirm tailoring handshake, end to end.
+
+    The diff-based improve flow calls many LLM services. We mock every
+    LLM-touching boundary imported into ``app.routers.resumes`` so the flow is
+    deterministic, drive a real ``/improve/preview``, then echo the returned
+    ``resume_preview`` back into ``/improve/confirm`` (exactly as the real
+    client does). Confirm re-hashes the payload and validates the preview_hash
+    persisted on the job, so a self-consistent round trip is what proves the
+    handshake + tailored-resume persistence actually wire together.
+
+    Refinement (``refine_resume``) is mocked to raise: the router explicitly
+    catches refinement failures and falls back to the unrefined result, so the
+    preview_hash is computed on our canned ``improved_data`` and the
+    brittle ``RefinementResult`` attribute surface never has to be faked.
+    """
+
+    async def test_preview_then_confirm_persists_tailored_resume(
+        self, isolated_db, sample_resume
+    ):
+        # Seed a master resume (with processed_data so the diff path runs) and a
+        # job, both through the real upload routers.
+        upload_resp = await _upload_resume(isolated_db, sample_resume)
+        assert upload_resp.status_code == 200
+        resume_id = upload_resp.json()["resume_id"]
+
+        async with _new_client() as client:
+            jobs_resp = await client.post(
+                "/api/v1/jobs/upload",
+                json={
+                    "job_descriptions": [
+                        "Senior Backend Engineer: Python, FastAPI, Docker, AWS."
+                    ]
+                },
+            )
+        assert jobs_resp.status_code == 200
+        job_id = jobs_resp.json()["job_id"][0]
+
+        # Canned tailored resume: identical personalInfo (required by the confirm
+        # invariant) with a tweaked summary so we can prove the *tailored* copy
+        # is what gets stored.
+        #
+        # Run it through ResumeData first so it carries the full, default-filled
+        # key set the real ``parse_resume_to_json``/``apply_diffs`` pipeline
+        # produces. The preview hashes this raw dict, while the preview *response*
+        # serializes ``ResumeData.model_validate(...)``; canonicalizing here makes
+        # the two byte-identical (mirroring production, where stored processed_data
+        # is already Pydantic-normalized) so the confirm preview_hash matches.
+        improved = ResumeData.model_validate(copy.deepcopy(sample_resume)).model_dump()
+        improved["summary"] = (
+            "Senior backend engineer with 6 years building scalable Python and "
+            "FastAPI services on AWS and Docker."
+        )
+
+        diff_result = SimpleNamespace(changes=[])
+
+        with (
+            patch(
+                "app.routers.resumes.extract_job_keywords",
+                new_callable=AsyncMock,
+                return_value={"keywords": ["Python", "FastAPI"], "required_skills": []},
+            ),
+            patch(
+                "app.routers.resumes.generate_skill_target_plan",
+                new_callable=AsyncMock,
+                return_value={"accepted": [], "rejected": []},
+            ),
+            patch(
+                "app.routers.resumes.verify_skill_target_plan",
+                return_value={"accepted": [], "rejected": []},
+            ),
+            patch(
+                "app.routers.resumes.generate_resume_diffs",
+                new_callable=AsyncMock,
+                return_value=diff_result,
+            ),
+            patch(
+                "app.routers.resumes.apply_diffs",
+                return_value=(copy.deepcopy(improved), [], []),
+            ),
+            patch("app.routers.resumes.verify_diff_result", return_value=[]),
+            # Force the unrefined fallback path (handled gracefully by the router)
+            # so we don't have to fake the RefinementResult object.
+            patch(
+                "app.routers.resumes.refine_resume",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("refinement disabled for test"),
+            ),
+            # Auxiliary generators are awaited in confirm; keep them cheap.
+            patch(
+                "app.routers.resumes.generate_resume_title",
+                new_callable=AsyncMock,
+                return_value="Senior Backend Engineer - TechCorp",
+            ),
+        ):
+            # --- Preview (no persistence; resume_id stays null) ---
+            async with _new_client() as client:
+                preview_resp = await client.post(
+                    "/api/v1/resumes/improve/preview",
+                    json={"resume_id": resume_id, "job_id": job_id},
+                )
+            assert preview_resp.status_code == 200, preview_resp.text
+            preview_data = preview_resp.json()["data"]
+            assert preview_data["resume_id"] is None
+            assert preview_data["job_id"] == job_id
+            preview_resume = preview_data["resume_preview"]
+            assert preview_resume["summary"] == improved["summary"]
+            # Preview must NOT have persisted a tailored resume.
+            assert isolated_db.get_stats()["total_resumes"] == 1
+            # The preview_hash was persisted on the job for the confirm handshake.
+            job_after_preview = isolated_db.get_job(job_id)
+            assert job_after_preview.get("preview_hash")
+
+            # --- Confirm (echo the preview back, exactly as the client does) ---
+            async with _new_client() as client:
+                confirm_resp = await client.post(
+                    "/api/v1/resumes/improve/confirm",
+                    json={
+                        "resume_id": resume_id,
+                        "job_id": job_id,
+                        "improved_data": preview_resume,
+                        "improvements": preview_data["improvements"],
+                    },
+                )
+            assert confirm_resp.status_code == 200, confirm_resp.text
+
+        confirm_data = confirm_resp.json()["data"]
+        tailored_id = confirm_data["resume_id"]
+        assert tailored_id is not None
+        assert tailored_id != resume_id
+
+        # The tailored resume is REALLY persisted, as a non-master child of the
+        # original, carrying the tailored summary.
+        stored_tailored = isolated_db.get_resume(tailored_id)
+        assert stored_tailored is not None
+        assert stored_tailored["is_master"] is False
+        assert stored_tailored["parent_id"] == resume_id
+        assert stored_tailored["processing_status"] == "ready"
+        assert stored_tailored["processed_data"]["summary"] == improved["summary"]
+        # personalInfo preserved from the master (the confirm invariant).
+        assert (
+            stored_tailored["processed_data"]["personalInfo"]
+            == sample_resume["personalInfo"]
+        )
+
+        # An improvements record links original -> tailored for this job.
+        improvement = isolated_db.get_improvement_by_tailored_resume(tailored_id)
+        assert improvement is not None
+        assert improvement["original_resume_id"] == resume_id
+        assert improvement["job_id"] == job_id
+
+        # Master + tailored both present; master unchanged.
+        stats = isolated_db.get_stats()
+        assert stats["total_resumes"] == 2
+        assert stats["total_improvements"] == 1
+        master = isolated_db.get_master_resume()
+        assert master["resume_id"] == resume_id
+        assert master["processed_data"]["summary"] == sample_resume["summary"]

--- a/apps/backend/tests/integration/test_upload_api.py
+++ b/apps/backend/tests/integration/test_upload_api.py
@@ -1,0 +1,77 @@
+"""Integration tests for the resume upload endpoint guards.
+
+POST /api/v1/resumes/upload validates: file type → size → empty file →
+extractable text. These guards are deterministic (no LLM needed) and exercise
+the real resumes router (previously ~18% covered). The empty-extracted-text
+guard pins PR #794 (reject image-based / scanned PDFs).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.routers.resumes import MAX_FILE_SIZE
+
+
+@pytest.fixture
+def client():
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+class TestUploadGuards:
+    async def test_rejects_unsupported_file_type(self, client):
+        async with client:
+            resp = await client.post(
+                "/api/v1/resumes/upload",
+                files={"file": ("resume.txt", b"hello", "text/plain")},
+            )
+        assert resp.status_code == 400
+        assert "Invalid file type" in resp.json()["detail"]
+
+    async def test_rejects_empty_file(self, client):
+        async with client:
+            resp = await client.post(
+                "/api/v1/resumes/upload",
+                files={"file": ("resume.pdf", b"", "application/pdf")},
+            )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Empty file"
+
+    async def test_rejects_oversized_file(self, client):
+        oversized = b"x" * (MAX_FILE_SIZE + 1)
+        async with client:
+            resp = await client.post(
+                "/api/v1/resumes/upload",
+                files={"file": ("resume.pdf", oversized, "application/pdf")},
+            )
+        assert resp.status_code == 413
+
+    @patch("app.routers.resumes.parse_document", new_callable=AsyncMock)
+    async def test_rejects_empty_extracted_text(self, mock_parse, client):
+        """#794: a valid-but-image-based PDF parses to empty text → 422,
+        and we must NOT persist anything to the database."""
+        mock_parse.return_value = "   \n  "  # whitespace only → "no extractable text"
+        with patch("app.routers.resumes.db") as mock_db:
+            async with client:
+                resp = await client.post(
+                    "/api/v1/resumes/upload",
+                    files={"file": ("scanned.pdf", b"%PDF-1.4 image-only", "application/pdf")},
+                )
+        assert resp.status_code == 422
+        assert "extract text" in resp.json()["detail"].lower()
+        mock_db.create_resume_atomic_master.assert_not_called()
+
+    @patch("app.routers.resumes.parse_document", new_callable=AsyncMock)
+    async def test_maps_parse_failure_to_422(self, mock_parse, client):
+        """A parser exception is surfaced as a generic 422, not a 500."""
+        mock_parse.side_effect = RuntimeError("corrupt file")
+        async with client:
+            resp = await client.post(
+                "/api/v1/resumes/upload",
+                files={"file": ("broken.pdf", b"%PDF-1.4 broken", "application/pdf")},
+            )
+        assert resp.status_code == 422
+        assert "Failed to parse" in resp.json()["detail"]

--- a/apps/backend/tests/unit/test_check_locale_parity.py
+++ b/apps/backend/tests/unit/test_check_locale_parity.py
@@ -64,6 +64,18 @@ def test_fails_on_object_vs_leaf_mismatch(messages_dir: Path) -> None:
     assert clp.main(["prog", str(messages_dir)]) == 1
 
 
+def test_fails_on_string_vs_number_mismatch(messages_dir: Path) -> None:
+    # a.b is a string in en but a number here — also breaks `next build`, and a
+    # coarse branch/leaf classification would have missed it.
+    _write(messages_dir, "es.json", {"a": {"b": 5, "c": "ya"}, "d": "z"})
+    assert clp.main(["prog", str(messages_dir)]) == 1
+
+
+def test_fails_on_string_vs_array_mismatch(messages_dir: Path) -> None:
+    _write(messages_dir, "es.json", {"a": {"b": ["x"], "c": "ya"}, "d": "z"})
+    assert clp.main(["prog", str(messages_dir)]) == 1
+
+
 def test_fails_on_malformed_json(messages_dir: Path) -> None:
     (messages_dir / "es.json").write_text("{ not valid json ", encoding="utf-8")
     assert clp.main(["prog", str(messages_dir)]) == 1

--- a/apps/backend/tests/unit/test_check_locale_parity.py
+++ b/apps/backend/tests/unit/test_check_locale_parity.py
@@ -1,0 +1,74 @@
+"""Anti-theater tests for ``scripts/check_locale_parity.py``.
+
+That script is the node-free guard (run by the pre-push hook) for the i18n build
+break: a locale JSON that does not structurally match ``en.json`` fails
+``next build``. These tests prove the guard actually FIRES on the three failure
+modes it must catch:
+
+* a MISSING key,
+* a leaf-vs-object SHAPE mismatch (the key path is present but its kind differs —
+  the gap a presence-only check would let through; raised by cubic on PR #820),
+* MALFORMED JSON (a clean exit 1, not a raw traceback),
+
+and stays quiet (exit 0) when locales match. The script lives at the repo root,
+outside the backend package, so it's loaded by file path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[4] / "scripts" / "check_locale_parity.py"
+_spec = importlib.util.spec_from_file_location("check_locale_parity", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+clp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(clp)
+
+
+def _write(dir_path: Path, name: str, data: Any) -> None:
+    (dir_path / name).write_text(json.dumps(data), encoding="utf-8")
+
+
+@pytest.fixture
+def messages_dir(tmp_path: Path) -> Path:
+    # A non-trivial reference: a nested object plus leaves at two depths.
+    _write(tmp_path, "en.json", {"a": {"b": "hi", "c": "yo"}, "d": "z"})
+    return tmp_path
+
+
+def test_passes_when_locale_matches(messages_dir: Path) -> None:
+    _write(messages_dir, "es.json", {"a": {"b": "hola", "c": "ya"}, "d": "z"})
+    assert clp.main(["prog", str(messages_dir)]) == 0
+
+
+def test_fails_on_missing_key(messages_dir: Path) -> None:
+    _write(messages_dir, "es.json", {"a": {"b": "hola"}, "d": "z"})  # missing a.c
+    assert clp.main(["prog", str(messages_dir)]) == 1
+
+
+def test_fails_on_leaf_vs_object_mismatch(messages_dir: Path) -> None:
+    # a.b is a string in en but an object here: the key path a.b is still
+    # present, so a presence-only diff PASSES — yet `next build` would fail.
+    _write(messages_dir, "es.json", {"a": {"b": {"x": "deep"}, "c": "ya"}, "d": "z"})
+    assert clp.main(["prog", str(messages_dir)]) == 1
+
+
+def test_fails_on_object_vs_leaf_mismatch(messages_dir: Path) -> None:
+    # The reverse: a (object in en) is a string here.
+    _write(messages_dir, "es.json", {"a": "flat", "d": "z"})
+    assert clp.main(["prog", str(messages_dir)]) == 1
+
+
+def test_fails_on_malformed_json(messages_dir: Path) -> None:
+    (messages_dir / "es.json").write_text("{ not valid json ", encoding="utf-8")
+    assert clp.main(["prog", str(messages_dir)]) == 1
+
+
+def test_extra_keys_are_non_fatal(messages_dir: Path) -> None:
+    _write(messages_dir, "es.json", {"a": {"b": "hola", "c": "ya"}, "d": "z", "x": "ok"})
+    assert clp.main(["prog", str(messages_dir)]) == 0

--- a/apps/backend/tests/unit/test_database.py
+++ b/apps/backend/tests/unit/test_database.py
@@ -1,0 +1,148 @@
+"""Tests for the real TinyDB layer (app.database.Database).
+
+Every integration test mocks `db`, so the actual persistence layer (34% cover)
+was never exercised. These run a real TinyDB against a temp file, so CRUD,
+master-resume assignment, and stats are verified end-to-end on the storage.
+"""
+
+import pytest
+
+from app.database import Database
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = Database(db_path=tmp_path / "test_db.json")
+    yield database
+    database.close()
+
+
+class TestResumeCrud:
+    def test_create_and_get(self, db):
+        created = db.create_resume(content="# Resume", filename="r.pdf")
+        assert created["resume_id"]
+        fetched = db.get_resume(created["resume_id"])
+        assert fetched is not None
+        assert fetched["content"] == "# Resume"
+        assert fetched["filename"] == "r.pdf"
+
+    def test_get_missing_returns_none(self, db):
+        assert db.get_resume("does-not-exist") is None
+
+    def test_list_resumes(self, db):
+        db.create_resume(content="a")
+        db.create_resume(content="b")
+        assert len(db.list_resumes()) == 2
+
+    def test_update_resume_changes_field_and_timestamp(self, db):
+        created = db.create_resume(content="x")
+        updated = db.update_resume(created["resume_id"], {"title": "New Title"})
+        assert updated["title"] == "New Title"
+        assert updated["updated_at"] >= created["updated_at"]
+
+    def test_update_missing_raises(self, db):
+        with pytest.raises(ValueError):
+            db.update_resume("missing", {"title": "X"})
+
+    def test_delete_resume(self, db):
+        created = db.create_resume(content="x")
+        assert db.delete_resume(created["resume_id"]) is True
+        assert db.get_resume(created["resume_id"]) is None
+
+    def test_delete_missing_returns_false(self, db):
+        assert db.delete_resume("missing") is False
+
+
+class TestMasterResume:
+    def test_no_master_initially(self, db):
+        assert db.get_master_resume() is None
+
+    def test_set_master_unsets_previous(self, db):
+        r1 = db.create_resume(content="1")
+        r2 = db.create_resume(content="2")
+
+        assert db.set_master_resume(r1["resume_id"]) is True
+        assert db.get_master_resume()["resume_id"] == r1["resume_id"]
+
+        assert db.set_master_resume(r2["resume_id"]) is True
+        master = db.get_master_resume()
+        assert master["resume_id"] == r2["resume_id"]
+        # Only one master at a time.
+        assert sum(1 for r in db.list_resumes() if r["is_master"]) == 1
+
+    def test_set_master_missing_returns_false(self, db):
+        assert db.set_master_resume("missing") is False
+
+    async def test_atomic_first_upload_becomes_master(self, db):
+        created = await db.create_resume_atomic_master(content="first", processing_status="ready")
+        assert created["is_master"] is True
+
+    async def test_atomic_second_upload_not_master(self, db):
+        await db.create_resume_atomic_master(content="first", processing_status="ready")
+        second = await db.create_resume_atomic_master(content="second", processing_status="ready")
+        assert second["is_master"] is False
+
+    async def test_atomic_recovers_when_master_stuck(self, db):
+        # Master stuck in "failed" → next upload is promoted to master.
+        first = await db.create_resume_atomic_master(content="first", processing_status="failed")
+        assert first["is_master"] is True
+        second = await db.create_resume_atomic_master(content="second", processing_status="ready")
+        assert second["is_master"] is True
+        assert db.get_master_resume()["resume_id"] == second["resume_id"]
+
+
+class TestJobs:
+    def test_create_and_get_job(self, db):
+        created = db.create_job(content="Engineer role", resume_id="r1")
+        fetched = db.get_job(created["job_id"])
+        assert fetched["content"] == "Engineer role"
+        assert fetched["resume_id"] == "r1"
+
+    def test_get_missing_job_returns_none(self, db):
+        assert db.get_job("missing") is None
+
+    def test_update_job(self, db):
+        created = db.create_job(content="old")
+        updated = db.update_job(created["job_id"], {"content": "new"})
+        assert updated["content"] == "new"
+
+    def test_update_missing_job_returns_none(self, db):
+        assert db.update_job("missing", {"content": "x"}) is None
+
+
+class TestImprovements:
+    def test_create_and_lookup_by_tailored_resume(self, db):
+        db.create_improvement(
+            original_resume_id="orig",
+            tailored_resume_id="tailored-1",
+            job_id="job-1",
+            improvements=[{"path": "summary"}],
+        )
+        found = db.get_improvement_by_tailored_resume("tailored-1")
+        assert found is not None
+        assert found["job_id"] == "job-1"
+
+    def test_lookup_missing_returns_none(self, db):
+        assert db.get_improvement_by_tailored_resume("nope") is None
+
+
+class TestStatsAndReset:
+    def test_get_stats(self, db):
+        db.create_resume(content="a")
+        db.set_master_resume(db.list_resumes()[0]["resume_id"])
+        db.create_job(content="jd")
+        stats = db.get_stats()
+        assert stats["total_resumes"] == 1
+        assert stats["total_jobs"] == 1
+        assert stats["has_master_resume"] is True
+
+    def test_reset_database_truncates(self, db, tmp_path, monkeypatch):
+        # reset_database also clears settings.data_dir/uploads — isolate it to tmp.
+        monkeypatch.setattr("app.database.settings.data_dir", tmp_path)
+        db.create_resume(content="a")
+        db.create_job(content="jd")
+        db.reset_database()
+        stats = db.get_stats()
+        assert stats["total_resumes"] == 0
+        assert stats["total_jobs"] == 0
+        assert stats["has_master_resume"] is False

--- a/apps/backend/tests/unit/test_llm_providers.py
+++ b/apps/backend/tests/unit/test_llm_providers.py
@@ -1,0 +1,195 @@
+"""Unit tests for provider routing & key resolution in app.llm.
+
+These are the pure functions where local-LLM (Ollama / openai_compatible) bugs
+live, and they pin behavior we recently shipped:
+  - get_model_name        — LiteLLM provider prefixing (Ollama, OpenRouter nesting)
+  - _normalize_api_base   — the /v1/v1 duplicate-path fix (issue #751) + Ollama suffixes
+  - resolve_api_key       — the security rule that local providers do NOT inherit
+                            the env LLM_API_KEY (so a paid key can't leak to a
+                            self-hosted server)
+  - _effective_api_key    — blank-key sentinel for openai_compatible
+  - _strip_thinking_tags  — deepseek-r1 / qwq <think> stripping
+"""
+
+import pytest
+
+from app.llm import (
+    LLMConfig,
+    _effective_api_key,
+    _normalize_api_base,
+    _strip_thinking_tags,
+    get_model_name,
+    resolve_api_key,
+)
+
+
+def _cfg(provider: str, model: str) -> LLMConfig:
+    return LLMConfig(provider=provider, model=model, api_key="")
+
+
+# ---------------------------------------------------------------------------
+# get_model_name — provider prefixing
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelName:
+    def test_openai_no_prefix(self):
+        assert get_model_name(_cfg("openai", "gpt-4")) == "gpt-4"
+
+    def test_ollama_uses_ollama_chat_prefix(self):
+        # ollama_chat/ routes to /api/chat (messages array) — the working path.
+        assert get_model_name(_cfg("ollama", "llama3")) == "ollama_chat/llama3"
+
+    def test_ollama_does_not_double_prefix(self):
+        assert get_model_name(_cfg("ollama", "ollama_chat/llama3")) == "ollama_chat/llama3"
+        assert get_model_name(_cfg("ollama", "ollama/llama3")) == "ollama/llama3"
+
+    def test_openai_compatible_uses_openai_prefix(self):
+        # llama.cpp / vLLM / LM Studio served via the OpenAI client.
+        assert get_model_name(_cfg("openai_compatible", "llama-3.1-8b")) == "openai/llama-3.1-8b"
+
+    def test_openrouter_nested_prefix(self):
+        assert (
+            get_model_name(_cfg("openrouter", "anthropic/claude-3.5-sonnet"))
+            == "openrouter/anthropic/claude-3.5-sonnet"
+        )
+
+    def test_openrouter_does_not_double_prefix(self):
+        assert (
+            get_model_name(_cfg("openrouter", "openrouter/anthropic/claude-3.5-sonnet"))
+            == "openrouter/anthropic/claude-3.5-sonnet"
+        )
+
+    def test_anthropic_prefix(self):
+        assert get_model_name(_cfg("anthropic", "claude-3-opus")) == "anthropic/claude-3-opus"
+
+    def test_gemini_prefix(self):
+        assert get_model_name(_cfg("gemini", "gemini-1.5-pro")) == "gemini/gemini-1.5-pro"
+
+    def test_deepseek_prefix(self):
+        assert get_model_name(_cfg("deepseek", "deepseek-chat")) == "deepseek/deepseek-chat"
+
+    def test_groq_prefix(self):
+        assert get_model_name(_cfg("groq", "llama-3.1-70b")) == "groq/llama-3.1-70b"
+
+    def test_existing_known_prefix_is_preserved(self):
+        # Model already carries a known prefix → don't add the provider's.
+        assert get_model_name(_cfg("anthropic", "anthropic/claude-3-opus")) == "anthropic/claude-3-opus"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_api_base — the /v1/v1 duplicate-path fix (issue #751)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeApiBase:
+    def test_none_and_blank(self):
+        assert _normalize_api_base("openai", None) is None
+        assert _normalize_api_base("openai", "") is None
+        assert _normalize_api_base("openai", "   ") is None
+
+    def test_openai_preserves_v1_as_is(self):
+        # #751: the OpenAI client resolves /v1 correctly; local llama.cpp etc.
+        # MUST keep the /v1 the user pasted, otherwise requests 404.
+        assert _normalize_api_base("openai", "http://localhost:8080/v1") == "http://localhost:8080/v1"
+        assert (
+            _normalize_api_base("openai_compatible", "http://localhost:8080/v1")
+            == "http://localhost:8080/v1"
+        )
+
+    def test_openai_strips_only_trailing_slash(self):
+        assert _normalize_api_base("openai_compatible", "http://localhost:8080/v1/") == "http://localhost:8080/v1"
+
+    def test_anthropic_strips_v1(self):
+        # Anthropic handler appends /v1/messages → avoid /v1/v1/messages.
+        assert _normalize_api_base("anthropic", "https://api.anthropic.com/v1") == "https://api.anthropic.com"
+
+    def test_gemini_strips_v1(self):
+        assert _normalize_api_base("gemini", "https://host/v1") == "https://host"
+
+    def test_openrouter_strips_v1(self):
+        assert _normalize_api_base("openrouter", "https://openrouter.ai/api/v1") == "https://openrouter.ai/api"
+
+    @pytest.mark.parametrize(
+        "pasted",
+        [
+            "http://localhost:11434/v1",
+            "http://localhost:11434/api/chat",
+            "http://localhost:11434/api/generate",
+            "http://localhost:11434/api",
+        ],
+    )
+    def test_ollama_strips_known_suffixes(self, pasted):
+        assert _normalize_api_base("ollama", pasted) == "http://localhost:11434"
+
+    def test_ollama_bare_host_unchanged(self):
+        assert _normalize_api_base("ollama", "http://localhost:11434") == "http://localhost:11434"
+
+
+# ---------------------------------------------------------------------------
+# resolve_api_key — local providers must NOT inherit the env key
+# ---------------------------------------------------------------------------
+
+
+class TestResolveApiKey:
+    def test_top_level_key_wins(self):
+        assert resolve_api_key({"api_key": "sk-top"}, "openai") == "sk-top"
+
+    def test_falls_back_to_provider_keymap(self):
+        # gemini → "google" in the api_keys dict.
+        assert resolve_api_key({"api_keys": {"google": "g-key"}}, "gemini") == "g-key"
+
+    def test_ollama_does_not_inherit_env_key(self, monkeypatch):
+        # SECURITY: a paid key in LLM_API_KEY must never leak to a local server.
+        monkeypatch.setattr("app.llm.settings.llm_api_key", "sk-paid-secret")
+        assert resolve_api_key({}, "ollama") == ""
+
+    def test_openai_compatible_does_not_inherit_env_key(self, monkeypatch):
+        monkeypatch.setattr("app.llm.settings.llm_api_key", "sk-paid-secret")
+        assert resolve_api_key({}, "openai_compatible") == ""
+
+    def test_cloud_provider_does_inherit_env_key(self, monkeypatch):
+        monkeypatch.setattr("app.llm.settings.llm_api_key", "sk-paid-secret")
+        assert resolve_api_key({}, "openai") == "sk-paid-secret"
+
+
+# ---------------------------------------------------------------------------
+# _effective_api_key — blank-key sentinel for openai_compatible
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveApiKey:
+    def test_openai_compatible_blank_gets_sentinel(self):
+        # The OpenAI client rejects empty strings; local servers ignore the value.
+        assert _effective_api_key("openai_compatible", "") == "sk-no-key"
+
+    def test_openai_compatible_real_key_passthrough(self):
+        assert _effective_api_key("openai_compatible", "local-key") == "local-key"
+
+    def test_ollama_blank_passthrough(self):
+        # Ollama goes through a different client path; no sentinel needed.
+        assert _effective_api_key("ollama", "") == ""
+
+    def test_openai_passthrough(self):
+        assert _effective_api_key("openai", "sk-real") == "sk-real"
+
+
+# ---------------------------------------------------------------------------
+# _strip_thinking_tags — deepseek-r1 / qwq reasoning models
+# ---------------------------------------------------------------------------
+
+
+class TestStripThinkingTags:
+    def test_strips_closed_block(self):
+        assert _strip_thinking_tags("<think>weighing options</think>final answer") == "final answer"
+
+    def test_strips_multiline_block(self):
+        content = "<think>\nline 1\nline 2\n</think>\nthe answer"
+        assert _strip_thinking_tags(content) == "the answer"
+
+    def test_strips_unclosed_block(self):
+        # Model still "thinking" at the token limit — drop the trailing tag.
+        assert _strip_thinking_tags("<think>still reasoning with no close") == ""
+
+    def test_no_tags_unchanged(self):
+        assert _strip_thinking_tags("plain output") == "plain output"

--- a/apps/backend/tests/unit/test_parser.py
+++ b/apps/backend/tests/unit/test_parser.py
@@ -1,0 +1,80 @@
+"""Unit tests for pure parsing helpers in app.services.parser.
+
+The LLM frequently drops months when parsing resume dates ("Jun 2020 - Aug 2021"
+→ "2020 - 2021"). restore_dates_from_markdown() patches that back from the raw
+markdown. This is pure, deterministic logic — the parser module was at ~20%
+coverage with none of it exercised.
+"""
+
+from app.services.parser import _extract_markdown_dates, restore_dates_from_markdown
+
+
+class TestExtractMarkdownDates:
+    def test_finds_full_range(self):
+        assert _extract_markdown_dates("Worked Jun 2020 - Aug 2021 there") == ["Jun 2020 - Aug 2021"]
+
+    def test_finds_present_range(self):
+        assert _extract_markdown_dates("May 2021 - Present") == ["May 2021 - Present"]
+
+    def test_finds_single_date(self):
+        assert _extract_markdown_dates("Graduated Jun 2023") == ["Jun 2023"]
+
+    def test_ignores_year_only(self):
+        # Year-only "2020 - 2021" has no month token → not captured.
+        assert _extract_markdown_dates("2020 - 2021") == []
+
+
+class TestRestoreDatesFromMarkdown:
+    def test_restores_months_in_work_experience(self):
+        parsed = {"workExperience": [{"title": "Dev", "years": "2020 - 2021"}]}
+        markdown = "Senior Dev, Jun 2020 - Aug 2021, built things"
+        result = restore_dates_from_markdown(parsed, markdown)
+        assert result["workExperience"][0]["years"] == "Jun 2020 - Aug 2021"
+
+    def test_restores_single_date(self):
+        parsed = {"education": [{"degree": "BS", "years": "2023"}]}
+        markdown = "B.S. Computer Science, Jun 2023"
+        result = restore_dates_from_markdown(parsed, markdown)
+        assert result["education"][0]["years"] == "Jun 2023"
+
+    def test_leaves_entries_that_already_have_months(self):
+        parsed = {"workExperience": [{"years": "Jan 2020 - Mar 2021"}]}
+        markdown = "Jun 2020 - Aug 2021"  # same years, different months
+        result = restore_dates_from_markdown(parsed, markdown)
+        # Already month-precise → must NOT be overwritten.
+        assert result["workExperience"][0]["years"] == "Jan 2020 - Mar 2021"
+
+    def test_no_markdown_dates_is_noop(self):
+        parsed = {"workExperience": [{"years": "2020 - 2021"}]}
+        result = restore_dates_from_markdown(parsed, "no dates here at all")
+        assert result["workExperience"][0]["years"] == "2020 - 2021"
+
+    def test_no_matching_year_key_is_noop(self):
+        parsed = {"workExperience": [{"years": "2019 - 2020"}]}
+        markdown = "Jun 2021 - Aug 2022"  # different years → no match
+        result = restore_dates_from_markdown(parsed, markdown)
+        assert result["workExperience"][0]["years"] == "2019 - 2020"
+
+    def test_restores_in_custom_item_list_sections(self):
+        parsed = {
+            "customSections": {
+                "volunteering": {
+                    "sectionType": "itemList",
+                    "items": [{"name": "Mentor", "years": "2020 - 2021"}],
+                }
+            }
+        }
+        markdown = "Mentor, Jun 2020 - Aug 2021"
+        result = restore_dates_from_markdown(parsed, markdown)
+        assert result["customSections"]["volunteering"]["items"][0]["years"] == "Jun 2020 - Aug 2021"
+
+    def test_tolerates_missing_sections(self):
+        # Should not raise on a minimal/odd structure.
+        parsed = {"personalInfo": {"name": "X"}}
+        assert restore_dates_from_markdown(parsed, "Jun 2020 - Aug 2021") == parsed
+
+    def test_skips_non_dict_entries(self):
+        parsed = {"workExperience": ["not a dict", {"years": "2020 - 2021"}]}
+        markdown = "Jun 2020 - Aug 2021"
+        result = restore_dates_from_markdown(parsed, markdown)
+        assert result["workExperience"][1]["years"] == "Jun 2020 - Aug 2021"

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -177,7 +177,15 @@ Backend must run separately on :8000 (see root CLAUDE.md). Frontend proxies `/ap
 
 ## Testing
 
-`vitest` (jsdom) + Testing Library. Config `vitest.config.ts`, setup `vitest.setup.ts`. Existing specs: `tests/diff-preview-modal.test.tsx`, `tests/download-utils.test.ts`, `tests/regenerate-wizard.test.tsx`. Run with `npm run test`. (Per project norms, do not add or run tests unless asked.)
+`vitest` (jsdom) + Testing Library. Config `vitest.config.ts`, setup `vitest.setup.ts` (auto-cleanup). Run `npm run test` (or `./node_modules/.bin/vitest run`). **Tests are in scope** (see [testing-strategy.md](../../docs/agent/testing-strategy.md)); keep them deterministic and anti-theater (a test must fail when its target breaks).
+
+Specs (`tests/`):
+- **i18n** — `i18n-utils.test.ts` (`getNestedValue` dot-path + `applyParams` substitution), `i18n-locale-parity.test.ts` (every `messages/*.json` must structurally match `en.json` — the in-suite guard for the build break).
+- **lib/utils** — `keyword-matcher.test.ts`, `section-helpers.test.ts`, `html-sanitizer.test.ts` (XSS whitelist), `download-utils.test.ts`.
+- **lib/api** — `api-client.test.ts` (URL resolution, timeout/AbortError; `fetch` stubbed).
+- **components** — `diff-preview-modal.test.tsx`, `regenerate-wizard.test.tsx`.
+
+Pure logic (i18n, utils, api) is tested directly with stubbed `fetch`/`t`; component specs render via Testing Library. The locale-parity spec mirrors `scripts/check_locale_parity.py` (which the pre-push hook also runs without Node). The local `pre-push` gate runs this vitest suite too when Node is available — `git config core.hooksPath .githooks`; see [`.githooks/README.md`](../../.githooks/README.md).
 
 ---
 

--- a/apps/frontend/tests/api-client.test.ts
+++ b/apps/frontend/tests/api-client.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { API_BASE, apiFetch, apiPost, getUploadUrl } from '@/lib/api/client';
+
+/**
+ * The single backend client. Tests cover URL resolution, JSON POST shape, and
+ * the timeout → friendly-message behavior (240s matches the backend wait_for).
+ * `fetch` is stubbed so nothing hits the network.
+ */
+
+describe('api client', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('API_BASE / getUploadUrl', () => {
+    it('defaults to /api/v1 in the browser env', () => {
+      expect(API_BASE).toBe('/api/v1');
+      expect(getUploadUrl()).toBe('/api/v1/resumes/upload');
+    });
+  });
+
+  describe('apiFetch URL resolution', () => {
+    it('prefixes a relative endpoint with API_BASE and passes an abort signal', async () => {
+      await apiFetch('/health');
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/health',
+        expect.objectContaining({ signal: expect.anything() })
+      );
+    });
+
+    it('adds a leading slash to a bare endpoint', async () => {
+      await apiFetch('health');
+      expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/health');
+    });
+
+    it('passes absolute URLs through untouched', async () => {
+      await apiFetch('https://example.com/x');
+      expect(fetchMock.mock.calls[0][0]).toBe('https://example.com/x');
+    });
+  });
+
+  describe('apiPost', () => {
+    it('sends a JSON body with POST + Content-Type', async () => {
+      await apiPost('/jobs/upload', { job_descriptions: ['x'] });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/v1/jobs/upload');
+      expect(init.method).toBe('POST');
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+      expect(init.body).toBe(JSON.stringify({ job_descriptions: ['x'] }));
+    });
+  });
+
+  describe('timeout / error handling', () => {
+    it('maps an AbortError to a friendly timeout message', async () => {
+      const abortErr = new Error('aborted');
+      abortErr.name = 'AbortError';
+      fetchMock.mockRejectedValueOnce(abortErr);
+      await expect(apiFetch('/slow')).rejects.toThrow(/timed out/i);
+    });
+
+    it('rethrows non-abort errors unchanged', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('network boom'));
+      await expect(apiFetch('/x')).rejects.toThrow('network boom');
+    });
+
+    it('aborts after the timeout and reports a timeout error', async () => {
+      vi.useFakeTimers();
+      try {
+        fetchMock.mockImplementation((_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => {
+              const e = new Error('The operation was aborted');
+              e.name = 'AbortError';
+              reject(e);
+            });
+          })
+        );
+        const promise = apiFetch('/slow', undefined, 5000);
+        const expectation = expect(promise).rejects.toThrow(/timed out/i);
+        await vi.advanceTimersByTimeAsync(5000);
+        await expectation;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/apps/frontend/tests/api-config.test.ts
+++ b/apps/frontend/tests/api-config.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  FeaturePromptsError,
+  PROVIDER_INFO,
+  updateFeaturePrompts,
+  type LLMProvider,
+} from '@/lib/api/config';
+
+/**
+ * Config-layer contracts: the provider table must stay in sync with the
+ * LLMProvider union, and the feature-prompts 422 path must surface the
+ * backend's structured `missing_placeholders` error as a typed exception.
+ */
+
+const ALL_PROVIDERS: LLMProvider[] = [
+  'openai',
+  'openai_compatible',
+  'anthropic',
+  'openrouter',
+  'gemini',
+  'deepseek',
+  'groq',
+  'ollama',
+];
+
+describe('PROVIDER_INFO', () => {
+  it('has a complete entry for every supported provider', () => {
+    for (const provider of ALL_PROVIDERS) {
+      const info = PROVIDER_INFO[provider];
+      expect(info, `missing PROVIDER_INFO for ${provider}`).toBeDefined();
+      expect(info.name.length).toBeGreaterThan(0);
+      expect(info.defaultModel.length).toBeGreaterThan(0);
+      expect(typeof info.requiresKey).toBe('boolean');
+    }
+  });
+
+  it('marks only local providers as not requiring a key', () => {
+    expect(PROVIDER_INFO.ollama.requiresKey).toBe(false);
+    expect(PROVIDER_INFO.openai_compatible.requiresKey).toBe(false);
+    expect(PROVIDER_INFO.openai.requiresKey).toBe(true);
+    expect(PROVIDER_INFO.anthropic.requiresKey).toBe(true);
+  });
+});
+
+describe('FeaturePromptsError', () => {
+  it('is an Error carrying the structured validation detail', () => {
+    const detail = {
+      code: 'missing_placeholders' as const,
+      field: 'cover_letter_prompt' as const,
+      missing: ['{resume_data}', '{output_language}'],
+    };
+    const err = new FeaturePromptsError(detail);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('FeaturePromptsError');
+    expect(err.detail).toEqual(detail);
+    expect(err.message).toContain('cover_letter_prompt');
+    expect(err.message).toContain('{resume_data}');
+  });
+});
+
+describe('updateFeaturePrompts error mapping', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('throws FeaturePromptsError on a 422 missing_placeholders response', async () => {
+    const detail = {
+      code: 'missing_placeholders',
+      field: 'cover_letter_prompt',
+      missing: ['{resume_data}'],
+    };
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ detail }), { status: 422 }));
+    await expect(updateFeaturePrompts({ cover_letter_prompt: 'bad' })).rejects.toBeInstanceOf(
+      FeaturePromptsError
+    );
+  });
+
+  it('throws a generic Error with the string detail on other failures', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ detail: 'server boom' }), { status: 500 }));
+    await expect(updateFeaturePrompts({ cover_letter_prompt: 'x' })).rejects.toThrow('server boom');
+  });
+
+  it('returns the parsed prompts on success', async () => {
+    const prompts = {
+      cover_letter_prompt: 'a',
+      outreach_message_prompt: 'b',
+      cover_letter_default: '',
+      outreach_message_default: '',
+    };
+    fetchMock.mockResolvedValue(new Response(JSON.stringify(prompts), { status: 200 }));
+    await expect(updateFeaturePrompts({ cover_letter_prompt: 'a' })).resolves.toEqual(prompts);
+  });
+});

--- a/apps/frontend/tests/html-sanitizer.test.ts
+++ b/apps/frontend/tests/html-sanitizer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeHtml } from '@/lib/utils/html-sanitizer';
+
+/**
+ * sanitizeHtml guards every `dangerouslySetInnerHTML` sink (rich-text bullets,
+ * LLM output). Whitelist: strong/em/u/a + href/target/rel. Anything else must go.
+ */
+
+describe('sanitizeHtml', () => {
+  it('keeps whitelisted formatting tags', () => {
+    const out = sanitizeHtml('<strong>bold</strong> <em>italic</em> <u>under</u>');
+    expect(out).toContain('<strong>bold</strong>');
+    expect(out).toContain('<em>italic</em>');
+    expect(out).toContain('<u>under</u>');
+  });
+
+  it('keeps anchor href', () => {
+    const out = sanitizeHtml('<a href="https://example.com">link</a>');
+    expect(out).toContain('href="https://example.com"');
+    expect(out).toContain('link');
+  });
+
+  it('strips <script> entirely (tag + content)', () => {
+    const out = sanitizeHtml('<script>alert(1)</script>safe');
+    expect(out).not.toContain('script');
+    expect(out).not.toContain('alert');
+    expect(out).toContain('safe');
+  });
+
+  it('strips event-handler attributes but keeps the element text', () => {
+    const out = sanitizeHtml('<a href="https://x.com" onclick="evil()">click</a>');
+    expect(out).not.toContain('onclick');
+    expect(out).toContain('click');
+  });
+
+  it('removes a non-whitelisted tag while keeping its text', () => {
+    const out = sanitizeHtml('<div>plain text</div>');
+    expect(out).not.toContain('<div>');
+    expect(out).toContain('plain text');
+  });
+
+  it('drops dangerous tags like <img onerror>', () => {
+    const out = sanitizeHtml('<img src=x onerror="alert(1)">');
+    expect(out).not.toContain('img');
+    expect(out).not.toContain('onerror');
+  });
+});

--- a/apps/frontend/tests/i18n-locale-parity.test.ts
+++ b/apps/frontend/tests/i18n-locale-parity.test.ts
@@ -19,35 +19,50 @@ import { locales, type Locale } from '@/i18n/config';
  * the pre-push hook runs without Node).
  */
 
-function keyPaths(obj: unknown, prefix = ''): string[] {
-  if (!obj || typeof obj !== 'object') return [];
-  const out: string[] = [];
+type Kind = 'branch' | 'leaf';
+
+function keyKinds(obj: unknown, prefix = '', out: Map<string, Kind> = new Map()): Map<string, Kind> {
+  if (!obj || typeof obj !== 'object') return out;
   for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
     const path = prefix ? `${prefix}.${key}` : key;
-    out.push(path);
-    out.push(...keyPaths(val, path));
+    const isBranch = !!val && typeof val === 'object';
+    out.set(path, isBranch ? 'branch' : 'leaf');
+    if (isBranch) keyKinds(val, path, out);
   }
   return out;
 }
 
-const REFERENCE = keyPaths(en).sort();
-const refSet = new Set(REFERENCE);
+const REFERENCE = keyKinds(en);
 const LOCALES: Record<string, unknown> = { es, zh, ja, pt };
 
 describe('i18n locale parity (guards the next build break)', () => {
   it.each(Object.keys(LOCALES))('%s.json matches en.json key structure exactly', (name) => {
-    const keys = keyPaths(LOCALES[name]).sort();
-    const keySet = new Set(keys);
-    const missing = REFERENCE.filter((k) => !keySet.has(k));
-    const extra = keys.filter((k) => !refSet.has(k));
-    // Missing keys are build-breaking; extra keys are drift. Locales should be identical.
+    const localeKinds = keyKinds(LOCALES[name]);
+    const missing = [...REFERENCE.keys()].filter((k) => !localeKinds.has(k));
+    const extra = [...localeKinds.keys()].filter((k) => !REFERENCE.has(k));
+    // A key present in BOTH but with a different shape (object vs string) keeps
+    // the path present yet still breaks `next build` — a presence-only check
+    // misses it. Compare the node KIND, not just the key path.
+    const mismatched = [...REFERENCE.keys()].filter(
+      (k) => localeKinds.has(k) && localeKinds.get(k) !== REFERENCE.get(k)
+    );
     expect(missing, `${name}.json is MISSING keys present in en.json`).toEqual([]);
+    expect(mismatched, `${name}.json has keys whose SHAPE differs from en.json`).toEqual([]);
     expect(extra, `${name}.json has EXTRA keys not in en.json`).toEqual([]);
   });
 
   it('reference (en.json) has a non-trivial number of keys', () => {
     // Guards against the check silently passing on an empty/garbled reference.
-    expect(REFERENCE.length).toBeGreaterThan(20);
+    expect(REFERENCE.size).toBeGreaterThan(20);
+  });
+
+  it('detects a leaf-vs-object shape mismatch, not just missing keys', () => {
+    // Proves the kind-aware comparison fires on the exact gap a presence-only
+    // set-diff would let through (cubic review, PR #820).
+    const ref = keyKinds({ a: { b: 'str' } });
+    const bad = keyKinds({ a: { b: { c: 'deep' } } }); // a.b is an object here
+    const mismatched = [...ref.keys()].filter((k) => bad.has(k) && bad.get(k) !== ref.get(k));
+    expect(mismatched).toContain('a.b');
   });
 });
 

--- a/apps/frontend/tests/i18n-locale-parity.test.ts
+++ b/apps/frontend/tests/i18n-locale-parity.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '@/messages/en.json';
+import es from '@/messages/es.json';
+import zh from '@/messages/zh.json';
+import ja from '@/messages/ja.json';
+import pt from '@/messages/pt-BR.json';
+
+import { getMessages } from '@/lib/i18n/messages';
+import { locales, type Locale } from '@/i18n/config';
+
+/**
+ * `lib/i18n/messages.ts` declares `type Messages = typeof en` and
+ * `Record<Locale, Messages>`, so every locale JSON must structurally match
+ * en.json — a *missing* key makes `tsc` / `next build` fail. That exact drift
+ * once shipped to main and only surfaced post-merge in the Docker build.
+ *
+ * This catches it in-suite (and mirrors scripts/check_locale_parity.py, which
+ * the pre-push hook runs without Node).
+ */
+
+function keyPaths(obj: unknown, prefix = ''): string[] {
+  if (!obj || typeof obj !== 'object') return [];
+  const out: string[] = [];
+  for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    out.push(path);
+    out.push(...keyPaths(val, path));
+  }
+  return out;
+}
+
+const REFERENCE = keyPaths(en).sort();
+const refSet = new Set(REFERENCE);
+const LOCALES: Record<string, unknown> = { es, zh, ja, pt };
+
+describe('i18n locale parity (guards the next build break)', () => {
+  it.each(Object.keys(LOCALES))('%s.json matches en.json key structure exactly', (name) => {
+    const keys = keyPaths(LOCALES[name]).sort();
+    const keySet = new Set(keys);
+    const missing = REFERENCE.filter((k) => !keySet.has(k));
+    const extra = keys.filter((k) => !refSet.has(k));
+    // Missing keys are build-breaking; extra keys are drift. Locales should be identical.
+    expect(missing, `${name}.json is MISSING keys present in en.json`).toEqual([]);
+    expect(extra, `${name}.json has EXTRA keys not in en.json`).toEqual([]);
+  });
+
+  it('reference (en.json) has a non-trivial number of keys', () => {
+    // Guards against the check silently passing on an empty/garbled reference.
+    expect(REFERENCE.length).toBeGreaterThan(20);
+  });
+});
+
+describe('getMessages', () => {
+  it('resolves every locale declared in i18n/config to a populated object', () => {
+    for (const locale of locales) {
+      const msgs = getMessages(locale) as Record<string, unknown>;
+      expect(Object.keys(msgs).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('falls back to en for an unknown locale', () => {
+    expect(getMessages('xx' as unknown as Locale)).toBe(getMessages('en'));
+  });
+});

--- a/apps/frontend/tests/i18n-locale-parity.test.ts
+++ b/apps/frontend/tests/i18n-locale-parity.test.ts
@@ -19,15 +19,23 @@ import { locales, type Locale } from '@/i18n/config';
  * the pre-push hook runs without Node).
  */
 
-type Kind = 'branch' | 'leaf';
+// Classify a JSON value by the type `typeof en` infers (object/array/string/…).
+// Note arrays and null are `typeof === 'object'` in JS, so they must be handled
+// before the generic object case — this keeps the classification in lock-step
+// with scripts/check_locale_parity.py (where lists/None are NOT objects).
+function nodeKind(v: unknown): string {
+  if (Array.isArray(v)) return 'array';
+  if (v === null) return 'null';
+  if (typeof v === 'object') return 'object';
+  return typeof v; // 'string' | 'number' | 'boolean'
+}
 
-function keyKinds(obj: unknown, prefix = '', out: Map<string, Kind> = new Map()): Map<string, Kind> {
-  if (!obj || typeof obj !== 'object') return out;
+function keyKinds(obj: unknown, prefix = '', out: Map<string, string> = new Map()): Map<string, string> {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return out;
   for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
     const path = prefix ? `${prefix}.${key}` : key;
-    const isBranch = !!val && typeof val === 'object';
-    out.set(path, isBranch ? 'branch' : 'leaf');
-    if (isBranch) keyKinds(val, path, out);
+    out.set(path, nodeKind(val));
+    if (val && typeof val === 'object' && !Array.isArray(val)) keyKinds(val, path, out);
   }
   return out;
 }
@@ -56,13 +64,16 @@ describe('i18n locale parity (guards the next build break)', () => {
     expect(REFERENCE.size).toBeGreaterThan(20);
   });
 
-  it('detects a leaf-vs-object shape mismatch, not just missing keys', () => {
-    // Proves the kind-aware comparison fires on the exact gap a presence-only
-    // set-diff would let through (cubic review, PR #820).
+  it('detects shape mismatches by JSON type (object / number / array vs string)', () => {
+    // Proves the kind-aware comparison fires on the exact gaps a presence-only
+    // set-diff would let through (cubic review, PR #820) — including primitive
+    // and array mismatches, not just object-vs-string.
     const ref = keyKinds({ a: { b: 'str' } });
-    const bad = keyKinds({ a: { b: { c: 'deep' } } }); // a.b is an object here
-    const mismatched = [...ref.keys()].filter((k) => bad.has(k) && bad.get(k) !== ref.get(k));
-    expect(mismatched).toContain('a.b');
+    const diff = (other: Map<string, string>) =>
+      [...ref.keys()].filter((k) => other.has(k) && other.get(k) !== ref.get(k));
+    expect(diff(keyKinds({ a: { b: { c: 'deep' } } }))).toContain('a.b'); // object
+    expect(diff(keyKinds({ a: { b: 5 } }))).toContain('a.b'); // number
+    expect(diff(keyKinds({ a: { b: ['x'] } }))).toContain('a.b'); // array
   });
 });
 

--- a/apps/frontend/tests/i18n-server.test.ts
+++ b/apps/frontend/tests/i18n-server.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { translate } from '@/lib/i18n/server';
+import { getMessages } from '@/lib/i18n/messages';
+import type { Locale } from '@/i18n/config';
+
+/**
+ * `translate()` is the server-side i18n entry used by the print/* pages that
+ * headless Chromium renders into PDFs. It composes getMessages + getNestedValue
+ * + applyParams, so these tests pin that composition end-to-end.
+ */
+
+function firstStringLeaf(
+  obj: Record<string, unknown>,
+  prefix: string
+): { path: string; value: string } | null {
+  for (const [key, val] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof val === 'string') return { path, value: val };
+    if (val && typeof val === 'object') {
+      const found = firstStringLeaf(val as Record<string, unknown>, path);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+const leaf = firstStringLeaf(getMessages('en') as unknown as Record<string, unknown>, '')!;
+
+describe('translate (server-side)', () => {
+  it('resolves a real key in the requested locale', () => {
+    expect(translate('en', leaf.path)).toBe(leaf.value);
+  });
+
+  it('returns the key itself when missing', () => {
+    expect(translate('en', 'totally.missing.key')).toBe('totally.missing.key');
+  });
+
+  it('falls back to en for an unknown locale', () => {
+    expect(translate('xx' as unknown as Locale, leaf.path)).toBe(translate('en', leaf.path));
+  });
+
+  it('composes lookup + param substitution (missing path still gets params applied)', () => {
+    // getNestedValue returns the raw path 'nope.{n}', then applyParams fills {n}.
+    expect(translate('en', 'nope.{n}', { n: 5 })).toBe('nope.5');
+  });
+});

--- a/apps/frontend/tests/i18n-utils.test.ts
+++ b/apps/frontend/tests/i18n-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { applyParams, getNestedValue } from '@/lib/i18n/utils';
+import { getMessages } from '@/lib/i18n/messages';
+
+/**
+ * The translation engine (useTranslations / translate) is a thin wrapper over
+ * these two pure functions. They decide what a missing key does and how
+ * {placeholder} substitution works — the behavior every `t('a.b.c')` relies on.
+ */
+
+function firstStringLeaf(
+  obj: Record<string, unknown>,
+  prefix: string
+): { path: string; value: string } | null {
+  for (const [key, val] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof val === 'string') return { path, value: val };
+    if (val && typeof val === 'object') {
+      const found = firstStringLeaf(val as Record<string, unknown>, path);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+describe('getNestedValue', () => {
+  const tree = {
+    common: { save: 'Save', nested: { deep: 'Deep value' } },
+    count: 3,
+  };
+
+  it('resolves a top-level string key', () => {
+    expect(getNestedValue({ hello: 'world' }, 'hello')).toBe('world');
+  });
+
+  it('resolves a nested dot path', () => {
+    expect(getNestedValue(tree, 'common.save')).toBe('Save');
+    expect(getNestedValue(tree, 'common.nested.deep')).toBe('Deep value');
+  });
+
+  it('returns the key itself when a segment is missing (no throw)', () => {
+    // This is the contract: a missing translation renders the raw key, never crashes.
+    expect(getNestedValue(tree, 'common.missing')).toBe('common.missing');
+    expect(getNestedValue(tree, 'does.not.exist')).toBe('does.not.exist');
+  });
+
+  it('returns the path when it resolves to a non-string (object/number)', () => {
+    expect(getNestedValue(tree, 'common')).toBe('common'); // object, not a leaf string
+    expect(getNestedValue(tree, 'count')).toBe('count'); // number, not a string
+  });
+
+  it('round-trips a real nested leaf from the bundled en messages', () => {
+    const en = getMessages('en') as unknown as Record<string, unknown>;
+    const leaf = firstStringLeaf(en, '');
+    expect(leaf).not.toBeNull();
+    // The real message tree resolves an actual leaf path to its string value.
+    expect(getNestedValue(en, leaf!.path)).toBe(leaf!.value);
+  });
+});
+
+describe('applyParams', () => {
+  it('returns the value unchanged when no params are given', () => {
+    expect(applyParams('Hello {name}')).toBe('Hello {name}');
+  });
+
+  it('substitutes a single placeholder', () => {
+    expect(applyParams('Hello {name}', { name: 'Ada' })).toBe('Hello Ada');
+  });
+
+  it('substitutes multiple placeholders', () => {
+    expect(applyParams('{greeting}, {name}!', { greeting: 'Hi', name: 'Ada' })).toBe('Hi, Ada!');
+  });
+
+  it('coerces numeric params to strings', () => {
+    expect(applyParams('{count} items', { count: 5 })).toBe('5 items');
+  });
+
+  it('leaves unknown placeholders untouched', () => {
+    expect(applyParams('Hello {name}', { other: 'x' })).toBe('Hello {name}');
+  });
+
+  it('leaves a string with no placeholders unchanged', () => {
+    expect(applyParams('Just text', { name: 'Ada' })).toBe('Just text');
+  });
+});

--- a/apps/frontend/tests/keyword-matcher.test.ts
+++ b/apps/frontend/tests/keyword-matcher.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateMatchStats,
+  extractKeywords,
+  segmentTextByKeywords,
+} from '@/lib/utils/keyword-matcher';
+
+/**
+ * Pure JD↔resume keyword logic that drives the match highlighting / stats in
+ * the tailor view. Deterministic, no DOM.
+ */
+
+describe('extractKeywords', () => {
+  it('lowercases and keeps significant words', () => {
+    const kw = extractKeywords('Senior Python Engineer with FastAPI');
+    expect(kw.has('python')).toBe(true);
+    expect(kw.has('fastapi')).toBe(true);
+    expect(kw.has('engineer')).toBe(true);
+  });
+
+  it('drops stop words (incl. job-posting filler) and short words', () => {
+    const kw = extractKeywords('the and with of go ai');
+    expect(kw.has('the')).toBe(false);
+    expect(kw.has('with')).toBe(false);
+    expect(kw.has('go')).toBe(false); // < 3 chars
+    expect(kw.has('ai')).toBe(false); // < 3 chars
+  });
+
+  it('drops pure numbers but keeps alphanumerics', () => {
+    const kw = extractKeywords('5 years 2024 k8s');
+    expect(kw.has('5')).toBe(false);
+    expect(kw.has('2024')).toBe(false);
+    expect(kw.has('years')).toBe(false); // stop word
+    expect(kw.has('k8s')).toBe(true); // alphanumeric kept
+  });
+
+  it('deduplicates via a Set', () => {
+    const kw = extractKeywords('Docker docker DOCKER');
+    expect([...kw]).toEqual(['docker']);
+  });
+
+  it('returns an empty set when everything is filtered', () => {
+    expect(extractKeywords('5 years of experience').size).toBe(0);
+  });
+});
+
+describe('segmentTextByKeywords', () => {
+  it('marks only the matching words, preserving original text + spacing', () => {
+    const segments = segmentTextByKeywords('Python and Go', new Set(['python']));
+    expect(segments.map((s) => s.text).join('')).toBe('Python and Go'); // lossless
+    const matched = segments.filter((s) => s.isMatch).map((s) => s.text);
+    expect(matched).toEqual(['Python']); // case-insensitive match, original casing kept
+  });
+
+  it('matches nothing when there are no keywords', () => {
+    const segments = segmentTextByKeywords('Python FastAPI', new Set());
+    expect(segments.some((s) => s.isMatch)).toBe(false);
+  });
+});
+
+describe('calculateMatchStats', () => {
+  it('counts matched JD keywords against the resume and rounds the percentage', () => {
+    const stats = calculateMatchStats('Python FastAPI Docker', new Set(['python', 'kubernetes']));
+    expect(stats.matchCount).toBe(1);
+    expect(stats.totalKeywords).toBe(2);
+    expect(stats.matchPercentage).toBe(50);
+    expect([...stats.matchedKeywords]).toEqual(['python']);
+  });
+
+  it('reports 0% (no divide-by-zero) when the JD has no keywords', () => {
+    const stats = calculateMatchStats('Python', new Set());
+    expect(stats.matchPercentage).toBe(0);
+    expect(stats.matchCount).toBe(0);
+  });
+});

--- a/apps/frontend/tests/section-helpers.test.ts
+++ b/apps/frontend/tests/section-helpers.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ResumeData,
+  SectionMeta,
+} from '@/components/dashboard/resume-component';
+import {
+  DEFAULT_SECTION_META,
+  createCustomSection,
+  generateCustomSectionId,
+  getAllSections,
+  getSectionMeta,
+  getSortedSections,
+  localizeDefaultSectionMeta,
+  withLocalizedDefaultSections,
+} from '@/lib/utils/section-helpers';
+
+/** Pure resume-section metadata logic (ordering, custom IDs, localization). */
+
+function meta(overrides: Partial<SectionMeta>): SectionMeta {
+  return {
+    id: 'x',
+    key: 'x',
+    displayName: 'X',
+    sectionType: 'text',
+    isDefault: false,
+    isVisible: true,
+    order: 0,
+    ...overrides,
+  } as SectionMeta;
+}
+
+function resume(sectionMeta?: SectionMeta[]): ResumeData {
+  return { sectionMeta } as unknown as ResumeData;
+}
+
+describe('getSectionMeta', () => {
+  it('returns the resume sectionMeta when present', () => {
+    const sm = [meta({ id: 'a' })];
+    expect(getSectionMeta(resume(sm))).toBe(sm);
+  });
+
+  it('falls back to DEFAULT_SECTION_META when missing or empty', () => {
+    expect(getSectionMeta(resume(undefined))).toBe(DEFAULT_SECTION_META);
+    expect(getSectionMeta(resume([]))).toBe(DEFAULT_SECTION_META);
+  });
+});
+
+describe('getSortedSections', () => {
+  it('keeps only visible sections, sorted by order', () => {
+    const sm = [
+      meta({ id: 'c', order: 2, isVisible: true }),
+      meta({ id: 'a', order: 0, isVisible: true }),
+      meta({ id: 'hidden', order: 1, isVisible: false }),
+    ];
+    expect(getSortedSections(resume(sm)).map((s) => s.id)).toEqual(['a', 'c']);
+  });
+});
+
+describe('getAllSections', () => {
+  it('includes hidden sections, sorted by order', () => {
+    const sm = [
+      meta({ id: 'b', order: 1, isVisible: false }),
+      meta({ id: 'a', order: 0, isVisible: true }),
+    ];
+    expect(getAllSections(resume(sm)).map((s) => s.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('generateCustomSectionId', () => {
+  it('starts at custom_1 when none exist', () => {
+    expect(generateCustomSectionId([])).toBe('custom_1');
+    expect(generateCustomSectionId([meta({ id: 'summary' })])).toBe('custom_1');
+  });
+
+  it('increments past the highest existing custom id', () => {
+    const sections = [meta({ id: 'custom_1' }), meta({ id: 'custom_3' })];
+    expect(generateCustomSectionId(sections)).toBe('custom_4');
+  });
+});
+
+describe('createCustomSection', () => {
+  it('creates a non-default visible section after the last order', () => {
+    const existing = [meta({ id: 'summary', order: 5 })];
+    const created = createCustomSection(existing, 'Volunteering', 'itemList');
+    expect(created.id).toBe('custom_1');
+    expect(created.displayName).toBe('Volunteering');
+    expect(created.sectionType).toBe('itemList');
+    expect(created.isDefault).toBe(false);
+    expect(created.isVisible).toBe(true);
+    expect(created.order).toBe(6); // maxOrder + 1
+  });
+});
+
+describe('localizeDefaultSectionMeta', () => {
+  const t = (key: string) => `t:${key}`;
+
+  it('localizes a default section whose name is still the English default', () => {
+    const out = localizeDefaultSectionMeta([meta({ id: 'summary', displayName: 'Summary', isDefault: true })], t);
+    expect(out[0].displayName).toBe('t:resume.sections.summary');
+  });
+
+  it('leaves a renamed default section untouched', () => {
+    const out = localizeDefaultSectionMeta([meta({ id: 'summary', displayName: 'My Story', isDefault: true })], t);
+    expect(out[0].displayName).toBe('My Story');
+  });
+
+  it('leaves non-default (custom) sections untouched', () => {
+    const out = localizeDefaultSectionMeta([meta({ id: 'custom_1', displayName: 'Summary', isDefault: false })], t);
+    expect(out[0].displayName).toBe('Summary');
+  });
+});
+
+describe('withLocalizedDefaultSections', () => {
+  const t = (key: string) => `t:${key}`;
+
+  it('generates localized defaults when the resume has no sectionMeta', () => {
+    const out = withLocalizedDefaultSections(resume(undefined), t);
+    expect(out.sectionMeta).toHaveLength(DEFAULT_SECTION_META.length);
+    const summary = out.sectionMeta!.find((s) => s.id === 'summary');
+    expect(summary!.displayName).toBe('t:resume.sections.summary');
+  });
+});

--- a/docs/agent/testing-strategy.md
+++ b/docs/agent/testing-strategy.md
@@ -1,7 +1,7 @@
 # Testing Strategy & Verification Plan
 
 > **Status:** Living document. Started 2026-05-30 on branch `test/backend-coverage-foundation` (base: `dev`).
-> **Scope of phase 1:** Backend (`apps/backend`). Frontend and CI follow in later, separately-agreed phases.
+> **Scope:** Backend (`apps/backend`, Phases 1–6) **and** frontend (`apps/frontend`, vitest — §8). Gating is a local `pre-push` hook, not PR CI.
 > **Why this exists:** We shipped a build break that no automation caught, users report "Ollama doesn't work" and "resume won't render," and we had no evidence-based read on whether our tests are real or theater. This doc is the resumable record of the assessment and the plan.
 
 ---
@@ -176,8 +176,25 @@ uv run pytest tests/unit/test_parser.py -q
 
 ---
 
-## 8. Open questions / future
+## 8. Frontend test suite
 
-- Frontend: add a locale-parity test (every `messages/*.json` structurally matches `en.json`) — this *exactly* reproduces and prevents the build break that started this effort. Belongs to the frontend phase.
-- Decide coverage floors per module once Phase 1–4 land (avoid a single global % that hides the I/O gaps).
-- When CI lands, structural evals run in-gate; LLM-judge evals run nightly with a repo secret or skip.
+`apps/frontend` uses **vitest + Testing Library (jsdom)** — run `npm run test` (or `./node_modules/.bin/vitest run`). The same rigor as the backend was applied: assess what existed (a green 65-test suite over `download-utils` + two components), then cover the highest-value untested logic.
+
+Added (`apps/frontend/tests/`):
+- `i18n-utils.test.ts` — the `t()` engine (`getNestedValue` dot-path + missing-key fallback, `applyParams` substitution).
+- `i18n-locale-parity.test.ts` — **in-suite guard for the build break**: every `messages/*.json` must structurally match `en.json` (mirrors `scripts/check_locale_parity.py`). Verified anti-theater (adding a key to `en.json` fails all four locales).
+- `keyword-matcher.test.ts` — JD↔resume keyword extract/segment/match-stats.
+- `section-helpers.test.ts` — section ordering, custom-section IDs, localize-only-untouched-defaults.
+- `html-sanitizer.test.ts` — the DOMPurify XSS whitelist (`strong/em/u/a`).
+- `api-client.test.ts` — `lib/api/client` URL resolution + timeout/AbortError (`fetch` stubbed).
+
+Net: **65 → 117 frontend tests**, all green. The `pre-push` gate runs this suite when Node is available; a full `tsc`/`next build` gate remains future work (nvm-in-hook fragility).
+
+---
+
+## 9. Open questions / future
+
+- ✅ ~~Frontend locale-parity test~~ — done (`i18n-locale-parity.test.ts` + the hook's `scripts/check_locale_parity.py`).
+- Decide coverage floors per module once the I/O surface is broadly covered (avoid a single global % that hides gaps).
+- A Node-aware `tsc`/`next build` gate (catches TS errors beyond locale drift) — deferred; needs reliable node-in-hook.
+- If GitHub Actions is ever reconsidered, run it on push to `dev`/`main` only (not on PRs).

--- a/docs/agent/testing-strategy.md
+++ b/docs/agent/testing-strategy.md
@@ -118,21 +118,24 @@ Legend: ✅ done · 🚧 in progress · ⬜ planned
 - ✅ Real-TinyDB `database.py` CRUD tests (`tests/unit/test_database.py`)
 - ✅ Verify: **192 → 265 tests, 1 silent failure → 0, coverage 54% → 58%** (database 34→96%, parser 20→72%, llm 47→55%, health now meaningful). Anti-theater mutation check passed.
 
-**Phase 2 — Transport contract tests (LLM/Ollama)**
-- ⬜ `respx`-backed tests: real `complete` / `complete_json` / `check_llm_health` against a fake Ollama + OpenAI-compatible server (request shape, base-URL handling, thinking-tag stripping, JSON-mode fallback, error-code mapping)
+**Phase 2 — Transport contract tests (LLM/Ollama) ✅ COMPLETE** (`tests/integration/test_llm_contract.py`, 8 tests)
+- ✅ `respx`-backed tests: real `complete` / `complete_json` / `check_llm_health` against a fake Ollama + OpenAI-compatible HTTP server (base-URL handling #751, JSON extraction over the wire, thinking-tag stripping, health error-code mapping + secret scrubbing). Findings: litellm 1.86 defaults to an aiohttp transport respx can't see → tests set `disable_aiohttp_transport`; Ollama makes two calls (`/api/show` probe + `/api/chat`). **`llm.py` 55% → 74%.**
 
-**Phase 3 — Render safety net**
-- ⬜ Playwright PDF smoke test (print route → non-empty valid PDF) + error-path mapping in `pdf.py`
+**Phase 3 — Render safety net ✅ COMPLETE** (`tests/integration/test_pdf_render.py`, 11 tests)
+- ✅ Real headless-Chromium render of a self-contained `data:` URL → asserts genuine `%PDF` bytes; pure-helper tests (format/margins); connection-refused → `PDFRenderError` mapping. Render tests skip cleanly without Chromium. **`pdf.py` 20% → 54%.**
 
-**Phase 4 — End-to-end pipeline**
-- ⬜ One e2e: upload → parse → tailor → render with a mocked LLM, exercising real routers + real DB
+**Phase 4 — End-to-end pipeline ✅ COMPLETE** (`tests/integration/test_pipeline_e2e.py`, 5 tests)
+- ✅ Real routers + real temp DB (`isolated_db`), every LLM boundary mocked: upload → jobs → fetch **and** the preview→confirm tailoring handshake. Asserts real persisted state (master invariant, `parent_id` linkage, `improvements` record). **`resumes.py` 18% → 53%.**
 
-**Phase 5 — Eval harness (structural + LLM-as-judge)**
-- ⬜ Golden fixtures + structural scorers (run in normal suite)
-- ⬜ LLM-as-judge using the **developer's own configured key**, gated/skipped when no key is present; nightly/on-demand only
+**Phase 5 — Eval harness (structural + LLM-as-judge) ✅ COMPLETE** (`tests/evals/`, 31 scorer tests + 1 gated judge)
+- ✅ Pure structural scorers (`sections_preserved`, `no_fabricated_employers`, `jd_keywords_present`, `is_valid_resume`, `personal_info_unchanged`) + golden fixtures, each proven on good AND bad inputs.
+- ✅ LLM-as-judge marked `@pytest.mark.eval`, uses the developer's own configured key, **excluded from the default run** (`addopts -m "not eval"`); run on demand with `uv run pytest -m eval`. Skips cleanly with no key.
 
 **Phase 6 — CI (separate sign-off)**
-- ⬜ GitHub Actions PR gate: backend `pytest`, frontend `tsc`/`build`/lint, structural evals. (Deferred per §7.)
+- ⬜ GitHub Actions PR gate: backend `pytest`, frontend `tsc`/`build`/lint, structural evals. (Deferred per §7 — still needs explicit sign-off.)
+
+### Result after Phases 1–5
+**192 → 320 deterministic tests** (+ 1 opt-in LLM-judge eval), **0 failures**, **coverage 54% → 69%**. Built via parallel subagents (one per phase, strict file ownership) using the `dispatching-parallel-agents` skill; integrated and re-verified together.
 
 ---
 
@@ -141,11 +144,15 @@ Legend: ✅ done · 🚧 in progress · ⬜ planned
 ```bash
 cd apps/backend
 
-# Full suite
+# Full deterministic suite (LLM-judge evals are auto-excluded via addopts -m "not eval")
 uv run pytest
 
-# Quiet + coverage (ephemeral plugin, no pyproject change)
+# Coverage (ephemeral plugin, no pyproject change)
 uv run --with pytest-cov pytest -q --cov=app --cov-report=term-missing
+
+# Prompt-quality evals on demand — structural scorers always run; the LLM-judge
+# runs only when an LLM key is configured (uses the developer's own key), else skips
+uv run pytest -m eval
 
 # One module
 uv run pytest tests/unit/test_parser.py -q

--- a/docs/agent/testing-strategy.md
+++ b/docs/agent/testing-strategy.md
@@ -1,0 +1,173 @@
+# Testing Strategy & Verification Plan
+
+> **Status:** Living document. Started 2026-05-30 on branch `test/backend-coverage-foundation` (base: `dev`).
+> **Scope of phase 1:** Backend (`apps/backend`). Frontend and CI follow in later, separately-agreed phases.
+> **Why this exists:** We shipped a build break that no automation caught, users report "Ollama doesn't work" and "resume won't render," and we had no evidence-based read on whether our tests are real or theater. This doc is the resumable record of the assessment and the plan.
+
+---
+
+## 1. TL;DR
+
+- A real backend test suite already exists: **192 tests**, `pytest` + `pytest-asyncio` + `httpx`. We do **not** need a new framework.
+- When run: **191 pass, 1 fails, 54% line coverage.** The one failure (`test_health_returns_degraded`) is a **stale test**, not a product bug — and the fact it sat red proves the suite is **never run by automation**.
+- Root cause of "the build broke and nobody caught it": **there is no PR-gating CI.** The only workflow is `docker-publish.yml` (build+push on merge to `main`). Nothing runs `pytest`, `tsc`, `next build`, or lint before merge.
+- The tests we have cluster on the **deterministic algorithmic core** (diff engine, schemas) and **mock away the entire I/O surface** (DB, LLM, parser, Playwright). So coverage is real where it exists but absent exactly where users get hurt.
+- Two test types are needed and are **different things**: deterministic tests (plumbing correctness, LLM mocked, run on every change) and **evals** (LLM output quality, real/recorded LLM, run on demand/nightly). We have the first kind only for the core, and zero of the second.
+
+---
+
+## 2. Current-state assessment (evidence)
+
+Run command (no `pyproject.toml` change — ephemeral coverage plugin):
+
+```bash
+cd apps/backend
+uv run --with pytest-cov pytest -q --cov=app --cov-report=term-missing
+# 192 tests · 191 passed · 1 FAILED · 54% coverage · ~6s
+```
+
+### 2.1 The one failure is the canary
+
+`tests/integration/test_health_api.py::test_health_returns_degraded` expects `GET /health` to report `"degraded"` when the LLM is unhealthy. But `app/routers/health.py` was refactored so `/health` is a **pure liveness probe** that never calls the LLM (`return HealthResponse(status="healthy")`); readiness now lives at `GET /status`. The test was never updated. Its sibling `test_health_returns_healthy` *passes for the wrong reason* — it mocks `check_llm_health`, which the endpoint no longer calls, so the mock is dead and the assertion is hollow.
+
+Takeaway: a green checkmark here meant nothing, and a red one went unseen. That is the exact failure mode behind the production incidents.
+
+### 2.2 Coverage map (what's real vs absent)
+
+| Module | Cover | Read |
+|---|---|---|
+| `services/improver.py` (diff engine) | 84% | ✅ Genuinely strong — path resolution, apply/verify diffs, skill gating |
+| `schemas/models.py` | 88% | ✅ Real |
+| `services/refiner.py` | 72% | ✅ Decent |
+| `routers/config.py` | 53% | 🟡 Contract-level only |
+| `llm.py` | 47% | 🟡 Pure helpers tested; **real request + `check_llm_health` + Ollama paths NOT** |
+| `routers/enrichment.py` | 38% | 🟡 Regenerate matching tested; rest mocked |
+| `config_cache.py` | 38% | 🔴 |
+| `database.py` (TinyDB) | 34% | 🔴 Real DB never exercised — every integration test mocks `db` |
+| `services/cover_letter.py` | 26% | 🔴 Untested |
+| `services/parser.py` | 20% | 🔴 Upload→markdown→JSON untested; even the pure date-restore is uncovered |
+| `pdf.py` (render) | 20% | 🔴 The "resume won't render" class |
+| `routers/resumes.py` | 18% | 🔴 Biggest file (1,796 LOC): tailor + PDF + CRUD — almost entirely untested |
+
+### 2.3 The structural truth about the integration tests
+
+Every `tests/integration/*` test patches `app.routers.<x>.db` and the LLM/parse calls. They verify **status codes, request validation, response shape, and router branch logic** (e.g. API-key masking, regenerate fallback matching). They are valuable *contract* tests. They do **not** prove TinyDB persists, Playwright renders, markitdown parses, or any provider (Ollama included) actually responds.
+
+---
+
+## 3. The framework decision
+
+**Keep `pytest` + `pytest-asyncio` + `httpx`.** It is correctly configured (`asyncio_mode=auto`, strict markers, `unit`/`service`/`integration` markers). Add, incrementally:
+
+| Need | Tool | Why |
+|---|---|---|
+| Coverage as a tracked number | `pytest-cov` | Quantify gaps & deltas; stop guessing |
+| Real `llm.py` against a fake provider (incl. Ollama) | `respx` (or `pytest-httpx`) | Mock at the HTTP transport so our actual routing/normalization code runs — the only way to regression-test "Ollama doesn't work" |
+| PDF render proof | Playwright (already a dep) | One smoke test → real PDF bytes from the print route |
+| Prompt/skill quality | In-repo **eval harness** | Golden fixtures + structural scorers + optional LLM-as-judge |
+| Build/route/lint gate | GitHub Actions | **Deferred** — see §7 |
+
+### 3.1 Deterministic tests vs evals (the key distinction)
+
+- **Deterministic test** — LLM mocked, asserts code behavior given a known response. Fast, runs on every change. Answers *"is the plumbing correct?"*
+- **Eval** — real (or recorded) LLM call scored against a rubric. Non-deterministic, costs money/time, runs nightly/on-demand, **never in the PR gate**. Answers *"did this prompt change make the output better?"*
+
+You cannot answer "does my prompt change help?" with a deterministic test. You need evals. Conversely you should never block a PR on a non-deterministic eval. Both layers, kept separate.
+
+### 3.2 The prompt chain ("skills") and how each stage is tested
+
+```
+upload → parse_resume_to_json
+       → extract_job_keywords
+       → generate_skill_target_plan → verify_skill_target_plan   (verify = pure, deterministic gate)
+       → generate_resume_diffs  [strategy: keywords | nudge | full]
+       → apply_diffs            (pure)
+       → render_resume_pdf
+```
+
+For each stage:
+- **Deterministic layer** — structural invariants that hold regardless of wording: valid JSON/schema, **no fabricated employers/dates** (truthfulness rules), every section preserved, JD keywords actually present in output, diff paths resolve. Most "the prompt change broke something" regressions are caught here, for free.
+- **Eval layer** — golden `(resume, job_description)` fixtures → run the stage with a real model → score with a rubric (heuristic + LLM-as-judge). Tracks quality over time and across prompt edits.
+
+---
+
+## 4. What "verify our recent work" means here
+
+Three concrete mechanisms, applied to every change in this initiative:
+
+1. **Coverage delta.** Each batch reports before/after coverage for the modules it touches. Numbers, not vibes.
+2. **Anti-theater check.** For new tests on critical logic, confirm the test *fails when the code is broken* (a quick manual mutation). This is the antidote to the `test_health_returns_healthy` "passes for the wrong reason" trap.
+3. **Regression tests that pin recent PRs.** The first new coverage deliberately locks in behavior we recently shipped, so "our recent work" gains a safety net:
+   - `_normalize_api_base` — the `/v1/v1` duplicate-path dedup and OpenAI preserve-as-is (issue #751).
+   - `resolve_api_key` — the security rule that `ollama`/`openai_compatible` must **not** fall back to the env `LLM_API_KEY` (so a paid key can't leak to a local server).
+   - `get_model_name` — `ollama_chat/` prefix and OpenRouter nested prefixes.
+   - Empty-extracted-text rejection on upload (`resumes.py:546`, PR #794).
+   - `restore_dates_from_markdown` — months survive LLM parsing.
+
+---
+
+## 5. Phased roadmap
+
+Legend: ✅ done · 🚧 in progress · ⬜ planned
+
+**Phase 1 — Foundation + cheap deterministic coverage (this branch → `dev`)**
+- ✅ Audit + this document
+- 🚧 Make the suite green (fix stale `health` tests; liveness vs readiness)
+- 🚧 `llm.py` provider/Ollama pure-function regression tests
+- 🚧 `parser.py` pure tests (date restoration) + empty-text rejection
+- 🚧 Real-TinyDB `database.py` CRUD tests
+- ⬜ Verify: green suite + coverage delta recorded
+
+**Phase 2 — Transport contract tests (LLM/Ollama)**
+- ⬜ `respx`-backed tests: real `complete` / `complete_json` / `check_llm_health` against a fake Ollama + OpenAI-compatible server (request shape, base-URL handling, thinking-tag stripping, JSON-mode fallback, error-code mapping)
+
+**Phase 3 — Render safety net**
+- ⬜ Playwright PDF smoke test (print route → non-empty valid PDF) + error-path mapping in `pdf.py`
+
+**Phase 4 — End-to-end pipeline**
+- ⬜ One e2e: upload → parse → tailor → render with a mocked LLM, exercising real routers + real DB
+
+**Phase 5 — Eval harness (structural + LLM-as-judge)**
+- ⬜ Golden fixtures + structural scorers (run in normal suite)
+- ⬜ LLM-as-judge using the **developer's own configured key**, gated/skipped when no key is present; nightly/on-demand only
+
+**Phase 6 — CI (separate sign-off)**
+- ⬜ GitHub Actions PR gate: backend `pytest`, frontend `tsc`/`build`/lint, structural evals. (Deferred per §7.)
+
+---
+
+## 6. How to run
+
+```bash
+cd apps/backend
+
+# Full suite
+uv run pytest
+
+# Quiet + coverage (ephemeral plugin, no pyproject change)
+uv run --with pytest-cov pytest -q --cov=app --cov-report=term-missing
+
+# One module
+uv run pytest tests/unit/test_parser.py -q
+```
+
+> `uv run pytest` is unaffected by the project's nvm/npm constraints — it's Python-only. Frontend `tsc`/`build`/lint are run separately and are out of scope for this backend phase.
+
+---
+
+## 7. Decisions log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-30 | Base this initiative on **`dev`**, not `main`. Sync `dev`←`main`, branch off `dev`, merge work back to `dev`. | User directive — batch this important work on `dev` before it reaches `main`. |
+| 2026-05-30 | **No CI workflow yet** (tests only). | User directive. CI is the highest-ROI fix but is a separate, explicit decision (and `.github/workflows/` is change-controlled). |
+| 2026-05-30 | Eval layer = **structural + LLM-as-judge**, judge uses the **developer-provided** LLM key, skipped when absent. | User directive — the developer (usually the maintainer) supplies the key, so real-LLM scoring is acceptable when configured. |
+| 2026-05-30 | Keep `pytest`; add `respx`, `pytest-cov`, Playwright smoke, eval harness. | Existing framework is correct; fill gaps rather than replace. |
+
+---
+
+## 8. Open questions / future
+
+- Frontend: add a locale-parity test (every `messages/*.json` structurally matches `en.json`) — this *exactly* reproduces and prevents the build break that started this effort. Belongs to the frontend phase.
+- Decide coverage floors per module once Phase 1–4 land (avoid a single global % that hides the I/O gaps).
+- When CI lands, structural evals run in-gate; LLM-judge evals run nightly with a repo secret or skip.

--- a/docs/agent/testing-strategy.md
+++ b/docs/agent/testing-strategy.md
@@ -65,7 +65,7 @@ Every `tests/integration/*` test patches `app.routers.<x>.db` and the LLM/parse 
 | Real `llm.py` against a fake provider (incl. Ollama) | `respx` (or `pytest-httpx`) | Mock at the HTTP transport so our actual routing/normalization code runs — the only way to regression-test "Ollama doesn't work" |
 | PDF render proof | Playwright (already a dep) | One smoke test → real PDF bytes from the print route |
 | Prompt/skill quality | In-repo **eval harness** | Golden fixtures + structural scorers + optional LLM-as-judge |
-| Build/route/lint gate | GitHub Actions | **Deferred** — see §7 |
+| Push gate (local, replaces PR CI) | `pre-push` git hook (`.githooks/`) | Runs backend suite + locale parity, blocks red pushes; no PR-triggered CI — see §5 Phase 6 |
 
 ### 3.1 Deterministic tests vs evals (the key distinction)
 
@@ -131,8 +131,10 @@ Legend: ✅ done · 🚧 in progress · ⬜ planned
 - ✅ Pure structural scorers (`sections_preserved`, `no_fabricated_employers`, `jd_keywords_present`, `is_valid_resume`, `personal_info_unchanged`) + golden fixtures, each proven on good AND bad inputs.
 - ✅ LLM-as-judge marked `@pytest.mark.eval`, uses the developer's own configured key, **excluded from the default run** (`addopts -m "not eval"`); run on demand with `uv run pytest -m eval`. Skips cleanly with no key.
 
-**Phase 6 — CI (separate sign-off)**
-- ⬜ GitHub Actions PR gate: backend `pytest`, frontend `tsc`/`build`/lint, structural evals. (Deferred per §7 — still needs explicit sign-off.)
+**Phase 6 — Local pre-push gate (replaces PR CI) ✅ COMPLETE** (`.githooks/pre-push`)
+- ✅ A version-controlled `pre-push` hook runs the backend suite + a node-free locale-parity check and **blocks the push on red**. Activate per-clone with `git config core.hooksPath .githooks`; bypass with `git push --no-verify`. See `.githooks/README.md`.
+- ✅ We **deliberately avoid a GitHub Actions PR gate** — the repo gets a high volume of external contributor PRs; PR-triggered CI would run on every one (and run untrusted code). The local hook keeps `dev`/`main` green for the maintainer's own pushes without that cost.
+- ⬜ (Optional, future) a Node-based `tsc`/`next build` check — deferred due to nvm-in-hook fragility; the pure-Python locale-parity guard already covers the known i18n break.
 
 ### Result after Phases 1–5
 **192 → 320 deterministic tests** (+ 1 opt-in LLM-judge eval), **0 failures**, **coverage 54% → 69%**. Built via parallel subagents (one per phase, strict file ownership) using the `dispatching-parallel-agents` skill; integrated and re-verified together.
@@ -170,6 +172,7 @@ uv run pytest tests/unit/test_parser.py -q
 | 2026-05-30 | **No CI workflow yet** (tests only). | User directive. CI is the highest-ROI fix but is a separate, explicit decision (and `.github/workflows/` is change-controlled). |
 | 2026-05-30 | Eval layer = **structural + LLM-as-judge**, judge uses the **developer-provided** LLM key, skipped when absent. | User directive — the developer (usually the maintainer) supplies the key, so real-LLM scoring is acceptable when configured. |
 | 2026-05-30 | Keep `pytest`; add `respx`, `pytest-cov`, Playwright smoke, eval harness. | Existing framework is correct; fill gaps rather than replace. |
+| 2026-05-30 | Gate pushes with a **local `pre-push` hook**, NOT GitHub Actions on PRs. | Maintainer gets a high volume of external PRs; PR-triggered CI would run on all of them (incl. untrusted code). A local hook keeps `dev`/`main` green for the maintainer's own pushes — backend suite + node-free locale parity — without that cost. `.githooks/` + `core.hooksPath`. |
 
 ---
 

--- a/docs/agent/testing-strategy.md
+++ b/docs/agent/testing-strategy.md
@@ -110,13 +110,13 @@ Three concrete mechanisms, applied to every change in this initiative:
 
 Legend: ✅ done · 🚧 in progress · ⬜ planned
 
-**Phase 1 — Foundation + cheap deterministic coverage (this branch → `dev`)**
+**Phase 1 — Foundation + cheap deterministic coverage (PR #820 → `dev`) ✅ COMPLETE**
 - ✅ Audit + this document
-- 🚧 Make the suite green (fix stale `health` tests; liveness vs readiness)
-- 🚧 `llm.py` provider/Ollama pure-function regression tests
-- 🚧 `parser.py` pure tests (date restoration) + empty-text rejection
-- 🚧 Real-TinyDB `database.py` CRUD tests
-- ⬜ Verify: green suite + coverage delta recorded
+- ✅ Make the suite green (fixed stale `health` tests; liveness vs readiness)
+- ✅ `llm.py` provider/Ollama pure-function regression tests (`tests/unit/test_llm_providers.py`)
+- ✅ `parser.py` pure tests (date restoration) (`tests/unit/test_parser.py`) + empty-text rejection (`tests/integration/test_upload_api.py`)
+- ✅ Real-TinyDB `database.py` CRUD tests (`tests/unit/test_database.py`)
+- ✅ Verify: **192 → 265 tests, 1 silent failure → 0, coverage 54% → 58%** (database 34→96%, parser 20→72%, llm 47→55%, health now meaningful). Anti-theater mutation check passed.
 
 **Phase 2 — Transport contract tests (LLM/Ollama)**
 - ⬜ `respx`-backed tests: real `complete` / `complete_json` / `check_llm_health` against a fake Ollama + OpenAI-compatible server (request shape, base-URL handling, thinking-tag stripping, JSON-mode fallback, error-code mapping)

--- a/scripts/check_locale_parity.py
+++ b/scripts/check_locale_parity.py
@@ -29,20 +29,42 @@ MESSAGES_DIR = Path(__file__).resolve().parents[1] / "apps" / "frontend" / "mess
 REFERENCE = "en.json"
 
 
-def key_kinds(obj: Any, prefix: str = "") -> dict[str, str]:
-    """Map every dotted key path to its kind: ``"branch"`` (object) or ``"leaf"``.
+def _node_kind(value: Any) -> str:
+    """Classify a JSON value by the type ``typeof en`` would infer for it.
 
-    Comparing *kinds* — not just key presence — is what catches a locale that
-    has, say, ``a.b`` as an object where ``en`` has it as a string. Such a
-    mismatch keeps the key path present (so a presence-only check passes) yet
-    still breaks ``next build`` because the locale is no longer assignable to
-    ``typeof en``.
+    ``bool`` is checked before ``int`` because ``bool`` is a subclass of ``int``
+    in Python (``isinstance(True, int)`` is ``True``).
+    """
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if value is None:
+        return "null"
+    return "string"
+
+
+def key_kinds(obj: Any, prefix: str = "") -> dict[str, str]:
+    """Map every dotted key path to its JSON *kind* (object/array/string/number/…).
+
+    Comparing *kinds* — not just key presence — is what catches a locale whose
+    ``a.b`` is an object (or a number, or an array) where ``en`` has a string:
+    the key path is still present, so a presence-only check passes, yet it still
+    breaks ``next build`` because the locale is no longer assignable to
+    ``typeof en``. Tracking the full JSON type (rather than a coarse
+    branch/leaf) catches primitive/array mismatches too, and keeps this in lock-
+    step with the frontend in-suite guard. Recursion descends into objects only
+    (the only container these message files nest with).
     """
     kinds: dict[str, str] = {}
     if isinstance(obj, dict):
         for key, value in obj.items():
             path = f"{prefix}.{key}" if prefix else key
-            kinds[path] = "branch" if isinstance(value, dict) else "leaf"
+            kinds[path] = _node_kind(value)
             kinds.update(key_kinds(value, path))
     return kinds
 
@@ -100,8 +122,8 @@ def main(argv: list[str]) -> int:
         if mismatched:
             failed = True
             print(
-                f"locale-parity: ✗ {path.name} has keys whose shape differs from "
-                f"{REFERENCE} (object vs. string) — this breaks `next build`:",
+                f"locale-parity: ✗ {path.name} has keys whose JSON type differs "
+                f"from {REFERENCE} — this breaks `next build`:",
                 file=sys.stderr,
             )
             for key in sorted(mismatched):

--- a/scripts/check_locale_parity.py
+++ b/scripts/check_locale_parity.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Verify every frontend locale file structurally matches ``en.json``.
+
+The frontend declares ``type Messages = typeof en`` and
+``const allMessages: Record<Locale, Messages>``, so a locale JSON that is
+*missing* a key present in ``en.json`` makes ``tsc`` / ``next build`` fail. That
+is exactly the break that shipped to ``main`` and only surfaced (post-merge)
+inside the Docker publish job — the incident that motivated the testing work.
+
+This check reproduces and prevents it with **pure stdlib** — no Node, npm, or
+nvm — so it runs fast inside the local pre-push hook regardless of shell setup.
+
+Exit code: 0 = all locales match; 1 = at least one locale is missing keys.
+Extra keys (present in a locale but not in ``en``) are reported as warnings only
+(they don't break the ``typeof en`` build, but signal drift worth cleaning up).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+MESSAGES_DIR = Path(__file__).resolve().parents[1] / "apps" / "frontend" / "messages"
+REFERENCE = "en.json"
+
+
+def key_paths(obj: Any, prefix: str = "") -> set[str]:
+    """Return the set of dotted key paths (branches + leaves) in a nested dict."""
+    paths: set[str] = set()
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            path = f"{prefix}.{key}" if prefix else key
+            paths.add(path)
+            paths |= key_paths(value, path)
+    return paths
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    # Optional argv[1] overrides the messages dir (used by tests / the hook).
+    messages_dir = Path(argv[1]).resolve() if len(argv) > 1 else MESSAGES_DIR
+
+    reference_file = messages_dir / REFERENCE
+    if not reference_file.exists():
+        print(f"locale-parity: reference {reference_file} not found", file=sys.stderr)
+        return 1
+
+    reference_keys = key_paths(_load(reference_file))
+    failed = False
+
+    for path in sorted(messages_dir.glob("*.json")):
+        if path.name == REFERENCE:
+            continue
+        locale_keys = key_paths(_load(path))
+        missing = reference_keys - locale_keys
+        extra = locale_keys - reference_keys
+
+        if missing:
+            failed = True
+            print(f"locale-parity: ✗ {path.name} is MISSING keys from {REFERENCE}:", file=sys.stderr)
+            for key in sorted(missing):
+                print(f"    missing: {key}", file=sys.stderr)
+        if extra:
+            print(f"locale-parity: ⚠ {path.name} has extra keys not in {REFERENCE} (non-fatal):", file=sys.stderr)
+            for key in sorted(extra):
+                print(f"    extra:   {key}", file=sys.stderr)
+
+    if failed:
+        print(
+            "locale-parity: locale files are out of sync with en.json — this would "
+            "break `next build` (type Messages = typeof en). Add the missing keys.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("locale-parity: ✓ all locale files match en.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_locale_parity.py
+++ b/scripts/check_locale_parity.py
@@ -3,14 +3,17 @@
 
 The frontend declares ``type Messages = typeof en`` and
 ``const allMessages: Record<Locale, Messages>``, so a locale JSON that is
-*missing* a key present in ``en.json`` makes ``tsc`` / ``next build`` fail. That
-is exactly the break that shipped to ``main`` and only surfaced (post-merge)
-inside the Docker publish job — the incident that motivated the testing work.
+*missing* a key present in ``en.json`` — or that has a key of a *different shape*
+(an object where ``en`` has a string, or vice versa) — makes ``tsc`` /
+``next build`` fail. That is exactly the break that shipped to ``main`` and only
+surfaced (post-merge) inside the Docker publish job — the incident that
+motivated the testing work.
 
 This check reproduces and prevents it with **pure stdlib** — no Node, npm, or
 nvm — so it runs fast inside the local pre-push hook regardless of shell setup.
 
-Exit code: 0 = all locales match; 1 = at least one locale is missing keys.
+Exit code: 0 = all locales match; 1 = at least one locale is missing keys, has a
+key whose shape (leaf vs. object) differs from ``en``, or is not valid JSON.
 Extra keys (present in a locale but not in ``en``) are reported as warnings only
 (they don't break the ``typeof en`` build, but signal drift worth cleaning up).
 """
@@ -26,19 +29,30 @@ MESSAGES_DIR = Path(__file__).resolve().parents[1] / "apps" / "frontend" / "mess
 REFERENCE = "en.json"
 
 
-def key_paths(obj: Any, prefix: str = "") -> set[str]:
-    """Return the set of dotted key paths (branches + leaves) in a nested dict."""
-    paths: set[str] = set()
+def key_kinds(obj: Any, prefix: str = "") -> dict[str, str]:
+    """Map every dotted key path to its kind: ``"branch"`` (object) or ``"leaf"``.
+
+    Comparing *kinds* — not just key presence — is what catches a locale that
+    has, say, ``a.b`` as an object where ``en`` has it as a string. Such a
+    mismatch keeps the key path present (so a presence-only check passes) yet
+    still breaks ``next build`` because the locale is no longer assignable to
+    ``typeof en``.
+    """
+    kinds: dict[str, str] = {}
     if isinstance(obj, dict):
         for key, value in obj.items():
             path = f"{prefix}.{key}" if prefix else key
-            paths.add(path)
-            paths |= key_paths(value, path)
-    return paths
+            kinds[path] = "branch" if isinstance(value, dict) else "leaf"
+            kinds.update(key_kinds(value, path))
+    return kinds
 
 
 def _load(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    """Parse a locale JSON file; raise ``ValueError`` with a clean message on bad JSON."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path.name} is not valid JSON: {exc}") from exc
 
 
 def main(argv: list[str]) -> int:
@@ -50,21 +64,52 @@ def main(argv: list[str]) -> int:
         print(f"locale-parity: reference {reference_file} not found", file=sys.stderr)
         return 1
 
-    reference_keys = key_paths(_load(reference_file))
+    try:
+        reference_kinds = key_kinds(_load(reference_file))
+    except ValueError as exc:
+        print(f"locale-parity: ✗ {exc}", file=sys.stderr)
+        return 1
+
+    reference_paths = set(reference_kinds)
     failed = False
 
     for path in sorted(messages_dir.glob("*.json")):
         if path.name == REFERENCE:
             continue
-        locale_keys = key_paths(_load(path))
-        missing = reference_keys - locale_keys
-        extra = locale_keys - reference_keys
+        try:
+            locale_kinds = key_kinds(_load(path))
+        except ValueError as exc:
+            failed = True
+            print(f"locale-parity: ✗ {exc}", file=sys.stderr)
+            continue
+
+        locale_paths = set(locale_kinds)
+        missing = reference_paths - locale_paths
+        extra = locale_paths - reference_paths
+        mismatched = {
+            p
+            for p in reference_paths & locale_paths
+            if reference_kinds[p] != locale_kinds[p]
+        }
 
         if missing:
             failed = True
             print(f"locale-parity: ✗ {path.name} is MISSING keys from {REFERENCE}:", file=sys.stderr)
             for key in sorted(missing):
                 print(f"    missing: {key}", file=sys.stderr)
+        if mismatched:
+            failed = True
+            print(
+                f"locale-parity: ✗ {path.name} has keys whose shape differs from "
+                f"{REFERENCE} (object vs. string) — this breaks `next build`:",
+                file=sys.stderr,
+            )
+            for key in sorted(mismatched):
+                print(
+                    f"    type-mismatch: {key} "
+                    f"({REFERENCE}={reference_kinds[key]}, {path.name}={locale_kinds[key]})",
+                    file=sys.stderr,
+                )
         if extra:
             print(f"locale-parity: ⚠ {path.name} has extra keys not in {REFERENCE} (non-fatal):", file=sys.stderr)
             for key in sorted(extra):
@@ -73,7 +118,8 @@ def main(argv: list[str]) -> int:
     if failed:
         print(
             "locale-parity: locale files are out of sync with en.json — this would "
-            "break `next build` (type Messages = typeof en). Add the missing keys.",
+            "break `next build` (type Messages = typeof en). Fix the missing / "
+            "mismatched keys.",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
## Testing initiative (base `dev`) — backend + frontend + local gate

A deliberate, evidence-based testing effort. **No production code changed** — additive tests, a local gate, and docs only. Full record: `docs/agent/testing-strategy.md`.

### Why
We shipped a build break nothing caught, users report Ollama/render failures, and there was no read on whether tests were real or theater. Running the suite found the smoking gun: a test had been failing silently because **nothing runs the suite** (only `docker-publish.yml`; no PR gate).

### Backend (Phases 1–5)
| | start | now |
|---|---|---|
| Tests | 192 (1 silently failing) | **320 + 1 opt-in LLM-judge eval, green** |
| Coverage | 54% | **69%** |
| `database.py` / `llm.py` / `resumes.py` | 34 / 47 / 18% | **97 / 74 / 53%** |

- Greened the suite (fixed a stale `health` test), covered the untested I/O surface, added `respx` LLM/Ollama transport contract tests, a Playwright PDF render smoke test, an e2e pipeline test (real routers + isolated temp DB), and a prompt-quality eval harness (structural scorers + a gated LLM-judge using the dev's own key). Phases 2–5 were built via parallel subagents with strict file ownership.

### Frontend (vitest)
- Assessed the pre-existing suite (65 tests), then added coverage **in the same manner**: i18n engine + **in-suite locale-parity guard** (the exact build-break class), `keyword-matcher`, `section-helpers`, `html-sanitizer` (XSS), `lib/api/client` + `config`, and the server `translate()`. **65 → 127 tests, green.**

### Local push gate (no PR CI)
- `.githooks/pre-push` runs the backend suite + a node-free locale-parity check + the frontend vitest suite (when Node is present) and **blocks red pushes**. Activate: `git config core.hooksPath .githooks`; bypass `git push --no-verify`. We deliberately avoid GitHub Actions on PRs (high external-PR volume).

### Context docs
- Updated root / backend / frontend `CLAUDE.md` (tests now in scope, suites, layers, the gate) and `docs/agent/testing-strategy.md`.

### Verified
Every phase mutation-checked (break the target → the test fails). Final gate run: backend `320 passed, 1 deselected`; frontend `127 passed`; locale parity ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)