### PR TITLE
fix(resumes): improve/confirm rejects valid tailorings for non-schema-complete resumes (preview/confirm hash mismatch)

### DIFF
--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
+from pydantic import ValidationError
 
 from app.config_cache import get_content_language, load_config as _load_config
 from app.database import db
@@ -92,8 +93,21 @@ def _normalize_payload(value: Any) -> Any:
 
 
 def _hash_improved_data(data: dict[str, Any]) -> str:
-    """Hash canonicalized improved data for preview/confirm validation."""
-    normalized = _normalize_payload(data)
+    """Hash canonicalized improved data for preview/confirm validation.
+
+    Canonicalize through ``ResumeData`` first so a payload that merely omits
+    optional fields (which the schema defaults) hashes identically to its
+    schema-complete form. Without this, ``improve/preview`` (which hashes the
+    raw ``improved_data`` dict) and ``improve/confirm`` (which hashes the
+    ``ResumeData`` round-trip, ``request.improved_data.model_dump()``) disagree
+    for any stored resume whose ``processed_data`` is not schema-complete, and a
+    valid tailoring is rejected with 400 ("preview hash mismatch").
+    """
+    try:
+        canonical: Any = ResumeData.model_validate(data).model_dump()
+    except ValidationError:
+        canonical = data  # not a full resume payload; hash as-is
+    normalized = _normalize_payload(canonical)
     serialized = json.dumps(
         normalized,
         sort_keys=True,

--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -104,7 +104,7 @@ def _hash_improved_data(data: dict[str, Any]) -> str:
     valid tailoring is rejected with 400 ("preview hash mismatch").
     """
     try:
-        canonical: Any = ResumeData.model_validate(data).model_dump()
+        canonical: dict[str, Any] = ResumeData.model_validate(data).model_dump()
     except ValidationError:
         canonical = data  # not a full resume payload; hash as-is
     normalized = _normalize_payload(canonical)

--- a/apps/backend/tests/integration/test_pipeline_e2e.py
+++ b/apps/backend/tests/integration/test_pipeline_e2e.py
@@ -370,3 +370,112 @@ class TestTailoringPipeline:
         master = isolated_db.get_master_resume()
         assert master["resume_id"] == resume_id
         assert master["processed_data"]["summary"] == sample_resume["summary"]
+
+    async def test_preview_confirm_succeeds_for_non_canonical_stored_resume(
+        self, isolated_db, sample_resume
+    ):
+        """A stored resume whose ``processed_data`` OMITS optional schema fields
+        must still tailor + confirm successfully (regression for the confirm 400).
+
+        ``improve/preview`` hashes the raw ``improved_data`` — here a project that
+        omits the optional ``github``/``website`` keys ``ResumeData`` defaults to
+        ``None`` — while ``improve/confirm`` hashes the schema-defaulted
+        ``ResumeData`` round-trip. Before ``_hash_improved_data`` canonicalized
+        both sides these diverged and confirm returned 400 ("preview hash
+        mismatch"). NO canonicalize workaround is applied to ``improved`` here —
+        that is exactly the point.
+        """
+        upload_resp = await _upload_resume(isolated_db, sample_resume)
+        assert upload_resp.status_code == 200
+        resume_id = upload_resp.json()["resume_id"]
+
+        async with _new_client() as client:
+            jobs_resp = await client.post(
+                "/api/v1/jobs/upload",
+                json={"job_descriptions": ["Senior Backend Engineer: Python, FastAPI."]},
+            )
+        assert jobs_resp.status_code == 200
+        job_id = jobs_resp.json()["job_id"][0]
+
+        # Non-canonical tailored data: a project missing the optional
+        # github/website fields. personalInfo stays canonical/unchanged so the
+        # confirm identity invariant holds; only personalProjects is non-canonical.
+        improved = ResumeData.model_validate(copy.deepcopy(sample_resume)).model_dump()
+        improved["summary"] = (
+            "Senior backend engineer building Python and FastAPI services."
+        )
+        improved["personalProjects"] = [
+            {
+                "id": 1,
+                "name": "Sidecar",
+                "role": "Author",
+                "years": "2022",
+                "description": ["Shipped a CLI"],
+            }  # deliberately NO github/website keys
+        ]
+        assert "github" not in improved["personalProjects"][0]
+
+        with (
+            patch(
+                "app.routers.resumes.extract_job_keywords",
+                new_callable=AsyncMock,
+                return_value={"keywords": ["Python", "FastAPI"], "required_skills": []},
+            ),
+            patch(
+                "app.routers.resumes.generate_skill_target_plan",
+                new_callable=AsyncMock,
+                return_value={"accepted": [], "rejected": []},
+            ),
+            patch(
+                "app.routers.resumes.verify_skill_target_plan",
+                return_value={"accepted": [], "rejected": []},
+            ),
+            patch(
+                "app.routers.resumes.generate_resume_diffs",
+                new_callable=AsyncMock,
+                return_value=SimpleNamespace(changes=[]),
+            ),
+            patch(
+                "app.routers.resumes.apply_diffs",
+                return_value=(copy.deepcopy(improved), [], []),
+            ),
+            patch("app.routers.resumes.verify_diff_result", return_value=[]),
+            patch(
+                "app.routers.resumes.refine_resume",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("refinement disabled for test"),
+            ),
+            patch(
+                "app.routers.resumes.generate_resume_title",
+                new_callable=AsyncMock,
+                return_value="Senior Backend Engineer",
+            ),
+        ):
+            async with _new_client() as client:
+                preview_resp = await client.post(
+                    "/api/v1/resumes/improve/preview",
+                    json={"resume_id": resume_id, "job_id": job_id},
+                )
+            assert preview_resp.status_code == 200, preview_resp.text
+            preview_data = preview_resp.json()["data"]
+            preview_resume = preview_data["resume_preview"]
+            # The preview RESPONSE is schema-complete even though the stored
+            # improved_data wasn't — this asymmetry is what used to break confirm.
+            assert "github" in preview_resume["personalProjects"][0]
+
+            async with _new_client() as client:
+                confirm_resp = await client.post(
+                    "/api/v1/resumes/improve/confirm",
+                    json={
+                        "resume_id": resume_id,
+                        "job_id": job_id,
+                        "improved_data": preview_resume,
+                        "improvements": preview_data["improvements"],
+                    },
+                )
+            assert confirm_resp.status_code == 200, confirm_resp.text
+
+        # The tailored resume really persisted as a child of the master.
+        tailored_id = confirm_resp.json()["data"]["resume_id"]
+        assert tailored_id is not None and tailored_id != resume_id
+        assert isolated_db.get_resume(tailored_id) is not None

--- a/apps/backend/tests/unit/test_improve_confirm_hash.py
+++ b/apps/backend/tests/unit/test_improve_confirm_hash.py
@@ -1,0 +1,52 @@
+"""Regression test for the improve/preview -> improve/confirm hash gate.
+
+The bug: ``improve/preview`` hashes the RAW ``improved_data`` dict, while
+``improve/confirm`` hashes its ``ResumeData`` round-trip
+(``request.improved_data.model_dump()``). A resume that merely OMITS optional
+fields — which ``ResumeData`` defaults to ``None`` — therefore hashes
+differently on the two sides, so a valid tailoring is rejected with 400
+("preview hash mismatch") whenever the stored ``processed_data`` is not already
+schema-complete. ``_hash_improved_data`` must canonicalize through ``ResumeData``
+so the two sides agree.
+"""
+
+from __future__ import annotations
+
+from app.routers.resumes import _hash_improved_data
+from app.schemas import ResumeData
+
+
+def _canonical(data: dict) -> dict:
+    return ResumeData.model_validate(data).model_dump()
+
+
+def test_hash_is_stable_across_resumedata_roundtrip() -> None:
+    # A resume whose personalProjects entry omits the optional github/website
+    # fields (which ResumeData defaults to None) — exactly the non-canonical
+    # stored-processed_data shape that triggers the confirm 400.
+    raw = {
+        "personalInfo": {"name": "Jane Doe", "email": "jane@x.dev"},
+        "summary": "Backend engineer.",
+        "personalProjects": [
+            {
+                "id": 1,
+                "name": "Proj",
+                "role": "Author",
+                "years": "2022",
+                "description": ["Built it"],
+            }  # no github / website keys
+        ],
+    }
+    # The raw dict and its schema-complete round-trip differ in key set...
+    assert "github" not in raw["personalProjects"][0]
+    assert "github" in _canonical(raw)["personalProjects"][0]
+    # ...but their hashes MUST match, or preview (hashes raw) and confirm
+    # (hashes the round-trip) disagree and reject a valid tailoring.
+    assert _hash_improved_data(raw) == _hash_improved_data(_canonical(raw))
+
+
+def test_hash_distinguishes_genuinely_different_resumes() -> None:
+    # Anti-theater: canonicalization must NOT collapse real content differences.
+    a = {"personalInfo": {"name": "Jane"}, "summary": "Backend engineer."}
+    b = {"personalInfo": {"name": "Jane"}, "summary": "Frontend engineer."}
+    assert _hash_improved_data(a) != _hash_improved_data(b)


### PR DESCRIPTION
## The bug

`POST /api/v1/resumes/improve/confirm` returns **400 "preview hash mismatch"** — i.e. **"tailoring won't save"** — for any stored resume whose `processed_data` isn't schema-complete (omits optional `ResumeData` fields the schema defaults to `null`, e.g. `personalProjects[].github` / `website`).

**Root cause:** `improve/preview` hashes the *raw* `improved_data` dict (`_hash_improved_data(improved_data)`), while `improve/confirm` hashes its `ResumeData` round-trip (`request.improved_data.model_dump()`). The preview *response* serializes `ResumeData.model_validate(improved_data)`, which fills the missing optional fields — so the value the client echoes back to confirm is schema-complete while the value preview hashed wasn't, and the two hashes diverge. `_normalize_payload` only does NFC string normalization; it doesn't reconcile missing-vs-defaulted keys.

This was latent and quietly worked around: the existing `test_preview_then_confirm` e2e test canonicalizes its canned data first (with a comment explaining exactly this), and the new agentic e2e monitor (#823) had to seed a canonical master — but the app itself was never fixed. Any user whose stored `processed_data` isn't canonical hits it.

## The fix

`_hash_improved_data` now canonicalizes through `ResumeData` before hashing — which is what its docstring already *claimed* ("Hash **canonicalized** improved data"). Both preview and confirm call it, so the two sides now agree.

- **Idempotent** for schema-complete data → no behavior change on the normal path.
- Only the previously-**rejected** non-canonical case changes (now accepted).
- Falls back to hashing as-is if the payload isn't a valid `ResumeData`.

## Tests

- **Unit** (`tests/unit/test_improve_confirm_hash.py`): the hash is stable across the `ResumeData` round-trip, and (anti-theater) still distinguishes genuinely different resumes.
- **Integration** (`tests/integration/test_pipeline_e2e.py`): `preview → confirm` now returns 200 for a stored resume whose project omits optional `github`/`website`. **Proven anti-theater** — reverting only `resumes.py` makes it fail with `assert 400 == 200`.
- Full backend suite: **331 passed**, no regressions; pre-push gate green.

## How it was found

The agentic e2e monitor (#823) failed all 4 tailorings with this exact 400 on its **first live run** — the monitor catching a real product bug on day one, which is precisely what it's for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview/confirm hash mismatch that blocked saving tailored resumes when stored `processed_data` omitted optional fields. Both endpoints now hash the same canonicalized improved data, so confirm succeeds.

- **Bug Fixes**
  - `_hash_improved_data` now canonicalizes via `ResumeData` and hashes a strictly typed `dict[str, Any]` to align preview and confirm.
  - Falls back to hashing as-is when payload is not valid `ResumeData`.
  - No change for schema-complete resumes; previously rejected non-canonical cases now pass.

- **Tests**
  - Unit: hash is stable across `ResumeData` round-trips and still detects real content changes.
  - Integration: preview → confirm returns 200 for a resume missing optional `github`/`website` fields.

<sup>Written for commit 07bb8e5463c6af75960ed9375b0b1e8ebb7a39a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

