### PR TITLE
feat(prompts): JD-keyword incorporation as the default across all sections (truthful reframing)

### DIFF
--- a/apps/backend/app/prompts/refinement.py
+++ b/apps/backend/app/prompts/refinement.py
@@ -135,14 +135,15 @@ AI_PHRASE_REPLACEMENTS: dict[str, str] = {
 
 
 # Prompt for injecting missing keywords into a resume
-KEYWORD_INJECTION_PROMPT = """Inject the following keywords into this resume where they can be naturally and TRUTHFULLY incorporated.
+KEYWORD_INJECTION_PROMPT = """Inject the following keywords into this resume by reframing the candidate's existing experience in the job description's language. Target EVERY section (summary, work experience, projects, technical skills) by default.
 
 CRITICAL RULES:
-1. Only add keywords where the master resume provides supporting evidence
+1. Only reframe with keywords the master resume substantively supports (e.g., if the master shows "used Python for data analysis", surface "Python" and "data analysis" language)
 2. Do NOT add skills, technologies, or certifications not in the master resume
-3. Rephrase existing bullet points to include keywords - do not invent new content
+3. Rephrase existing bullet points and content to include keywords - do not invent new content, metrics, or work history
 4. Maintain the exact same JSON structure
 5. Do not use em-dashes (—) or their variants (---, --)
+6. Make keyword incorporation the DEFAULT across all content sections, not an optional enhancement
 
 Keywords to inject (only if supported by master resume):
 {keywords_to_inject}

--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -457,7 +457,7 @@ Output this exact JSON format:
 DIFF_IMPROVE_PROMPT = """Given this resume and job description, output a JSON object with targeted changes to better align the resume with the job.
 
 RULES:
-1. Only modify content — never change names, companies, dates, institutions, or degrees
+1. Only modify content; never change names, companies, dates, institutions, or degrees
 2. Do not invent metrics or achievements not supported by the original resume text
 3. Do not add new work entries, education entries, or project entries
 4. {strategy_instruction}
@@ -465,9 +465,9 @@ RULES:
 6. For each change, explain WHY it helps match the job description
 7. Generate all new text in {output_language}
 8. Do not use em dash characters
-9. Keep changes minimal and targeted — do not rewrite content that already aligns well
+9. Keep changes minimal and targeted; do not rewrite content that already aligns well
 10. Exception to rule 2: you may add a skill only if it appears in the verified skill targets below
-11. By DEFAULT, scan the summary and every work, project, and education description for content that already demonstrates a job-description keyword or skill, and reframe that text using the job description's terminology, while preserving the candidate's actual accomplishment. Do NOT add new work, metrics, or responsibilities; only restate existing content in the JD's language, and verify every reframe stays factually accurate.
+11. By DEFAULT, scan the summary and every work, project, and education description for content that already demonstrates a job-description keyword or skill, and reframe that text using the job description's terminology where it is not already phrased that way (per rule 9, leave content that already aligns well), while preserving the candidate's actual accomplishment. Do NOT add new work, metrics, or responsibilities; only restate existing content in the JD's language, and verify every reframe stays factually accurate.
 12. Preserve original capitalization, especially for proper nouns, technical terms (e.g., REST, API, AWS), and acronyms. Do not change the casing of words that were capitalized in the original.
 
 PATHS you can target:

--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -360,7 +360,7 @@ Requirements:
 - 100-150 words maximum
 - 3-4 short paragraphs
 - Opening: Reference ONE specific thing from the job description (product, tech stack, or problem they're solving) - not generic excitement about "the role"
-- Middle: Pick 1-2 qualifications from resume that DIRECTLY match stated requirements - prioritize relevance over impressiveness
+- Middle: Pick 1-2 qualifications from resume that DIRECTLY match stated requirements, and reframe them in the job's language/terminology where the candidate's proven experience supports it (e.g., if the resume shows "built automated data pipelines" and the job says "ETL," describe that real work as ETL) - prioritize relevance over impressiveness
 - Closing: Simple availability to discuss, no desperate enthusiasm
 - If resume shows career transition, frame the pivot as intentional and relevant
 - Extract company name from job description - do not use placeholders
@@ -467,7 +467,7 @@ RULES:
 8. Do not use em dash characters
 9. Keep changes minimal and targeted — do not rewrite content that already aligns well
 10. Exception to rule 2: you may add a skill only if it appears in the verified skill targets below
-11. Improve work and project bullets around the verified skill targets when the original text supports that alignment
+11. By DEFAULT, scan the summary and every work and project bullet for content that already demonstrates a job-description keyword or skill, and reframe that text using the job description's terminology — while preserving the candidate's actual accomplishment. Do NOT add new work, metrics, or responsibilities; only restate existing content in the JD's language, and verify every reframe stays factually accurate.
 12. Preserve original capitalization, especially for proper nouns, technical terms (e.g., REST, API, AWS), and acronyms. Do not change the casing of words that were capitalized in the original.
 
 PATHS you can target:

--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -467,7 +467,7 @@ RULES:
 8. Do not use em dash characters
 9. Keep changes minimal and targeted — do not rewrite content that already aligns well
 10. Exception to rule 2: you may add a skill only if it appears in the verified skill targets below
-11. By DEFAULT, scan the summary and every work and project bullet for content that already demonstrates a job-description keyword or skill, and reframe that text using the job description's terminology — while preserving the candidate's actual accomplishment. Do NOT add new work, metrics, or responsibilities; only restate existing content in the JD's language, and verify every reframe stays factually accurate.
+11. By DEFAULT, scan the summary and every work, project, and education description for content that already demonstrates a job-description keyword or skill, and reframe that text using the job description's terminology, while preserving the candidate's actual accomplishment. Do NOT add new work, metrics, or responsibilities; only restate existing content in the JD's language, and verify every reframe stays factually accurate.
 12. Preserve original capitalization, especially for proper nouns, technical terms (e.g., REST, API, AWS), and acronyms. Do not change the casing of words that were capitalized in the original.
 
 PATHS you can target:

--- a/apps/backend/tests/unit/test_prompt_guardrails.py
+++ b/apps/backend/tests/unit/test_prompt_guardrails.py
@@ -1,0 +1,42 @@
+"""Content guards on the tailoring prompts.
+
+Two invariants this locks:
+1. JD-keyword incorporation is the DEFAULT across sections (the maintainer goal).
+2. The anti-fabrication clauses stay present. Per the truthfulness audit,
+   invented bullet *narrative* (e.g. "led 12 engineers") is NOT caught by
+   verify_diff_result (its metric regex misses bare counts) or verify_alignment
+   (which only checks skills/certs/companies) — so these prompt clauses are the
+   ONLY guard. If a future edit drops them, this test fails loudly.
+"""
+
+from app.prompts.templates import COVER_LETTER_PROMPT, DIFF_IMPROVE_PROMPT
+from app.prompts.refinement import KEYWORD_INJECTION_PROMPT
+
+
+class TestJdIncorporationIsDefault:
+    def test_diff_prompt_reframes_by_default(self):
+        assert "By DEFAULT" in DIFF_IMPROVE_PROMPT
+        assert "reframe" in DIFF_IMPROVE_PROMPT.lower()
+
+    def test_keyword_injection_targets_every_section_by_default(self):
+        assert "EVERY section" in KEYWORD_INJECTION_PROMPT
+        assert "DEFAULT" in KEYWORD_INJECTION_PROMPT
+
+    def test_cover_letter_reframes_in_jd_terminology(self):
+        assert "terminology" in COVER_LETTER_PROMPT.lower()
+
+
+class TestAntiFabricationClausesPresent:
+    def test_diff_prompt_keeps_no_invented_work_clauses(self):
+        # rule 11's reframe permission must ship WITH its anti-fabrication clause
+        assert "Do NOT add new work, metrics, or responsibilities" in DIFF_IMPROVE_PROMPT
+        # rule 2 must remain
+        assert "Do not invent metrics or achievements not supported by the original resume" in DIFF_IMPROVE_PROMPT
+
+    def test_keyword_injection_keeps_no_invent_clauses(self):
+        assert "do not invent new content, metrics, or work history" in KEYWORD_INJECTION_PROMPT
+        assert "Do NOT add skills, technologies, or certifications not in the master resume" in KEYWORD_INJECTION_PROMPT
+
+    def test_cover_letter_keeps_no_invent_clauses(self):
+        assert "Do NOT invent information not in the resume" in COVER_LETTER_PROMPT
+        assert "proven experience supports it" in COVER_LETTER_PROMPT


### PR DESCRIPTION
Makes the tailoring pull JD-relevant keywords through **every** section (summary, work experience, projects, skills, cover letter) **by default** — the thing that actually moves an ATS/recruiter score — via **truthful reframing** of the candidate's real experience in the JD's language. Explicitly **not** by inventing accomplishments or work history.

## Changes (3 prompt surfaces)
- **`DIFF_IMPROVE_PROMPT` rule 11** — was conditional ("improve bullets … *when the original text supports that alignment*"); now a systematic per-section reframe pass, shipped *with* its anti-fabrication clause: *"Do NOT add new work, metrics, or responsibilities; only restate existing content in the JD's language, and verify every reframe stays factually accurate."*
- **`COVER_LETTER_PROMPT`** — reframe qualifications in the job's terminology, gated to *"where the candidate's proven experience supports it"* (with a data-pipelines→ETL example showing terminology-shift, not new claims). The existing "Do NOT invent information not in the resume" line is untouched.
- **`KEYWORD_INJECTION_PROMPT`** (refiner) — target EVERY section by default; stronger evidentiary bar ("substantively supports") and no-invent clause ("do not invent new content, metrics, or work history").

## Truthfulness (the important part)
Designed and **adversarially truthfulness-audited** via a subagent workflow (4 analysts + 1 auditor). Key finding I acted on: invented bullet *narrative* (e.g. "led 12 engineers") is **not** caught by `verify_diff_result` (its metric regex misses bare counts) or `verify_alignment` (skills/certs/companies only) — so the prompt clauses are the **sole** guard. They're now locked by `tests/unit/test_prompt_guardrails.py`, which fails if either the default-incorporation language *or* the anti-fabrication clauses are dropped.

Skipped one proposed edit (`CRITICAL_TRUTHFULNESS_RULES['keywords']` reorder permission) — marginal value, and it touches the full-output fallback that lacks a diff check.

## Verification
- `uv run pytest` → **391 passed, 1 deselected**. `.format()` placeholders verified intact on all three prompts.
- No new dependencies.
- Will run the e2e-monitor on this branch before merge (it'll show JD keywords pulled through more sections, with `fabricated_employers` still `[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make JD-relevant keyword incorporation the default across resume and cover letter sections by truthfully reframing existing experience in the job’s language. Improves ATS/recruiter alignment without inventing content, metrics, or work history.

- **New Features**
  - Updated `DIFF_IMPROVE_PROMPT` rule 11 to run a default reframing pass across summary, work, projects, and education with an explicit no-fabrication clause.
  - Updated `KEYWORD_INJECTION_PROMPT` to target every section by default and require substantive evidence; strengthened the no-invent language and added a rule making default incorporation explicit.
  - Updated `COVER_LETTER_PROMPT` to reframe qualifications in JD terminology only where proven experience supports it.
  - Added unit tests to lock the default-incorporation behavior and anti-fabrication guardrails.

- **Bug Fixes**
  - Removed em dashes from `DIFF_IMPROVE_PROMPT` rules 1, 9, and 11 to avoid priming disallowed characters, and reconciled rule 11 with rule 9 so the default reframing skips content that already aligns well.

<sup>Written for commit 50107d5607154c32393ed61cf34ec90b039c1da2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

