### PR TITLE
fix(editor): stop duplicate tiptap link/underline extension warnings

### DIFF
--- a/apps/frontend/components/ui/rich-text-editor.tsx
+++ b/apps/frontend/components/ui/rich-text-editor.tsx
@@ -54,6 +54,11 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({
         codeBlock: false,
         horizontalRule: false,
         hardBreak: false,
+        // StarterKit v3 bundles link + underline; we register them explicitly
+        // below (Link with custom openOnClick/HTMLAttributes), so disable the
+        // bundled ones to avoid "Duplicate extension names" warnings.
+        link: false,
+        underline: false,
       }),
       Underline,
       Link.configure({

--- a/apps/frontend/tests/rich-text-editor-extensions.test.tsx
+++ b/apps/frontend/tests/rich-text-editor-extensions.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+
+import { RichTextEditor } from '@/components/ui/rich-text-editor';
+
+// Regression: StarterKit (v3) already bundles the `link` and `underline`
+// extensions, so adding them again as standalone extensions makes Tiptap warn
+// "Duplicate extension names found: ['link', 'underline']". Rendering the editor
+// must not produce that warning.
+it('registers no duplicate tiptap extensions', () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    render(<RichTextEditor value="" onChange={() => {}} />);
+    const duplicateWarnings = warn.mock.calls
+      .flat()
+      .filter((arg) => typeof arg === 'string' && arg.includes('Duplicate extension names'));
+    expect(duplicateWarnings).toEqual([]);
+  } finally {
+    warn.mockRestore();
+  }
+});


### PR DESCRIPTION
Fixes the repeated console warning: `[tiptap warn]: Duplicate extension names found: ['link', 'underline']. This can lead to issues.`

## Root cause (verified)
`@tiptap/starter-kit@3.20` **bundles** `link` and `underline` (they're direct deps of StarterKit in v3). `rich-text-editor.tsx` configured `StarterKit` *and* also added standalone `Underline` + `Link.configure(...)`, so each extension was registered twice.

## Fix (small)
Disable the StarterKit-bundled ones — `StarterKit.configure({ ..., link: false, underline: false })` — and keep the standalone `Underline` + `Link.configure({ openOnClick: false, HTMLAttributes: { target, rel } })`. The standalone `Link` carries the custom config the `LinkDialog` (`setLink`/`unsetLink`) depends on, so editor behavior is unchanged — only the duplicate registration (and the warning) is removed.

## Verification
- New render-based regression test (`tests/rich-text-editor-extensions.test.tsx`) renders `RichTextEditor` and asserts no `Duplicate extension names` warning. Confirmed it **fails on the old code** (reproduces the exact warning) and **passes after the fix** (TDD).
- Full frontend suite: **132 passed**.
- Frontend-only editor config — no backend/e2e impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the repeated Tiptap warning about duplicate `link` and `underline` extensions by disabling the `StarterKit`-bundled ones and keeping our configured `Link`/`Underline`. No editor behavior changes.

- **Bug Fixes**
  - Disabled `link` and `underline` in `StarterKit.configure({ link: false, underline: false })` since `@tiptap/starter-kit@3.20` bundles them.
  - Kept standalone `Underline` and `Link.configure({ openOnClick: false, HTMLAttributes: { target, rel } })` for existing behavior.
  - Added `rich-text-editor-extensions.test.tsx` to render `RichTextEditor` and assert no "Duplicate extension names" console warning.

<sup>Written for commit 0edb1c4d20ddf04b69fc1c2e2a44f790817c8b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

