### PR TITLE
fix(builder): preserve Enter newlines in Additional Info textareas (#763)

### DIFF
--- a/apps/frontend/components/builder/forms/additional-form.tsx
+++ b/apps/frontend/components/builder/forms/additional-form.tsx
@@ -16,8 +16,10 @@ export const AdditionalForm: React.FC<AdditionalFormProps> = ({ data, onChange }
 
   // Helper to handle array conversions (text -> string[])
   const handleArrayChange = (field: keyof AdditionalInfo, value: string) => {
-    // Split by newlines only (preserving spaces within items)
-    const items = value.split('\n').filter((item) => item.trim() !== '');
+    // Split by newlines only. Blank/whitespace lines are preserved while editing
+    // so pressing Enter creates a new line (issue #763); consumers filter empty
+    // entries at render time, and the backend drops them on save.
+    const items = value.split('\n');
     onChange({
       ...data,
       [field]: items,

--- a/apps/frontend/components/builder/highlighted-resume-view.tsx
+++ b/apps/frontend/components/builder/highlighted-resume-view.tsx
@@ -18,6 +18,15 @@ interface HighlightedResumeViewProps {
 export function HighlightedResumeView({ resumeData, keywords }: HighlightedResumeViewProps) {
   const { t } = useTranslations();
 
+  // Drop blank/whitespace-only entries so empty lines (e.g. from editing in the
+  // builder) never render in the preview (issue #763).
+  const visibleTechnicalSkills =
+    resumeData.additional?.technicalSkills?.filter((item) => item.trim() !== '') ?? [];
+  const visibleLanguages =
+    resumeData.additional?.languages?.filter((item) => item.trim() !== '') ?? [];
+  const visibleCertificationsTraining =
+    resumeData.additional?.certificationsTraining?.filter((item) => item.trim() !== '') ?? [];
+
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
@@ -127,48 +136,46 @@ export function HighlightedResumeView({ resumeData, keywords }: HighlightedResum
         {/* Skills */}
         {resumeData.additional && (
           <Section title={t('resume.sections.skills')} icon={<Wrench className="w-4 h-4" />}>
-            {resumeData.additional.technicalSkills &&
-              resumeData.additional.technicalSkills.length > 0 && (
-                <div className="mb-3">
-                  <div className="text-xs font-mono uppercase text-steel-grey mb-1">
-                    {t('resume.additional.technicalSkills')}
-                  </div>
-                  <div className="flex flex-wrap gap-1">
-                    {resumeData.additional.technicalSkills.map((skill, i) => (
-                      <SkillTag key={i} text={skill} keywords={keywords} />
-                    ))}
-                  </div>
+            {visibleTechnicalSkills.length > 0 && (
+              <div className="mb-3">
+                <div className="text-xs font-mono uppercase text-steel-grey mb-1">
+                  {t('resume.additional.technicalSkills')}
                 </div>
-              )}
+                <div className="flex flex-wrap gap-1">
+                  {visibleTechnicalSkills.map((skill, i) => (
+                    <SkillTag key={i} text={skill} keywords={keywords} />
+                  ))}
+                </div>
+              </div>
+            )}
 
-            {resumeData.additional.languages && resumeData.additional.languages.length > 0 && (
+            {visibleLanguages.length > 0 && (
               <div className="mb-3">
                 <div className="text-xs font-mono uppercase text-steel-grey mb-1">
                   {t('resume.sections.languages')}
                 </div>
                 <div className="flex flex-wrap gap-1">
-                  {resumeData.additional.languages.map((lang, i) => (
+                  {visibleLanguages.map((lang, i) => (
                     <SkillTag key={i} text={lang} keywords={keywords} />
                   ))}
                 </div>
               </div>
             )}
 
-            {resumeData.additional.certificationsTraining &&
-              resumeData.additional.certificationsTraining.length > 0 && (
-                <div className="mb-3">
-                  <div className="text-xs font-mono uppercase text-steel-grey mb-1">
-                    {t('resume.sections.certifications')}
-                  </div>
-                  <ul className="list-disc list-inside space-y-1 text-sm">
-                    {resumeData.additional.certificationsTraining.map((cert, i) => (
-                      <li key={i} className="text-ink-soft">
-                        <HighlightedText text={cert} keywords={keywords} />
-                      </li>
-                    ))}
-                  </ul>
+            {visibleCertificationsTraining.length > 0 && (
+              <div className="mb-3">
+                <div className="text-xs font-mono uppercase text-steel-grey mb-1">
+                  {t('resume.sections.certifications')}
                 </div>
-              )}
+                <ul className="list-disc list-inside space-y-1 text-sm">
+                  {visibleCertificationsTraining.map((cert, i) => (
+                    <li key={i} className="text-ink-soft">
+                      <HighlightedText text={cert} keywords={keywords} />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </Section>
         )}
       </div>

--- a/apps/frontend/components/resume/resume-modern-two-column.tsx
+++ b/apps/frontend/components/resume/resume-modern-two-column.tsx
@@ -38,6 +38,14 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
 }) => {
   const { personalInfo, summary, workExperience, education, personalProjects, additional } = data;
 
+  // Drop blank/whitespace-only entries so empty lines (e.g. from editing in the
+  // builder) never render in the resume or PDF (issue #763).
+  const technicalSkills = additional?.technicalSkills?.filter((item) => item.trim() !== '') ?? [];
+  const languages = additional?.languages?.filter((item) => item.trim() !== '') ?? [];
+  const certificationsTraining =
+    additional?.certificationsTraining?.filter((item) => item.trim() !== '') ?? [];
+  const awards = additional?.awards?.filter((item) => item.trim() !== '') ?? [];
+
   // Get sorted visible sections
   const sortedSections = getSortedSections(data);
 
@@ -300,21 +308,19 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
             )}
 
           {/* Certifications/Training - Main column */}
-          {isSectionVisible('additional') &&
-            additional?.certificationsTraining &&
-            additional.certificationsTraining.length > 0 && (
-              <div className={baseStyles['resume-section']}>
-                <h3 className={styles.sectionTitleAccent}>{headingFallbacks.certifications}</h3>
-                <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}>
-                  {additional.certificationsTraining.map((cert, index) => (
-                    <li key={index} className="flex">
-                      <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                      <span>{cert}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
+          {isSectionVisible('additional') && certificationsTraining.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitleAccent}>{headingFallbacks.certifications}</h3>
+              <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}>
+                {certificationsTraining.map((cert, index) => (
+                  <li key={index} className="flex">
+                    <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
+                    <span>{cert}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {/* Custom Sections - Main column */}
           {customSections.map((section) => (
@@ -361,41 +367,37 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
           )}
 
           {/* Skills Section */}
-          {isSectionVisible('additional') &&
-            additional?.technicalSkills &&
-            additional.technicalSkills.length > 0 && (
-              <div className={baseStyles['resume-section']}>
-                <h3
-                  className={`${baseStyles['resume-section-title-sm']} text-[var(--resume-accent-primary)]`}
-                >
-                  {headingFallbacks.skills}
-                </h3>
-                <div className="flex flex-wrap gap-1">
-                  {additional.technicalSkills.map((skill, index) => (
-                    <span key={index} className={baseStyles['resume-skill-pill']}>
-                      {skill}
-                    </span>
-                  ))}
-                </div>
+          {isSectionVisible('additional') && technicalSkills.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3
+                className={`${baseStyles['resume-section-title-sm']} text-[var(--resume-accent-primary)]`}
+              >
+                {headingFallbacks.skills}
+              </h3>
+              <div className="flex flex-wrap gap-1">
+                {technicalSkills.map((skill, index) => (
+                  <span key={index} className={baseStyles['resume-skill-pill']}>
+                    {skill}
+                  </span>
+                ))}
               </div>
-            )}
+            </div>
+          )}
 
           {/* Languages Section */}
-          {isSectionVisible('additional') &&
-            additional?.languages &&
-            additional.languages.length > 0 && (
-              <div className={baseStyles['resume-section']}>
-                <h3
-                  className={`${baseStyles['resume-section-title-sm']} text-[var(--resume-accent-primary)]`}
-                >
-                  {headingFallbacks.languages}
-                </h3>
-                <p className={baseStyles['resume-text-xs']}>{additional.languages.join(' • ')}</p>
-              </div>
-            )}
+          {isSectionVisible('additional') && languages.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3
+                className={`${baseStyles['resume-section-title-sm']} text-[var(--resume-accent-primary)]`}
+              >
+                {headingFallbacks.languages}
+              </h3>
+              <p className={baseStyles['resume-text-xs']}>{languages.join(' • ')}</p>
+            </div>
+          )}
 
           {/* Awards Section */}
-          {isSectionVisible('additional') && additional?.awards && additional.awards.length > 0 && (
+          {isSectionVisible('additional') && awards.length > 0 && (
             <div className={baseStyles['resume-section']}>
               <h3
                 className={`${baseStyles['resume-section-title-sm']} text-[var(--resume-accent-primary)]`}
@@ -403,7 +405,7 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                 {headingFallbacks.awards}
               </h3>
               <ul className={baseStyles['resume-list']}>
-                {additional.awards.map((award, index) => (
+                {awards.map((award, index) => (
                   <li key={index} className={baseStyles['resume-text-xs']}>
                     {award}
                   </li>

--- a/apps/frontend/components/resume/resume-modern.tsx
+++ b/apps/frontend/components/resume/resume-modern.tsx
@@ -368,11 +368,18 @@ const AdditionalSection: React.FC<{
   if (!additional) return null;
 
   const {
-    technicalSkills = [],
-    languages = [],
-    certificationsTraining = [],
-    awards = [],
+    technicalSkills: rawTechnicalSkills = [],
+    languages: rawLanguages = [],
+    certificationsTraining: rawCertificationsTraining = [],
+    awards: rawAwards = [],
   } = additional;
+
+  // Drop blank/whitespace-only entries so empty lines (e.g. from editing in the
+  // builder) never render in the resume or PDF (issue #763).
+  const technicalSkills = rawTechnicalSkills.filter((item) => item.trim() !== '');
+  const languages = rawLanguages.filter((item) => item.trim() !== '');
+  const certificationsTraining = rawCertificationsTraining.filter((item) => item.trim() !== '');
+  const awards = rawAwards.filter((item) => item.trim() !== '');
 
   const mergedLabels: AdditionalSectionLabels = {
     technicalSkills: labels?.technicalSkills ?? 'Technical Skills:',

--- a/apps/frontend/components/resume/resume-single-column.tsx
+++ b/apps/frontend/components/resume/resume-single-column.tsx
@@ -366,11 +366,18 @@ const AdditionalSection: React.FC<{
   if (!additional) return null;
 
   const {
-    technicalSkills = [],
-    languages = [],
-    certificationsTraining = [],
-    awards = [],
+    technicalSkills: rawTechnicalSkills = [],
+    languages: rawLanguages = [],
+    certificationsTraining: rawCertificationsTraining = [],
+    awards: rawAwards = [],
   } = additional;
+
+  // Drop blank/whitespace-only entries so empty lines (e.g. from editing in the
+  // builder) never render in the resume or PDF (issue #763).
+  const technicalSkills = rawTechnicalSkills.filter((item) => item.trim() !== '');
+  const languages = rawLanguages.filter((item) => item.trim() !== '');
+  const certificationsTraining = rawCertificationsTraining.filter((item) => item.trim() !== '');
+  const awards = rawAwards.filter((item) => item.trim() !== '');
 
   const mergedLabels: AdditionalSectionLabels = {
     technicalSkills: labels?.technicalSkills ?? 'Technical Skills:',

--- a/apps/frontend/components/resume/resume-two-column.tsx
+++ b/apps/frontend/components/resume/resume-two-column.tsx
@@ -32,6 +32,14 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
 }) => {
   const { personalInfo, summary, workExperience, education, personalProjects, additional } = data;
 
+  // Drop blank/whitespace-only entries so empty lines (e.g. from editing in the
+  // builder) never render in the resume or PDF (issue #763).
+  const technicalSkills = additional?.technicalSkills?.filter((item) => item.trim() !== '') ?? [];
+  const languages = additional?.languages?.filter((item) => item.trim() !== '') ?? [];
+  const certificationsTraining =
+    additional?.certificationsTraining?.filter((item) => item.trim() !== '') ?? [];
+  const awards = additional?.awards?.filter((item) => item.trim() !== '') ?? [];
+
   // Get sorted visible sections
   const sortedSections = getSortedSections(data);
 
@@ -335,23 +343,21 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
             )}
 
           {/* Certifications/Training - Main column */}
-          {isSectionVisible('additional') &&
-            additional?.certificationsTraining &&
-            additional.certificationsTraining.length > 0 && (
-              <div className={baseStyles['resume-section']}>
-                <h3 className={baseStyles['resume-section-title']}>
-                  {headingFallbacks.certifications}
-                </h3>
-                <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}>
-                  {additional.certificationsTraining.map((cert, index) => (
-                    <li key={index} className="flex">
-                      <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                      <span>{cert}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
+          {isSectionVisible('additional') && certificationsTraining.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={baseStyles['resume-section-title']}>
+                {headingFallbacks.certifications}
+              </h3>
+              <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}>
+                {certificationsTraining.map((cert, index) => (
+                  <li key={index} className="flex">
+                    <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
+                    <span>{cert}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {/* Custom Sections - Main column */}
           {customSections.map((section) => (
@@ -396,39 +402,33 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
           )}
 
           {/* Skills Section */}
-          {isSectionVisible('additional') &&
-            additional?.technicalSkills &&
-            additional.technicalSkills.length > 0 && (
-              <div className={baseStyles['resume-section']}>
-                <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.skills}</h3>
-                <div className="flex flex-wrap gap-1">
-                  {additional.technicalSkills.map((skill, index) => (
-                    <span key={index} className={baseStyles['resume-skill-pill']}>
-                      {skill}
-                    </span>
-                  ))}
-                </div>
+          {isSectionVisible('additional') && technicalSkills.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.skills}</h3>
+              <div className="flex flex-wrap gap-1">
+                {technicalSkills.map((skill, index) => (
+                  <span key={index} className={baseStyles['resume-skill-pill']}>
+                    {skill}
+                  </span>
+                ))}
               </div>
-            )}
+            </div>
+          )}
 
           {/* Languages Section */}
-          {isSectionVisible('additional') &&
-            additional?.languages &&
-            additional.languages.length > 0 && (
-              <div className={baseStyles['resume-section']}>
-                <h3 className={baseStyles['resume-section-title-sm']}>
-                  {headingFallbacks.languages}
-                </h3>
-                <p className={baseStyles['resume-text-xs']}>{additional.languages.join(' • ')}</p>
-              </div>
-            )}
+          {isSectionVisible('additional') && languages.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.languages}</h3>
+              <p className={baseStyles['resume-text-xs']}>{languages.join(' • ')}</p>
+            </div>
+          )}
 
           {/* Awards Section */}
-          {isSectionVisible('additional') && additional?.awards && additional.awards.length > 0 && (
+          {isSectionVisible('additional') && awards.length > 0 && (
             <div className={baseStyles['resume-section']}>
               <h3 className={baseStyles['resume-section-title-sm']}>{headingFallbacks.awards}</h3>
               <ul className={baseStyles['resume-list']}>
-                {additional.awards.map((award, index) => (
+                {awards.map((award, index) => (
                   <li key={index} className={baseStyles['resume-text-xs']}>
                     {award}
                   </li>

--- a/apps/frontend/tests/additional-info-newlines.test.tsx
+++ b/apps/frontend/tests/additional-info-newlines.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AdditionalForm } from '@/components/builder/forms/additional-form';
+import { ResumeSingleColumn } from '@/components/resume/resume-single-column';
+import type {
+  AdditionalInfo,
+  ResumeData,
+} from '@/components/dashboard/resume-component';
+
+// Components call useTranslations(); return the key so we can match deterministically.
+vi.mock('@/lib/i18n', () => ({
+  useTranslations: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('AdditionalForm newline handling (issue #763)', () => {
+  it('preserves a trailing blank line so Enter can create a new item', () => {
+    const onChange = vi.fn<(data: AdditionalInfo) => void>();
+    const data: AdditionalInfo = { technicalSkills: ['React'] };
+
+    render(<AdditionalForm data={data} onChange={onChange} />);
+
+    const textarea = screen.getByLabelText('resume.additional.technicalSkills');
+    // Simulate pressing Enter at the end of "React": the value now has a trailing
+    // newline (an empty line). Before the fix this empty line was filtered out on
+    // every keystroke, so the newline never survived a re-render.
+    fireEvent.change(textarea, { target: { value: 'React\n' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].technicalSkills).toEqual(['React', '']);
+  });
+
+  it('preserves a blank line between two items', () => {
+    const onChange = vi.fn<(data: AdditionalInfo) => void>();
+    const data: AdditionalInfo = {};
+
+    render(<AdditionalForm data={data} onChange={onChange} />);
+
+    const textarea = screen.getByLabelText('resume.additional.technicalSkills');
+    fireEvent.change(textarea, { target: { value: 'React\n\nTypeScript' } });
+
+    expect(onChange.mock.calls[0][0].technicalSkills).toEqual([
+      'React',
+      '',
+      'TypeScript',
+    ]);
+  });
+});
+
+describe('ResumeSingleColumn filters blank entries (issue #763)', () => {
+  it('does not render empty/whitespace-only additional entries', () => {
+    const data: ResumeData = {
+      personalInfo: { name: 'Jane Doe' },
+      additional: {
+        technicalSkills: ['React', '', '   ', 'TypeScript'],
+      },
+    } as ResumeData;
+
+    render(<ResumeSingleColumn data={data} />);
+
+    // Blank entries must not produce stray separators in the joined output.
+    expect(screen.getByText('React, TypeScript')).toBeInTheDocument();
+    expect(screen.queryByText(/React, , /)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #763 — in the resume builder's Additional Info form (Technical Skills, Languages, Certifications, Awards), pressing Enter didn't create a new line.

## Root cause (verified)
`additional-form.tsx` `handleArrayChange` ran `.filter((item) => item.trim() !== '')` on **every input event**, so the empty line created by Enter was stripped before being stored — the controlled textarea re-rendered with the filtered value, undoing the keystroke.

## Fix
- `additional-form.tsx`: split on `\n` only — blank lines persist while editing.
- Filter empty entries at **render time** in every consumer, so blank lines never appear in the résumé/PDF. Consumers traced + filtered: `resume-single-column`, `resume-modern`, `resume-two-column`, `resume-modern-two-column` (the four templates), and `highlighted-resume-view` (builder live preview). The dashboard `Resume` dispatcher, paginated preview, and `/print` route render through those templates (covered transitively). `jd-comparison-view` only uses items for keyword-match stats (not a visible render) — left unchanged intentionally.
- Backend already drops empty entries on save (`improver._normalize_string_list`) — no backend change.

This is the legitimate half of the abandoned PR #809 (which bundled it with unrelated changes), reimplemented cleanly.

## Verification
- Frontend **vitest: 128 baseline + 3 new = 131 passed** (independently confirmed the 128 baseline on a sibling branch; the new `additional-info-newlines.test.tsx` adds 3: form preserves a trailing blank line, preserves a blank line between items, and a template renders no empty entries). Run via the local vitest binary (nvm-safe).
- Reviewed the full diff: the larger per-file line counts are re-indentation from collapsing `additional?.field && ...length` guards into a single filtered-local condition; render logic is unchanged.
- Maintainer/CI should still run `npm run lint` + `npm run build`.

Built in parallel with #776 by a worktree-isolated subagent; diff reviewed before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #763: Enter now creates a newline in Additional Info textareas. Blank lines are kept while typing and never shown in resumes or PDFs.

- Bug Fixes
  - Stop input-time filtering in additional-form.tsx (split by '\n' only).
  - Filter empty/whitespace-only items at render in all templates (resume-single-column, resume-modern, resume-two-column, resume-modern-two-column) and the builder preview (highlighted-resume-view).
  - Add vitest tests for newline preservation and clean rendering; backend already drops empty strings.

<sup>Written for commit 4ec84b6f1a50b6d44202ed3d9d26f9703a4f12c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

