### PR TITLE
docs: issue close tracker (pending dev→main release)

### DIFF
--- a/docs/issue-close-tracker.md
+++ b/docs/issue-close-tracker.md
@@ -1,0 +1,57 @@
+# Issue Close Tracker
+
+> Status snapshot: **2026-06-02**. Nothing is closed yet (deliberate). All fixes below are merged to **`dev`**; the linked issues close on the next **`dev → main`** release. This is a transient release checklist — delete it once `main` ships and the issues are closed.
+
+## ✅ Fixed on `dev` — close on next `dev → main` release
+
+Each fix was root-caused from code, tested, and (for app-behavior changes) verified against the e2e-monitor before merge.
+
+| Issue | Title | Fix PR (→ `dev`) | Verification |
+|-------|-------|------------------|--------------|
+| #805 | AI Tailor lowercases / rewrites only some sections | #827 | e2e + evals |
+| #799 | PDF rendering timeout (503) | #828 | pytest + e2e (renders non-blank) |
+| #808 | Failed to download resume (503) | #828 | same root cause as #799 |
+| #811 | Error message overflows the download modal | #828 | backend generic error + modal containment |
+| #760 | Base URL / API endpoint in Settings gets stuck | #829 | pytest (null/blank/omit cases) |
+| #736 | Skill not parsing or changing | #830 | pytest + e2e (salvage fires, originals kept) |
+| #763 | Enter key doesn't create newlines in Additional Info | #834 | vitest 131 passed |
+| #776 | 240s timeout too short for local LLMs | #833 | pytest (settings + wiring) + frontend vitest |
+
+## ✅ Resolved (no PR needed) — close after release / safe to close now
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #806 | Frontend build is breaking | Cause (missing `tailor.errors.timeout` locale key) is gone; locale parity = 643 keys × 5 locales, and `npm run build` passes clean on `dev`. **Ready to close.** |
+
+## 🔒 Security
+
+| Alert | Title | Status |
+|-------|-------|--------|
+| Dependabot #224 | `vitest < 4.1.0` — CVE-2026-47429 (UI server arbitrary file read/exec) | Patched: `vitest 4.0.18 → 4.1.8` (#835, on `dev`). Dev-only dep, vulnerable feature (`@vitest/ui`) not installed/used → ~nil real exposure. Alert auto-resolves once the patched lockfile reaches the **default branch** (`main`). Do **not** dismiss — the bump is the fix. |
+
+## ⏸️ Deferred — will NOT close yet
+
+| Issue | Title | Why deferred |
+|-------|-------|--------------|
+| #777 | Garbled PDF output for Chinese resumes (Docker) | Root cause = missing CJK fonts in the Docker image; fix requires editing Docker build behavior, which is out of scope without explicit sign-off. Revisit when Docker work is approved. |
+
+## 📝 Still open — not part of this bug sweep (no close planned)
+
+These remain open for triage / contributors; listed only so they aren't mistaken for "pending close":
+
+- #731 — Feature: AWS Bedrock provider support
+- #737 — Feature: API endpoint for the AI agent
+- #740 — Feature: (under-specified — needs clarification or close)
+- #772 — Feature: Chrome extension (has external PR #821; not being pursued)
+- #810 — Feature: Resume scoring + ATS simulation (has external PR #813)
+- #732 — Internal review-tracking issue (maintainer)
+
+## How these actually close
+
+The per-PR `Fixes #NNN` keywords targeted **`dev`**, not the default branch, so they did **not** auto-close. To close them on release, put an explicit list in the **`dev → main`** PR body:
+
+```
+Closes #805, #799, #808, #811, #760, #736, #763, #776
+```
+
+(`#806` can be added there too, or closed manually as already-resolved.)


### PR DESCRIPTION
Adds `docs/issue-close-tracker.md` — a transient release checklist of which issues are fixed-on-`dev` and will close on the next `dev → main`, which are already resolved, deferred, or out of scope. **No issues are closed by this PR.**

Covers: the 8 bug fixes merged this cycle (#805/#799/#808/#811/#760/#736/#763/#776), the resolved-but-not-yet-closed #806, the Dependabot #224 vitest patch, the deferred #777 (Docker), and the still-open feature issues (so they're not mistaken for pending-close). Includes the exact `Closes #...` line to drop into the `dev → main` PR so they actually auto-close.

Docs-only — no code/e2e impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs/issue-close-tracker.md`, a temporary release checklist of issues fixed on `dev` that will close on the next `dev → main`, plus resolved (#806), deferred (#777), and security (`vitest` patch) notes. Includes a ready-to-paste line for the release PR: "Closes #805, #799, #808, #811, #760, #736, #763, #776"; docs-only, no code changes.

<sup>Written for commit 7925f44aa555dc0d880fc1dea1eae3b91496ed10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

