### PR TITLE
fix(improver): salvage skill reorder instead of dropping it wholesale (#736)

### DIFF
--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -314,23 +314,57 @@ def apply_diffs(
             if not isinstance(actual_value, list) or not isinstance(change.value, list):
                 rejected.append(change)
                 continue
-            # Validate same items (case-insensitive)
             orig_set = sorted(s.casefold() for s in actual_value if isinstance(s, str))
             new_set = sorted(s.casefold() for s in change.value if isinstance(s, str))
-            if orig_set != new_set:
-                logger.info("Diff rejected (reorder items mismatch): %s", path)
-                rejected.append(change)
-                continue
-            # Preserve original casing: map new order back to original strings
-            casefold_to_originals: dict[str, list[str]] = {}
-            for item in actual_value:
-                if isinstance(item, str):
-                    casefold_to_originals.setdefault(item.casefold(), []).append(item)
             reordered: list[str] = []
-            for item in change.value:
-                if isinstance(item, str):
-                    originals = casefold_to_originals.get(item.casefold(), [])
-                    reordered.append(originals.pop(0) if originals else item)
+            if orig_set == new_set:
+                # Pure permutation: map the new order back to original casing.
+                casefold_to_originals: dict[str, list[str]] = {}
+                for item in actual_value:
+                    if isinstance(item, str):
+                        casefold_to_originals.setdefault(item.casefold(), []).append(item)
+                for item in change.value:
+                    if isinstance(item, str):
+                        originals = casefold_to_originals.get(item.casefold(), [])
+                        reordered.append(originals.pop(0) if originals else item)
+            else:
+                # Salvage (issue #736): the LLM folded new/removed items into a
+                # reorder. Rather than dropping the whole change, apply the SAFE
+                # subset: reorder the existing items in the requested order,
+                # re-append any original the LLM omitted (never silently lose a
+                # real item), and — for the skills list only — add new items that
+                # pass the SAME verified gate as add_skill. Other lists
+                # (languages/certs/awards) have no verifier, so new items are
+                # dropped to avoid fabrication.
+                originals_by_cf: dict[str, str] = {}
+                for item in actual_value:
+                    if isinstance(item, str):
+                        originals_by_cf.setdefault(item.casefold(), item)
+                seen: set[str] = set()
+                for item in change.value:
+                    if not isinstance(item, str):
+                        continue
+                    cf = item.casefold()
+                    if cf in originals_by_cf and cf not in seen:
+                        reordered.append(originals_by_cf[cf])
+                        seen.add(cf)
+                for item in actual_value:  # preserve any omitted originals
+                    if isinstance(item, str) and item.casefold() not in seen:
+                        reordered.append(item)
+                        seen.add(item.casefold())
+                if path == "additional.technicalSkills":
+                    for item in change.value:  # add only verified new skills
+                        if not isinstance(item, str):
+                            continue
+                        skill = item.strip()
+                        if not skill or skill.casefold() in seen:
+                            continue
+                        if _normalize_skill_key(skill) in allowed_skill_keys:
+                            reordered.append(skill)
+                            seen.add(skill.casefold())
+                        else:
+                            logger.info("Reorder salvage dropped unverified skill: %s", skill)
+                logger.info("Diff reorder salvaged (item-set mismatch): %s", path)
             if not _set_at_path(result, path, reordered):
                 rejected.append(change)
                 continue

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -330,40 +330,43 @@ def apply_diffs(
             else:
                 # Salvage (issue #736): the LLM folded new/removed items into a
                 # reorder. Rather than dropping the whole change, apply the SAFE
-                # subset: reorder the existing items in the requested order,
-                # re-append any original the LLM omitted (never silently lose a
-                # real item), and — for the skills list only — add new items that
-                # pass the SAME verified gate as add_skill. Other lists
+                # subset *in the requested order*: walk the proposed list, placing
+                # each existing item where the model put it (so prioritized JD
+                # skills stay near the top) and — for the skills list only —
+                # inserting new items that pass the SAME verified gate as
+                # add_skill. Originals the model omitted are appended at the end
+                # so a real item is never silently lost. Other lists
                 # (languages/certs/awards) have no verifier, so new items are
                 # dropped to avoid fabrication.
-                originals_by_cf: dict[str, str] = {}
+                casefold_to_originals: dict[str, list[str]] = {}
                 for item in actual_value:
                     if isinstance(item, str):
-                        originals_by_cf.setdefault(item.casefold(), item)
-                seen: set[str] = set()
+                        casefold_to_originals.setdefault(item.casefold(), []).append(item)
+                original_cfs = set(casefold_to_originals)
+                is_skills = path == "additional.technicalSkills"
+                added_new: set[str] = set()
                 for item in change.value:
                     if not isinstance(item, str):
                         continue
                     cf = item.casefold()
-                    if cf in originals_by_cf and cf not in seen:
-                        reordered.append(originals_by_cf[cf])
-                        seen.add(cf)
-                for item in actual_value:  # preserve any omitted originals
-                    if isinstance(item, str) and item.casefold() not in seen:
-                        reordered.append(item)
-                        seen.add(item.casefold())
-                if path == "additional.technicalSkills":
-                    for item in change.value:  # add only verified new skills
-                        if not isinstance(item, str):
-                            continue
+                    if cf in original_cfs:
+                        bucket = casefold_to_originals[cf]
+                        if bucket:  # place original in requested position (dupes preserved)
+                            reordered.append(bucket.pop(0))
+                        # else: a duplicate of an already-placed original — skip
+                    elif is_skills and cf not in added_new:
                         skill = item.strip()
-                        if not skill or skill.casefold() in seen:
-                            continue
-                        if _normalize_skill_key(skill) in allowed_skill_keys:
-                            reordered.append(skill)
-                            seen.add(skill.casefold())
+                        if skill and _normalize_skill_key(skill) in allowed_skill_keys:
+                            reordered.append(skill)  # verified new skill, requested position
+                            added_new.add(cf)
                         else:
                             logger.info("Reorder salvage dropped unverified skill: %s", skill)
+                    # else: non-skills new item → dropped (no verifier to ground it)
+                for item in actual_value:  # append any originals the model omitted
+                    if isinstance(item, str):
+                        bucket = casefold_to_originals[item.casefold()]
+                        if bucket:
+                            reordered.append(bucket.pop(0))
                 logger.info("Diff reorder salvaged (item-set mismatch): %s", path)
             if not _set_at_path(result, path, reordered):
                 rejected.append(change)
@@ -797,6 +800,11 @@ def verify_skill_target_plan(
                 }
             )
         elif skill_key in jd_skills:
+            # JD-required/preferred skills are accepted as targets so the résumé
+            # can be tailored to actually pass ATS/recruiter screening — adding
+            # relevant JD skills is the product's purpose. (Truly unsupported
+            # skills — neither in the JD nor the résumé — are still rejected
+            # below.) The user reviews additions in the diff preview before save.
             accepted.append(
                 {
                     "skill": jd_skills[skill_key],

--- a/apps/backend/tests/unit/test_apply_diffs.py
+++ b/apps/backend/tests/unit/test_apply_diffs.py
@@ -204,19 +204,25 @@ class TestApplyDiffsReorder:
         assert len(applied) == 1
         assert result["additional"]["technicalSkills"] == reordered
 
-    def test_reorder_rejects_different_items(self, sample_resume):
+    def test_reorder_with_unverified_items_drops_them_keeps_originals(self, sample_resume):
+        """Issue #736: a reorder mixing in new items is salvaged, not dropped —
+        new items without a verified target are removed, originals preserved."""
+        original = sample_resume["additional"]["technicalSkills"]
         changes = [
             ResumeChange(
                 path="additional.technicalSkills",
                 action="reorder",
                 original=None,
-                value=["Python", "Kubernetes", "Go"],  # Different items
+                value=["Python", "Kubernetes", "Go"],  # Kubernetes/Go new, no verified targets
                 reason="test",
             )
         ]
         result, applied, rejected = apply_diffs(sample_resume, changes)
-        assert len(applied) == 0
-        assert len(rejected) == 1
+        skills = result["additional"]["technicalSkills"]
+        assert len(applied) == 1 and len(rejected) == 0
+        assert "Kubernetes" not in skills and "Go" not in skills
+        assert set(skills) == set(original)
+        assert skills[0] == "Python"
 
     def test_reorder_case_insensitive_matching(self, sample_resume):
         original_skills = sample_resume["additional"]["technicalSkills"]
@@ -525,19 +531,24 @@ class TestApplyDiffsEdgeCases:
         result, applied, rejected = apply_diffs(sample_resume, changes)
         assert len(rejected) == 1
 
-    def test_reorder_with_duplicates_rejected(self, sample_resume):
-        """Reorder that adds duplicates not in original should be rejected."""
+    def test_reorder_with_duplicates_is_deduped_and_preserves_originals(self, sample_resume):
+        """Issue #736: a reorder with a duplicate and missing items is salvaged —
+        the duplicate is collapsed and every original is preserved (no loss)."""
+        original = sample_resume["additional"]["technicalSkills"]
         changes = [
             ResumeChange(
                 path="additional.technicalSkills",
                 action="reorder",
                 original=None,
-                value=["Python", "Python", "Docker", "AWS", "PostgreSQL"],  # Python duplicated, Redis missing
+                value=["Python", "Python", "Docker", "AWS", "PostgreSQL"],  # Python duplicated, Redis/FastAPI missing
                 reason="test",
             )
         ]
         result, applied, rejected = apply_diffs(sample_resume, changes)
-        assert len(rejected) == 1
+        skills = result["additional"]["technicalSkills"]
+        assert len(applied) == 1
+        assert skills.count("Python") == 1          # duplicate collapsed
+        assert set(skills) == set(original)          # nothing lost
 
     def test_empty_path_rejected(self, sample_resume):
         """Empty path string should be rejected."""
@@ -706,3 +717,100 @@ class TestApplyDiffsNewPaths:
         _result, applied, rejected = apply_diffs(sample_resume, changes)
         assert len(applied) == 0
         assert len(rejected) == 1
+
+
+class TestReorderSalvage:
+    """Issue #736: a reorder whose items don't exactly match the original must be
+    SALVAGED, not dropped wholesale — reorder existing items, never lose an
+    original, and (skills only) add new items that pass the verified gate."""
+
+    def test_reorder_with_verified_new_skill_is_salvaged(self, sample_resume):
+        original = sample_resume["additional"]["technicalSkills"]  # 6 items
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="reorder",
+                original=None,
+                value=["FastAPI", "Python", "Docker", "AWS", "PostgreSQL", "Redis", "Kubernetes"],
+                reason="surface JD skills; Kubernetes is JD-required",
+            )
+        ]
+        result, applied, rejected = apply_diffs(
+            sample_resume, changes, allowed_skill_targets=[{"skill": "Kubernetes"}]
+        )
+        skills = result["additional"]["technicalSkills"]
+        assert len(applied) == 1 and len(rejected) == 0
+        assert "Kubernetes" in skills                      # verified new skill added
+        assert set(original).issubset(set(skills))         # no original lost
+        assert skills[0] == "FastAPI"                       # LLM order honored
+
+    def test_reorder_with_unverified_new_skill_drops_only_that_skill(self, sample_resume):
+        original = sample_resume["additional"]["technicalSkills"]
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="reorder",
+                original=None,
+                value=["Redis", "Python", "FastAPI", "Docker", "AWS", "PostgreSQL", "Rust"],
+                reason="Rust is not in the verified targets",
+            )
+        ]
+        result, applied, rejected = apply_diffs(
+            sample_resume, changes, allowed_skill_targets=[{"skill": "Kubernetes"}]
+        )
+        skills = result["additional"]["technicalSkills"]
+        assert len(applied) == 1                            # salvaged, not rejected
+        assert "Rust" not in skills                         # unverified addition dropped
+        assert set(original).issubset(set(skills))          # originals preserved
+        assert skills[0] == "Redis"
+
+    def test_reorder_omitting_original_skill_preserves_it(self, sample_resume):
+        original = sample_resume["additional"]["technicalSkills"]
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="reorder",
+                original=None,
+                value=["Redis", "Python"],  # omits 4 originals
+                reason="prioritize two skills",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        skills = result["additional"]["technicalSkills"]
+        assert len(applied) == 1
+        assert set(skills) == set(original)                 # nothing lost
+        assert skills[:2] == ["Redis", "Python"]            # requested order first
+
+    def test_reorder_languages_with_new_item_drops_it(self, sample_resume):
+        original = sample_resume["additional"]["languages"]
+        changes = [
+            ResumeChange(
+                path="additional.languages",
+                action="reorder",
+                original=None,
+                value=["Spanish (Conversational)", "English (Native)", "French (Fluent)"],
+                reason="no verified-target gate for languages — must not fabricate",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        langs = result["additional"]["languages"]
+        assert len(applied) == 1
+        assert "French (Fluent)" not in langs               # no fabrication
+        assert set(langs) == set(original)
+
+    def test_pure_permutation_still_applies(self, sample_resume):
+        """Regression: an exact permutation keeps working unchanged."""
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="reorder",
+                original=None,
+                value=["Redis", "PostgreSQL", "AWS", "Docker", "FastAPI", "Python"],
+                reason="pure reorder",
+            )
+        ]
+        result, applied, rejected = apply_diffs(sample_resume, changes)
+        assert len(applied) == 1 and len(rejected) == 0
+        assert result["additional"]["technicalSkills"] == [
+            "Redis", "PostgreSQL", "AWS", "Docker", "FastAPI", "Python"
+        ]

--- a/apps/backend/tests/unit/test_apply_diffs.py
+++ b/apps/backend/tests/unit/test_apply_diffs.py
@@ -814,3 +814,41 @@ class TestReorderSalvage:
         assert result["additional"]["technicalSkills"] == [
             "Redis", "PostgreSQL", "AWS", "Docker", "FastAPI", "Python"
         ]
+
+    def test_salvage_places_verified_new_skill_in_requested_position(self, sample_resume):
+        """PR #830 review (Copilot): a verified new skill the model puts near the
+        top of the reorder must land there, not be appended last."""
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="reorder",
+                original=None,
+                value=["Kubernetes", "Python", "FastAPI", "Docker", "AWS", "PostgreSQL", "Redis"],
+                reason="prioritize Kubernetes (JD-required, verified)",
+            )
+        ]
+        result, applied, rejected = apply_diffs(
+            sample_resume, changes, allowed_skill_targets=[{"skill": "Kubernetes"}]
+        )
+        skills = result["additional"]["technicalSkills"]
+        assert skills[0] == "Kubernetes"  # requested position honored, not appended last
+        assert set(sample_resume["additional"]["technicalSkills"]).issubset(set(skills))
+
+    def test_salvage_preserves_case_duplicate_originals(self, sample_resume):
+        """PR #830 review (kilo): case-duplicate originals must not be lost."""
+        resume = {"additional": {"technicalSkills": ["python", "Python", "Docker"]}}
+        changes = [
+            ResumeChange(
+                path="additional.technicalSkills",
+                action="reorder",
+                original=None,
+                value=["Docker", "python", "Go"],  # Go new+unverified, both pythons are originals
+                reason="test dup handling",
+            )
+        ]
+        result, applied, rejected = apply_diffs(resume, changes)
+        skills = result["additional"]["technicalSkills"]
+        assert len(applied) == 1
+        # Both case-variants of the original survive; the unverified new item is dropped.
+        assert sorted(skills) == sorted(["python", "Python", "Docker"])
+        assert "Go" not in skills


### PR DESCRIPTION
Fixes #736 — "Skill not parsing or changing." With a master resume + Full Tailor, technical skills were never reordered or added.

## Root cause (verified on current `dev`)
`apply_diffs` (`improver.py`) requires a `reorder` to be an *exact permutation* (`orig_set != new_set` → reject). When the LLM folds **new** skills into a `reorder` instead of using the `add_skill` action — observed with Claude Sonnet, and visible in our own e2e-monitor logs as `Diff rejected (reorder items mismatch): additional.technicalSkills` — the **entire** change is dropped, so nothing changes.

The strict check exists for truthfulness (a `reorder` must not smuggle in unverified skills, bypassing the verified-skill-target gate). So the fix can't just relax it.

## Fix — salvage the safe subset (keeps truthfulness)
On an item-set mismatch, instead of dropping the change:
- reorder the existing items in the requested order;
- **re-append any original the LLM omitted** — never silently lose a real skill;
- **skills list only:** add new items that pass the **same verified gate** as `add_skill` (`allowed_skill_targets`); unverified additions are dropped + logged;
- **languages / certs / awards:** no verifier exists, so new items are dropped — no fabrication.

Pure permutations are unchanged. Net: JD-relevant skills the LLM put in a reorder now get added **iff verified**, the list gets reordered, and originals are always preserved.

## Verification
- `uv run pytest` → **383 passed, 1 deselected**. 5 new salvage tests (verified-add, unverified-drop, omitted-original preserved, languages no-fabricate, pure-permutation regression). Two tests that asserted the old wholesale-reject were re-spec'd to the stronger salvage contract (dedup + originals preserved) — coverage strengthened, not removed.
- No new dependencies. Will run the e2e-monitor on this branch before merge (the monitor exercises this exact reorder path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #736 where mixed-item skill reorders were fully rejected, causing no changes. We now salvage reorders so skills are reordered in the requested order, originals (including case-duplicates) are kept, and only verified new skills are added.

- **Bug Fixes**
  - For `additional.technicalSkills` reorders with item mismatches: salvage the change by reordering in the requested order, re-appending omitted originals, adding only verified new skills (placed where requested), dropping/logging unverified additions, and preserving case-duplicate originals.
  - For `additional.languages`, `certifications`, and `awards`: reorder and preserve originals; drop new items to avoid fabrication.
  - Exact permutations are unchanged; invalid/non-list values remain rejected.

<sup>Written for commit 206a49cbf6c69bbe8343d0b0f7dea0fdefcf9918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

