### PR TITLE
fix(pdf): deterministic render wait + generic error; contain error modal (#799 #808 #811)

### DIFF
--- a/apps/backend/app/pdf.py
+++ b/apps/backend/app/pdf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 from pathlib import Path
@@ -15,6 +16,14 @@ from playwright.async_api import (
     Playwright,
     async_playwright,
 )
+
+logger = logging.getLogger(__name__)
+
+# Explicit, bounded navigation/selector timeout. Chosen over Playwright's
+# implicit 30s default so a slow-but-working render (large resume, cold cache,
+# modest hardware) still completes, while a genuinely stuck page still fails
+# in finite time rather than hanging.
+_NAV_TIMEOUT_MS = 60_000
 
 
 class PDFRenderError(Exception):
@@ -133,8 +142,15 @@ async def _render_page_to_pdf(
     pdf_format: str,
     pdf_margins: dict,
 ) -> bytes:
-    await page.goto(url, wait_until="networkidle")
-    await page.wait_for_selector(selector)
+    # NOTE: do NOT use wait_until="networkidle" here. The Next.js dev server
+    # (HMR/Turbopack + RSC streaming) keeps the network busy, so "idle" may
+    # never arrive and goto silently hangs until timeout → 503 (issues
+    # #799/#808), with the failure depending on environment/network noise.
+    # Wait on the real readiness condition instead — document "load", the
+    # resume content selector, and fonts — all bounded by an explicit timeout
+    # so the outcome is deterministic.
+    await page.goto(url, wait_until="load", timeout=_NAV_TIMEOUT_MS)
+    await page.wait_for_selector(selector, timeout=_NAV_TIMEOUT_MS)
     await page.evaluate("document.fonts.ready")
     return await page.pdf(
         format=pdf_format,
@@ -224,7 +240,15 @@ def _raise_playwright_error(error: PlaywrightError, url: str) -> NoReturn:
             f"2) The FRONTEND_BASE_URL environment variable in the backend .env file "
             f"matches the URL where your frontend is accessible."
         ) from error
-    raise PDFRenderError(f"PDF rendering failed: {error_msg}") from error
+    # Catch-all: the raw Playwright message can carry internal navigation URLs
+    # and a full call log. Log it server-side; return a generic message to the
+    # client (CLAUDE.md rule 5 — and it stops the verbose trace from overflowing
+    # the client error modal, #811).
+    logger.error("PDF rendering failed for %s: %s", url, error_msg)
+    raise PDFRenderError(
+        "PDF rendering failed. The page took too long to render or returned an "
+        "error. Please try again; if the problem persists, check the backend logs."
+    ) from error
 
 
 def _loop_supports_subprocess() -> bool:

--- a/apps/backend/app/pdf.py
+++ b/apps/backend/app/pdf.py
@@ -246,8 +246,8 @@ def _raise_playwright_error(error: PlaywrightError, url: str) -> NoReturn:
     # the client error modal, #811).
     logger.error("PDF rendering failed for %s: %s", url, error_msg)
     raise PDFRenderError(
-        "PDF rendering failed. The page took too long to render or returned an "
-        "error. Please try again; if the problem persists, check the backend logs."
+        "PDF rendering failed — the page took too long to render or returned an "
+        "error. Please try again, or try a simpler resume or a different template."
     ) from error
 
 

--- a/apps/backend/app/pdf.py
+++ b/apps/backend/app/pdf.py
@@ -151,7 +151,11 @@ async def _render_page_to_pdf(
     # so the outcome is deterministic.
     await page.goto(url, wait_until="load", timeout=_NAV_TIMEOUT_MS)
     await page.wait_for_selector(selector, timeout=_NAV_TIMEOUT_MS)
-    await page.evaluate("document.fonts.ready")
+    # Bound the fonts wait too — plain page.evaluate has no timeout, so a stuck
+    # font load could otherwise hang the render past _NAV_TIMEOUT_MS.
+    await page.wait_for_function(
+        "() => document.fonts.ready.then(() => true)", timeout=_NAV_TIMEOUT_MS
+    )
     return await page.pdf(
         format=pdf_format,
         print_background=True,
@@ -246,8 +250,8 @@ def _raise_playwright_error(error: PlaywrightError, url: str) -> NoReturn:
     # the client error modal, #811).
     logger.error("PDF rendering failed for %s: %s", url, error_msg)
     raise PDFRenderError(
-        "PDF rendering failed — the page took too long to render or returned an "
-        "error. Please try again, or try a simpler resume or a different template."
+        "PDF rendering failed. Please try again, or try a simpler resume or a "
+        "different template."
     ) from error
 
 

--- a/apps/backend/tests/integration/test_pdf_render.py
+++ b/apps/backend/tests/integration/test_pdf_render.py
@@ -17,12 +17,15 @@ be launched.
 """
 
 import socket
+from unittest.mock import AsyncMock
 
 import pytest
 from playwright.async_api import Error as PlaywrightError
 
 from app.pdf import (
     PDFRenderError,
+    _raise_playwright_error,
+    _render_page_to_pdf,
     _resolve_pdf_format,
     _resolve_pdf_margins,
     close_pdf_renderer,
@@ -143,6 +146,77 @@ class TestResolvePdfMargins:
             "bottom": "10mm",
             "left": "10mm",
         }
+
+
+class TestRenderPageWaitStrategy:
+    """#799/#808: rendering must wait on a deterministic readiness condition
+    (document 'load' + the resume content selector + fonts), NOT the
+    environment-fragile 'networkidle' that hangs against the Next.js dev server
+    (HMR/Turbopack/RSC streaming keep the network busy, so idle never arrives →
+    30s timeout → 503). These are browser-free: they mock the Playwright Page.
+    """
+
+    async def test_goto_does_not_wait_for_networkidle(self):
+        page = AsyncMock()
+        page.pdf.return_value = b"%PDF-1.4 fake"
+        await _render_page_to_pdf(page, "http://f/print/r", ".resume-print", "A4", {"top": "10mm"})
+        _, goto_kwargs = page.goto.call_args
+        assert goto_kwargs.get("wait_until") != "networkidle"
+
+    async def test_goto_uses_load_with_bounded_timeout(self):
+        page = AsyncMock()
+        page.pdf.return_value = b"%PDF-1.4 fake"
+        await _render_page_to_pdf(page, "http://f/print/r", ".resume-print", "A4", {"top": "10mm"})
+        _, goto_kwargs = page.goto.call_args
+        assert goto_kwargs.get("wait_until") == "load"
+        # An explicit, positive, bounded navigation timeout (not the fragile default).
+        timeout = goto_kwargs.get("timeout")
+        assert isinstance(timeout, (int, float)) and timeout > 0
+
+    async def test_still_gates_on_content_selector(self):
+        """The real readiness signal — the resume content must be present."""
+        page = AsyncMock()
+        page.pdf.return_value = b"%PDF-1.4 fake"
+        await _render_page_to_pdf(page, "http://f/print/r", ".resume-print", "A4", {"top": "10mm"})
+        page.wait_for_selector.assert_awaited()
+        selector_arg = page.wait_for_selector.call_args.args[0]
+        assert selector_arg == ".resume-print"
+
+
+class TestPlaywrightErrorMapping:
+    """#811 + info-disclosure (CLAUDE.md rule 5): the catch-all must NOT leak raw
+    Playwright internals (call log, internal navigation URLs) to the client;
+    curated, safe messages must be preserved.
+    """
+
+    def test_catch_all_is_generic_and_hides_internals(self):
+        raw = (
+            "Page.goto: Timeout 30000ms exceeded.\n"
+            "Call log:\n"
+            '  - navigating to "http://localhost:3000/print/resumes/SECRET-RESUME-ID"'
+        )
+        with pytest.raises(PDFRenderError) as exc_info:
+            _raise_playwright_error(PlaywrightError(raw), "http://localhost:3000/print/resumes/SECRET-RESUME-ID")
+        msg = str(exc_info.value)
+        assert "Call log" not in msg
+        assert "SECRET-RESUME-ID" not in msg
+        assert "30000ms" not in msg
+
+    def test_connection_refused_message_preserved(self):
+        with pytest.raises(PDFRenderError) as exc_info:
+            _raise_playwright_error(
+                PlaywrightError("net::ERR_CONNECTION_REFUSED at http://localhost:3000"),
+                "http://localhost:3000/print/x",
+            )
+        assert "cannot connect to frontend" in str(exc_info.value).lower()
+
+    def test_missing_executable_message_preserved(self):
+        with pytest.raises(PDFRenderError) as exc_info:
+            _raise_playwright_error(
+                PlaywrightError("Executable doesn't exist at /ms-playwright/chromium"),
+                "http://x/",
+            )
+        assert "playwright install" in str(exc_info.value).lower()
 
 
 class TestRenderResumePdf:

--- a/apps/backend/tests/integration/test_pdf_render.py
+++ b/apps/backend/tests/integration/test_pdf_render.py
@@ -156,13 +156,6 @@ class TestRenderPageWaitStrategy:
     30s timeout → 503). These are browser-free: they mock the Playwright Page.
     """
 
-    async def test_goto_does_not_wait_for_networkidle(self):
-        page = AsyncMock()
-        page.pdf.return_value = b"%PDF-1.4 fake"
-        await _render_page_to_pdf(page, "http://f/print/r", ".resume-print", "A4", {"top": "10mm"})
-        _, goto_kwargs = page.goto.call_args
-        assert goto_kwargs.get("wait_until") != "networkidle"
-
     async def test_goto_uses_load_with_bounded_timeout(self):
         page = AsyncMock()
         page.pdf.return_value = b"%PDF-1.4 fake"
@@ -181,6 +174,13 @@ class TestRenderPageWaitStrategy:
         page.wait_for_selector.assert_awaited()
         selector_arg = page.wait_for_selector.call_args.args[0]
         assert selector_arg == ".resume-print"
+
+    async def test_still_waits_for_fonts(self):
+        """Fonts must be loaded before snapshot, else text can render unstyled."""
+        page = AsyncMock()
+        page.pdf.return_value = b"%PDF-1.4 fake"
+        await _render_page_to_pdf(page, "http://f/print/r", ".resume-print", "A4", {"top": "10mm"})
+        page.evaluate.assert_any_await("document.fonts.ready")
 
 
 class TestPlaywrightErrorMapping:

--- a/apps/backend/tests/integration/test_pdf_render.py
+++ b/apps/backend/tests/integration/test_pdf_render.py
@@ -175,12 +175,15 @@ class TestRenderPageWaitStrategy:
         selector_arg = page.wait_for_selector.call_args.args[0]
         assert selector_arg == ".resume-print"
 
-    async def test_still_waits_for_fonts(self):
-        """Fonts must be loaded before snapshot, else text can render unstyled."""
+    async def test_still_waits_for_fonts_bounded(self):
+        """Fonts must be loaded before snapshot (else text renders unstyled), and
+        the wait must be bounded by the nav timeout — not Playwright's default."""
         page = AsyncMock()
         page.pdf.return_value = b"%PDF-1.4 fake"
         await _render_page_to_pdf(page, "http://f/print/r", ".resume-print", "A4", {"top": "10mm"})
-        page.evaluate.assert_any_await("document.fonts.ready")
+        page.wait_for_function.assert_awaited()
+        assert "fonts" in page.wait_for_function.call_args.args[0]
+        assert page.wait_for_function.call_args.kwargs.get("timeout")
 
 
 class TestPlaywrightErrorMapping:

--- a/apps/frontend/components/ui/confirm-dialog.tsx
+++ b/apps/frontend/components/ui/confirm-dialog.tsx
@@ -117,7 +117,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
               <DialogTitle className="font-serif text-xl font-bold uppercase tracking-tight">
                 {title}
               </DialogTitle>
-              <DialogDescription className="font-mono text-xs text-ink-soft mt-2">
+              <DialogDescription className="font-mono text-xs text-ink-soft mt-2 max-h-60 overflow-y-auto whitespace-pre-wrap [overflow-wrap:anywhere]">
                 {description}
               </DialogDescription>
             </div>
@@ -125,7 +125,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         </DialogHeader>
         {errorMessage && (
           <div className="px-6 pb-4">
-            <div className="border-2 border-red-600 bg-red-50 p-3 font-mono text-xs text-red-700">
+            <div className="border-2 border-red-600 bg-red-50 p-3 font-mono text-xs text-red-700 max-h-60 overflow-y-auto whitespace-pre-wrap [overflow-wrap:anywhere]">
               {errorMessage}
             </div>
           </div>


### PR DESCRIPTION
Fixes #799 and #808 (PDF download 503 / `Page.goto: Timeout 30000ms exceeded`), and the root cause of #811 (overflowing error modal).

## Root cause (verified, not assumed)
`pdf.py` waited `wait_until="networkidle"`. networkidle requires 500ms of network silence, but the **Next.js dev server (HMR/Turbopack + RSC streaming) keeps the socket busy**, so "idle" may never arrive — `goto` then hangs to its default 30s timeout → `PDFRenderError` → **503**. This is *environment-dependent* (it renders fine in our e2e monitor but fails for the reporters), which is the signature of a fragile wait condition rather than a real load problem.

## Changes
- **`pdf.py` — wait on the real readiness condition.** `wait_until="load"` + the existing `.resume-print` content-selector wait + `document.fonts.ready`, all bounded by an explicit 60s timeout. Deterministic regardless of dev-server network noise.
- **`pdf.py` — stop leaking internals (CLAUDE.md rule 5).** The catch-all path returned the raw Playwright message — including the internal navigation URL and full call log — straight into the 503 body. Now logged server-side; client gets a generic message. This *also* removes the verbose trace that was overflowing the modal (**#811 root cause**).
- **`confirm-dialog.tsx` — defense-in-depth (#811).** Contain long `description`/`errorMessage` text (`max-h-60 overflow-y-auto` + wrap) so *any* message stays inside the modal.

## Verification
- `uv run pytest` → **375 passed, 1 deselected**. New browser-free tests assert: `goto` no longer uses `networkidle` and passes a bounded timeout; content-selector gating preserved; catch-all hides internals (no call log / internal URL) while curated messages (connection-refused, missing-executable) are preserved.
- The **real-Chromium render test still passes** with the new wait strategy (valid `%PDF` bytes), so this isn't mock-only.
- **No new dependencies.** Frontend CSS not lint/built locally (nvm constraint) — relies on reviewer/CI.

## Notes
Separately tracked, not in this PR: #776 (configurable timeout — it's a 3-layer issue: backend + Next `proxyTimeout` + client `AbortController`), #760 (Base URL clear), #763 (Additional Info newlines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent PDF 503/timeouts by replacing `networkidle` with deterministic `load` + selector + fonts readiness, all capped at 60s. Also returns a neutral, user-friendly error and contains long error text in the modal. Fixes #799, #808, and #811.

- **Bug Fixes**
  - Backend: use `wait_until="load"` with a 60s timeout, gate on the resume selector, and await fonts via `page.wait_for_function(..., timeout)` to keep all waits bounded and deterministic.
  - Backend: log raw `Playwright` errors server-side and return a neutral, generic client message; curated messages for connection-refused and missing-executable are preserved.
  - Frontend: cap error text height, add scroll, and wrap long content in the confirm dialog to prevent overflow.
  - Tests: add browser-free checks for `load` + selector + bounded fonts wait and error redaction; drop a brittle negative assert. Real Chromium PDF render still passes. No new dependencies.

<sup>Written for commit 5d940c66bae0d7c65932b550b8f48b84cfff1778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

