### PR TITLE
feat(e2e-monitor): narrate the full loop + AI-agent handoff in the CLI

### DIFF
--- a/apps/backend/e2e_monitor/README.md
+++ b/apps/backend/e2e_monitor/README.md
@@ -38,7 +38,9 @@ The sweep:
 7. Writes a self-contained evidence bundle to `artifacts/e2e-monitor/<run-id>/`.
 8. Diffs against `baseline/baseline.json` and writes `baseline-diff.json`.
 
-The printed `bundle:` path is everything you need to judge.
+**The sweep only *captures* the bundle — it does not produce the verdict.** It's the deterministic half. The **agent in the loop** — a Claude Code instance, via the `/monitor-e2e` skill below or by just asking any Claude Code session to *"judge the latest e2e-monitor bundle"* — reads the bundle + logs, separates real issues from noise, and writes `report.md`. The sweep's terminal output narrates each move and points you to this handoff.
+
+In practice the front door is **`/monitor-e2e`** (it runs the sweep *and* judges in one step); the bare CLI is the plumbing the agent drives — handy for a quick capture, or a background / cron run that an AI agent later picks up to debug while you work on the app as normal.
 
 ---
 

--- a/apps/backend/e2e_monitor/__main__.py
+++ b/apps/backend/e2e_monitor/__main__.py
@@ -62,6 +62,15 @@ def _jds() -> list[tuple[str, str]]:
     )
 
 
+def _say(msg: str) -> None:
+    """Print live loop narration to stderr.
+
+    Progress/handoff text goes to stderr so the machine-readable ``bundle: <path>``
+    line stays alone on stdout for scripts/agents that parse it.
+    """
+    print(msg, file=sys.stderr, flush=True)
+
+
 def cmd_sweep(_: argparse.Namespace) -> int:
     ensure_enabled()
     from app.config import load_config_file
@@ -73,6 +82,13 @@ def cmd_sweep(_: argparse.Namespace) -> int:
         bundle.dir / "manifest.json",
         build_manifest(run_id=bundle.run_id, git_sha=_git_sha(), config=config, started_at=_now_iso()),
     )
+
+    _say("")
+    _say("  e2e-monitor · driving the real app end to end")
+    _say(f"  provider {config.get('provider', '?')}/{config.get('model', '?')}  ·  run {bundle.run_id}")
+    _say("  Captures an evidence bundle for an AI agent to JUDGE — built to run (or via")
+    _say("  the /monitor-e2e skill) while you work on the app as normal.")
+    _say("")
 
     # Pre-seed the isolated DB with a known master BEFORE booting the server.
     # Canonicalize to the exact ResumeData round-trip the app stores, so every
@@ -86,14 +102,17 @@ def cmd_sweep(_: argparse.Namespace) -> int:
     master = ResumeData.model_validate(raw_master).model_dump()
     resume_id = seed_master_db(bundle.data_dir, master)
     bundle.write_json(bundle.master_dir / "processed_data.json", master)
+    _say("  ✓ seed-master   canonical master → isolated DB (your real DB is untouched)")
 
     steps: list[dict[str, Any]] = []
     servers = Servers(bundle=bundle)
     variations: list[dict[str, Any]] = []
     try:
+        _say("  ▶ boot          spawning backend :8000 + frontend :3000 …")
         boot = servers.boot()
         steps.append({"stage": "boot", "ok": True, "ms": 0, "detail": boot})
         steps.append({"stage": "seed-master", "ok": True, "ms": 0, "detail": {"resume_id": resume_id}})
+        _say("  ✓ boot          backend up" + (" + frontend up" if boot.get("frontend_up") else " (frontend off — renders degrade to header+size)"))
 
         for jd_key, jd_text in _jds():
             vdir = bundle.variation_dir(jd_key)
@@ -103,10 +122,12 @@ def cmd_sweep(_: argparse.Namespace) -> int:
                 if kw.istitle() and kw.lower() not in _STOPWORDS
             ][:8]
 
+            _say(f"  ▶ {jd_key:<16} tailor → judge → render …")
             try:
                 t = tailor(resume_id, jd_text, keywords, master)
             except Exception as exc:  # noqa: BLE001
                 steps.append({"stage": f"tailor:{jd_key}", "ok": False, "ms": 0, "error": str(exc)})
+                _say(f"  ✗ {jd_key:<16} tailor FAILED: {str(exc)[:90]}")
                 continue
             bundle.write_json(vdir / "tailored.json", t["tailored"])
             bundle.write_json(vdir / "scores.json", t["scores"])
@@ -129,6 +150,13 @@ def cmd_sweep(_: argparse.Namespace) -> int:
                 except Exception as exc:  # noqa: BLE001
                     steps.append({"stage": f"render:{jd_key}", "ok": False, "ms": 0, "error": str(exc)})
             variations.append({"jd_key": jd_key, "scores": t["scores"], "judge": judge, "render": render})
+            _nb = render.get("non_blank")
+            _say(
+                f"  ✓ {jd_key:<16} judge={(judge or {}).get('score')}  "
+                f"kw={t['scores']['jd_keyword_coverage']}  "
+                f"render={'non-blank' if _nb else ('skipped' if _nb is None else 'BLANK!')}  "
+                f"fabricated={len(t['scores']['fabricated_employers'])}"
+            )
     finally:
         servers.teardown()
 
@@ -136,6 +164,7 @@ def cmd_sweep(_: argparse.Namespace) -> int:
     bundle.write_json(bundle.dir / "flow-trace.json", flow)
     summary = build_summary(flow=flow, variations=variations, provider=config.get("provider", ""))
     bundle.write_json(bundle.dir / "summary.json", summary)
+    baseline_line = ""
     if _BASELINE.exists():
         current = {
             v["jd_key"]: {
@@ -145,10 +174,30 @@ def cmd_sweep(_: argparse.Namespace) -> int:
             }
             for v in variations
         }
-        bundle.write_json(
-            bundle.dir / "baseline-diff.json",
-            diff_against_baseline(current, bundle.read_json(_BASELINE)),
+        diff = diff_against_baseline(current, bundle.read_json(_BASELINE))
+        bundle.write_json(bundle.dir / "baseline-diff.json", diff)
+        baseline_line = (
+            " · no regression vs baseline"
+            if not diff["regressed"]
+            else f" · REGRESSED ({len(diff['regressions'])} — see baseline-diff.json)"
         )
+
+    _say("")
+    _say("  ──────────────────────────────────────────────────────────────")
+    _say(
+        f"  sweep complete · {summary['variations']} variations · "
+        f"flow {'all passed' if summary['flow_all_passed'] else 'HAD FAILURES'} · "
+        f"renders {summary['renders_non_blank']}/{summary['variations']} non-blank"
+        + baseline_line
+    )
+    _say("")
+    _say("  ↳ NEXT — this is captured EVIDENCE, not a verdict. Hand it to an AI agent:")
+    _say("      • In Claude Code, invoke the  /monitor-e2e  skill, or just say")
+    _say('        "judge the latest e2e-monitor bundle".')
+    _say("      The agent reads the logs + artifacts, separates real issues from noise,")
+    _say("      and writes report.md. This harness is built to be DRIVEN BY an AI agent")
+    _say("      debugging in the background while you build the app as normal.")
+    _say("")
     print(f"bundle: {bundle.dir}")
     return 0
 

--- a/apps/backend/e2e_monitor/__main__.py
+++ b/apps/backend/e2e_monitor/__main__.py
@@ -105,13 +105,15 @@ def cmd_sweep(_: argparse.Namespace) -> int:
     _say("  ✓ seed-master   canonical master → isolated DB (your real DB is untouched)")
 
     steps: list[dict[str, Any]] = []
+    # seed-master ran above (BEFORE boot) — record it first so flow-trace.json
+    # ordering matches actual execution.
+    steps.append({"stage": "seed-master", "ok": True, "ms": 0, "detail": {"resume_id": resume_id}})
     servers = Servers(bundle=bundle)
     variations: list[dict[str, Any]] = []
     try:
         _say("  ▶ boot          spawning backend :8000 + frontend :3000 …")
         boot = servers.boot()
         steps.append({"stage": "boot", "ok": True, "ms": 0, "detail": boot})
-        steps.append({"stage": "seed-master", "ok": True, "ms": 0, "detail": {"resume_id": resume_id}})
         _say("  ✓ boot          backend up" + (" + frontend up" if boot.get("frontend_up") else " (frontend off — renders degrade to header+size)"))
 
         for jd_key, jd_text in _jds():
@@ -141,20 +143,27 @@ def cmd_sweep(_: argparse.Namespace) -> int:
             bundle.write_json(vdir / "judge.json", judge)
 
             render: dict[str, Any] = {"non_blank": None}
+            render_status = "skipped"  # frontend down or no tailored id
             if servers.frontend_up and t["tailored_resume_id"]:
                 try:
                     pdf, render = render_variation(t["tailored_resume_id"])
                     (vdir / "resume.pdf").write_bytes(pdf)
                     bundle.write_json(vdir / "render.json", render)
                     steps.append({"stage": f"render:{jd_key}", "ok": bool(render["non_blank"]), "ms": 0})
+                    render_status = "non-blank" if render["non_blank"] else "BLANK!"
                 except Exception as exc:  # noqa: BLE001
                     steps.append({"stage": f"render:{jd_key}", "ok": False, "ms": 0, "error": str(exc)})
+                    render_status = "FAILED"
             variations.append({"jd_key": jd_key, "scores": t["scores"], "judge": judge, "render": render})
-            _nb = render.get("non_blank")
+
+            # ✓ only when the judge produced a score AND the render didn't fail/blank;
+            # otherwise ⚠ — the marker must never claim success over a caught failure.
+            variation_ok = (judge or {}).get("score") is not None and render_status in ("non-blank", "skipped")
             _say(
-                f"  ✓ {jd_key:<16} judge={(judge or {}).get('score')}  "
+                f"  {'✓' if variation_ok else '⚠'} {jd_key:<16} "
+                f"judge={(judge or {}).get('score')}  "
                 f"kw={t['scores']['jd_keyword_coverage']}  "
-                f"render={'non-blank' if _nb else ('skipped' if _nb is None else 'BLANK!')}  "
+                f"render={render_status}  "
                 f"fabricated={len(t['scores']['fabricated_employers'])}"
             )
     finally:


### PR DESCRIPTION
## Why

Running the bare `uv run python -m e2e_monitor sweep` was silent except a final `bundle: <path>` — which made it feel like a dead end. It captures evidence but produces **no verdict**, because the verdict is the **agent's** job (the `/monitor-e2e` skill, or any Claude Code session). The harness is designed to be *driven by an AI agent* debugging in the background while you work on the app — but the CLI never said so.

## What

`cmd_sweep` now **narrates the whole loop live** (to stderr, so the machine-readable `bundle:` line stays alone on stdout):

```
  e2e-monitor · driving the real app end to end
  provider anthropic/claude-haiku-4-5  ·  run 20260601-141003
  Captures an evidence bundle for an AI agent to JUDGE — built to run (or via
  the /monitor-e2e skill) while you work on the app as normal.

  ✓ seed-master   canonical master → isolated DB (your real DB is untouched)
  ▶ boot          spawning backend :8000 + frontend :3000 …
  ✓ boot          backend up + frontend up
  ▶ backend-eng      tailor → judge → render …
  ✓ backend-eng      judge=5  kw=0.625  render=non-blank  fabricated=0
  …(per variation)…
  ──────────────────────────────────────────────────────────────
  sweep complete · 4 variations · flow all passed · renders 4/4 non-blank · no regression vs baseline

  ↳ NEXT — this is captured EVIDENCE, not a verdict. Hand it to an AI agent:
      • In Claude Code, invoke the  /monitor-e2e  skill, or just say
        "judge the latest e2e-monitor bundle".
      The agent reads the logs + artifacts, separates real issues from noise,
      and writes report.md. This harness is built to be DRIVEN BY an AI agent
      debugging in the background while you build the app as normal.
```

Plus a README reframe: the bare CLI is the *plumbing*; **the front door is the agent** (`/monitor-e2e` runs the sweep *and* judges in one step).

No change to the capture itself — `bundle: <path>` still prints on stdout for scripts/agents. Full backend suite: **355 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add live narration to the `e2e_monitor` CLI sweep and clarify the agent handoff, plus fix render failure reporting and step ordering. Stdout still prints only `bundle: <path>` for scripts.

- **New Features**
  - `cmd_sweep` narrates the loop to stderr: seed → boot → per-variation tailor/judge/render with score, keyword coverage, render status, fabricated count, then a sweep summary with baseline regression note and an explicit agent handoff.
  - README reframed: the sweep captures evidence; the agent provides the verdict. The front door is `/monitor-e2e`.

- **Bug Fixes**
  - Render status is tracked precisely (skipped / non-blank / BLANK! / FAILED), and the ✓/⚠ marker now reflects real outcomes (✓ only when the judge produced a score and render didn’t fail/blank).
  - `flow-trace.json` ordering fixed: `seed-master` is recorded before `boot` to match execution.

<sup>Written for commit c25674969cfd55bc830ded1992313eaf0600264d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

