### PR TITLE
fix(improver): reorder skill changes silently dropped — accept list 'original'

### DIFF
--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -5,7 +5,7 @@ import re
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 _TEXT_VALUE_KEYS = (
     "text",
@@ -757,6 +757,16 @@ class ResumeChange(BaseModel):
     )
     value: str | list[str] = Field(description="New content")
     reason: str = Field(description="Why this change helps match the JD")
+
+    @model_validator(mode="after")
+    def _list_original_only_for_reorder(self) -> "ResumeChange":
+        """A list ``original`` is only meaningful for ``reorder`` (the LLM sends
+        the current items). For the text actions it must stay a string/None — a
+        list there would silently bypass the replace verification gate and crash
+        the invented-metrics check, so reject it at parse time."""
+        if isinstance(self.original, list) and self.action != "reorder":
+            raise ValueError("'original' may be a list only for the reorder action")
+        return self
 
 
 class ImproveDiffResult(BaseModel):

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -749,8 +749,11 @@ class ResumeChange(BaseModel):
         description="Dot+bracket path, e.g. 'workExperience[0].description[1]'"
     )
     action: Literal["replace", "append", "reorder", "add_skill"]
-    original: str | None = Field(
-        default=None, description="Current text at path — for verification"
+    original: str | list[str] | None = Field(
+        default=None,
+        description="Current text at path — for verification. May be a list (the "
+        "current items) for the reorder action; only used for text verification of "
+        "replace/append, ignored otherwise.",
     )
     value: str | list[str] = Field(description="New content")
     reason: str = Field(description="Why this change helps match the JD")

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -204,8 +204,10 @@ def _set_at_path(data: dict[str, Any], path: str, value: Any) -> bool:
 
 def _verify_original_matches(actual: Any, expected: str | list[str] | None) -> bool:
     """Verify that the original text from the diff matches the actual value."""
+    if expected is None:
+        return True  # no original provided (e.g. append) — nothing to verify
     if not isinstance(expected, str):
-        return True  # None or a list (e.g. reorder's original) — no text check
+        return False  # a non-str original on a text action is malformed — reject
     if not isinstance(actual, str):
         return False
     return actual.strip().casefold() == expected.strip().casefold()

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -202,10 +202,10 @@ def _set_at_path(data: dict[str, Any], path: str, value: Any) -> bool:
     return True
 
 
-def _verify_original_matches(actual: Any, expected: str | None) -> bool:
+def _verify_original_matches(actual: Any, expected: str | list[str] | None) -> bool:
     """Verify that the original text from the diff matches the actual value."""
-    if expected is None:
-        return True  # No verification needed (e.g. append, reorder)
+    if not isinstance(expected, str):
+        return True  # None or a list (e.g. reorder's original) — no text check
     if not isinstance(actual, str):
         return False
     return actual.strip().casefold() == expected.strip().casefold()

--- a/apps/backend/tests/unit/test_apply_diffs.py
+++ b/apps/backend/tests/unit/test_apply_diffs.py
@@ -253,6 +253,21 @@ class TestApplyDiffsReorder:
         assert len(applied) == 1
         assert result["additional"]["technicalSkills"] == reordered
 
+    def test_list_original_rejected_for_non_reorder_actions(self):
+        # A list `original` is valid ONLY for reorder. For a text action like
+        # replace it would bypass the original-match gate and crash the
+        # invented-metrics check, so the schema rejects it at construction.
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ResumeChange(
+                path="summary",
+                action="replace",
+                original=["a", "b"],  # list original on a text action — invalid
+                value="new summary",
+                reason="test",
+            )
+
 
 class TestApplyDiffsBlockedPaths:
     """Tests for blocked path rejection."""

--- a/apps/backend/tests/unit/test_apply_diffs.py
+++ b/apps/backend/tests/unit/test_apply_diffs.py
@@ -233,6 +233,26 @@ class TestApplyDiffsReorder:
         result, applied, rejected = apply_diffs(sample_resume, changes)
         assert len(applied) == 1
 
+    def test_reorder_accepts_list_original_and_applies(self, sample_resume):
+        # The live LLM ignores the prompt's `original: null` for reorder and sends
+        # the current skills LIST as `original`. The schema must accept that — a
+        # `str | None`-only `original` dropped the whole change at parse time with a
+        # `string_type` error ("Skipping malformed change") — and a pure reorder
+        # (same items, new order) must still apply.
+        original_skills = sample_resume["additional"]["technicalSkills"]
+        reordered = list(reversed(original_skills))
+        change = ResumeChange(
+            path="additional.technicalSkills",
+            action="reorder",
+            original=original_skills,  # a LIST, exactly as the LLM sends it
+            value=reordered,
+            reason="prioritize JD-relevant skills",
+        )
+        assert change.original == original_skills
+        result, applied, rejected = apply_diffs(sample_resume, [change])
+        assert len(applied) == 1
+        assert result["additional"]["technicalSkills"] == reordered
+
 
 class TestApplyDiffsBlockedPaths:
     """Tests for blocked path rejection."""


### PR DESCRIPTION
## The bug (surfaced by the e2e monitor)

The agentic e2e monitor's report flagged a recurring warning across **all 4** tailoring variations:
`WARNING:app.services.improver:Skipping malformed change: {…'action':'reorder','path':'additional.technicalSkills'…} — 1 validation error for ResumeChange … string_type`

**Root cause:** the diff prompt tells the model to send `"original": null` for a `reorder` (`templates.py:514`), but the live LLM (claude-haiku) ignores that and sends the **current skills list** as `original`. `ResumeChange.original` was typed `str | None`, so every reorder change failed Pydantic validation on `original` (`string_type`: a list was given) and was skipped at parse time (`improver.py:545`) — **before `apply_diffs` ever ran.** Net effect: the JD-relevant skill reordering (a real, intended action with a working `apply_diffs` handler at `improver.py:301-326`) **never happened on any tailoring**, and the logs filled with noise.

## The fix

- `ResumeChange.original: str | list[str] | None` — the `reorder` handler reorders `value` and never reads `original`, so accepting a list there is safe and lets the change *parse*.
- `_verify_original_matches` treats a non-str `original` as "no text check" (it already did so for `None`), guarding the replace/append verification path against a list.

Pure reorders (same items, new order) now apply; non-pure ones (the model crammed new skills into the reorder value) still reject cleanly via the existing items-match gate — so truthfulness is unaffected.

## Test

`test_reorder_accepts_list_original_and_applies` reproduces the exact parse failure (constructing a `ResumeChange` with a list `original` raised `string_type` before this change) and asserts the reorder now both validates **and** applies. Full backend suite: **356 passed**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped skill reorders by accepting list `original` on `reorder` diffs and guarding text actions, so pure reorders now apply and the “Skipping malformed change” warning is gone.

- **Bug Fixes**
  - Allow `ResumeChange.original` as `str | list[str] | | None` with a model validator that permits a list only for `action="reorder"`.
  - Harden `_verify_original_matches`: non‑str `expected` now fails for text actions, preventing original‑match bypass and metric regex errors; reorder unaffected.
  - Tests: reorder with list `original` validates and applies; list `original` on `replace` raises `ValidationError`.

<sup>Written for commit 90faaee6d95e20c6eec76d467022dcf1156c55c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

