### PR TITLE
fix(config): clearing Base URL persists null, not a stale value (#760)

### DIFF
--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -134,8 +134,14 @@ async def update_llm_config(
         stored["model"] = request.model
     if request.api_key is not None:
         stored["api_key"] = request.api_key
-    if request.api_base is not None:
-        stored["api_base"] = request.api_base
+    # api_base: distinguish "omitted" (leave unchanged) from "present but
+    # blank/null" (explicit clear). The frontend sends api_base: null/"" when
+    # the Base URL field is cleared; treating that as "don't change" left a
+    # stale override in config.json (issue #760). Normalize blank → None so an
+    # empty string also never reaches LiteLLM as a bogus endpoint.
+    if "api_base" in request.model_fields_set:
+        cleaned = (request.api_base or "").strip()
+        stored["api_base"] = cleaned or None
     if request.reasoning_effort is not None:
         # Persist empty string on clear so the gpt-5 auto-migration doesn't
         # re-fire on next get_llm_config() call.

--- a/apps/backend/tests/integration/test_config_api.py
+++ b/apps/backend/tests/integration/test_config_api.py
@@ -73,6 +73,62 @@ class TestLlmConfig:
         assert data["api_key"].startswith("loca")
         assert data["api_key"].endswith("-key")
         assert "*" in data["api_key"]
+
+    # --- Base URL clearing (issue #760) ----------------------------------
+    # The frontend sends api_base: null (or "") when the field is cleared.
+    # A null/blank value that is *present* in the request must clear the
+    # stored override; an *omitted* field must leave it unchanged.
+
+    @patch("app.routers.config._log_llm_health_check", new_callable=AsyncMock)
+    @patch("app.routers.config._save_config")
+    @patch("app.routers.config._load_config")
+    async def test_put_null_api_base_clears_stale_value(
+        self, mock_load, mock_save, mock_log_health, client
+    ):
+        mock_load.return_value = {
+            "provider": "openrouter",
+            "model": "x",
+            "api_base": "http://stale.example/v1",
+        }
+        async with client:
+            resp = await client.put(
+                "/api/v1/config/llm-api-key",
+                json={"provider": "openrouter", "api_base": None},
+            )
+        assert resp.status_code == 200
+        saved_config = mock_save.call_args.args[0]
+        assert saved_config["api_base"] is None
+        assert resp.json()["api_base"] is None
+
+    @patch("app.routers.config._log_llm_health_check", new_callable=AsyncMock)
+    @patch("app.routers.config._save_config")
+    @patch("app.routers.config._load_config")
+    async def test_put_blank_api_base_is_normalized_to_none(
+        self, mock_load, mock_save, mock_log_health, client
+    ):
+        mock_load.return_value = {"provider": "openrouter", "api_base": "http://stale/v1"}
+        async with client:
+            resp = await client.put(
+                "/api/v1/config/llm-api-key",
+                json={"provider": "openrouter", "api_base": "   "},
+            )
+        assert resp.status_code == 200
+        assert mock_save.call_args.args[0]["api_base"] is None
+
+    @patch("app.routers.config._log_llm_health_check", new_callable=AsyncMock)
+    @patch("app.routers.config._save_config")
+    @patch("app.routers.config._load_config")
+    async def test_put_omitting_api_base_leaves_it_unchanged(
+        self, mock_load, mock_save, mock_log_health, client
+    ):
+        mock_load.return_value = {"provider": "openrouter", "api_base": "http://keep/v1"}
+        async with client:
+            resp = await client.put(
+                "/api/v1/config/llm-api-key",
+                json={"model": "new-model"},  # api_base intentionally omitted
+            )
+        assert resp.status_code == 200
+        assert mock_save.call_args.args[0]["api_base"] == "http://keep/v1"
         mock_log_health.assert_awaited_once()
 
 


### PR DESCRIPTION
Fixes #760 — clearing the **Base URL / API endpoint** in Settings didn't take effect; the backend kept using the previous `api_base` (only a manual `config.json` edit recovered it).

## Root cause (verified against code, not the report)
The Settings page sends `api_base: apiBase.trim() || null` (`settings/page.tsx:363,405`) — so **clearing the field sends `null`**. The save handler used `if request.api_base is not None:` (`config.py:137`), which treats `null` as "don't change" → the stale override stays in `config.json`.

## Fix (backend-only)
Use Pydantic `model_fields_set` to distinguish **omitted** (leave unchanged) from **present but blank/null** (explicit clear → `None`), and normalize blank/whitespace → `None` so an empty string can't reach LiteLLM as a bogus endpoint. No frontend change needed; robust to either `null` or `""`.

**Second-order / security:** a stale `api_base` can silently route a paid API key to a previously-configured endpoint — clearing it correctly closes that.

## Verification
- `uv run pytest` → **372 passed, 1 deselected**. New tests: `null` clears a stale value; blank/whitespace normalizes to `None`; omitting the field leaves it unchanged.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #760: clearing the Base URL in Settings now clears the backend value and stops routing to a stale endpoint. This prevents paid keys from being sent to a previously configured API base.

- **Bug Fixes**
  - Distinguish omitted vs present `api_base` using Pydantic `model_fields_set`; present null/blank clears to `None`.
  - Normalize blank/whitespace to `None` so an empty string never reaches `LiteLLM`.
  - Keep `api_base` unchanged when the field is omitted.
  - Added integration tests for null clear, blank normalization, and omission behavior.

<sup>Written for commit f6c1c6b134f83d5a02dfb1fd6ab1660774fa416c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

