### PR TITLE
feat(templates): add LaTeX, Clean, and Vivid résumé templates

### DIFF
--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -1430,7 +1430,7 @@ async def download_resume_pdf(
     """Generate a PDF for a resume using headless Chromium.
 
     Accepts template settings for customization:
-    - template: swiss-single, swiss-two-column, modern, or modern-two-column
+    - template: swiss-single, swiss-two-column, modern, modern-two-column, latex, clean, or vivid
     - pageSize: A4 or LETTER
     - marginTop/Bottom/Left/Right: page margins in mm (5-25)
     - sectionSpacing: gap between sections (1-5)

--- a/apps/frontend/app/print/resumes/[id]/page.tsx
+++ b/apps/frontend/app/print/resumes/[id]/page.tsx
@@ -130,11 +130,15 @@ function parseMargin(value: string | undefined, defaultValue: number): number {
  * Validate template type
  */
 function parseTemplate(value: string | undefined): TemplateType {
+  // Allow-list mirrors TEMPLATE_OPTIONS in lib/types/template-settings.ts — keep in sync.
   if (
     value === 'swiss-single' ||
     value === 'swiss-two-column' ||
     value === 'modern' ||
-    value === 'modern-two-column'
+    value === 'modern-two-column' ||
+    value === 'latex' ||
+    value === 'clean' ||
+    value === 'vivid'
   ) {
     return value;
   }

--- a/apps/frontend/components/builder/formatting-controls.tsx
+++ b/apps/frontend/components/builder/formatting-controls.tsx
@@ -185,7 +185,7 @@ export const FormattingControls: React.FC<FormattingControlsProps> = ({ settings
             <h4 className="font-mono text-xs font-bold uppercase tracking-wider mb-3 text-ink-soft">
               {t('builder.formatting.template')}
             </h4>
-            <div className="flex gap-3">
+            <div className="flex flex-wrap gap-3">
               {TEMPLATE_OPTIONS.map((template) => (
                 <button
                   key={template.id}

--- a/apps/frontend/components/builder/formatting-controls.tsx
+++ b/apps/frontend/components/builder/formatting-controls.tsx
@@ -135,6 +135,18 @@ export const FormattingControls: React.FC<FormattingControlsProps> = ({ settings
         name: t('builder.formatting.templates.modernTwoColumn.name'),
         description: t('builder.formatting.templates.modernTwoColumn.description'),
       },
+      latex: {
+        name: t('builder.formatting.templates.latex.name'),
+        description: t('builder.formatting.templates.latex.description'),
+      },
+      clean: {
+        name: t('builder.formatting.templates.clean.name'),
+        description: t('builder.formatting.templates.clean.description'),
+      },
+      vivid: {
+        name: t('builder.formatting.templates.vivid.name'),
+        description: t('builder.formatting.templates.vivid.description'),
+      },
     }),
     [t]
   );
@@ -204,7 +216,9 @@ export const FormattingControls: React.FC<FormattingControlsProps> = ({ settings
           </div>
 
           {/* Accent Color Selection - Visible for Modern templates */}
-          {(settings.template === 'modern' || settings.template === 'modern-two-column') && (
+          {(settings.template === 'modern' ||
+            settings.template === 'modern-two-column' ||
+            settings.template === 'vivid') && (
             <div>
               <h4 className="font-mono text-xs font-bold uppercase tracking-wider mb-3 text-ink-soft">
                 {t('builder.formatting.accentColor')}

--- a/apps/frontend/components/builder/formatting-controls.tsx
+++ b/apps/frontend/components/builder/formatting-controls.tsx
@@ -12,6 +12,7 @@ import {
   type BodyFontFamily,
   type AccentColor,
   DEFAULT_TEMPLATE_SETTINGS,
+  applyTemplatePreset,
   SECTION_SPACING_MAP,
   ITEM_SPACING_MAP,
   LINE_HEIGHT_MAP,
@@ -59,7 +60,9 @@ export const FormattingControls: React.FC<FormattingControlsProps> = ({ settings
     `${value.toFixed(2).replace(/\.00$/, '').replace(/0$/, '')}rem`;
 
   const handleTemplateChange = (template: TemplateType) => {
-    onChange({ ...settings, template });
+    // Single-typeface templates (latex/clean) seed their signature fonts on selection
+    // so they match their reference look by default; both font controls stay live.
+    onChange(applyTemplatePreset(settings, template));
   };
 
   const handlePageSizeChange = (pageSize: PageSize) => {

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -944,7 +944,9 @@ const ResumeBuilderContent = () => {
               <div className="w-2 h-2 bg-green-700"></div>
               <span className="uppercase">
                 {templateSettings.template === 'swiss-single' ||
-                templateSettings.template === 'modern'
+                templateSettings.template === 'modern' ||
+                templateSettings.template === 'latex' ||
+                templateSettings.template === 'clean'
                   ? t('builder.footer.singleColumn')
                   : t('builder.footer.twoColumn')}
               </span>

--- a/apps/frontend/components/builder/template-selector.tsx
+++ b/apps/frontend/components/builder/template-selector.tsx
@@ -49,7 +49,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({ value, onCha
   };
 
   return (
-    <div className="flex gap-3">
+    <div className="flex flex-wrap gap-3">
       {TEMPLATE_OPTIONS.map((template) => (
         <button
           key={template.id}

--- a/apps/frontend/components/builder/template-selector.tsx
+++ b/apps/frontend/components/builder/template-selector.tsx
@@ -117,6 +117,28 @@ export const TemplateThumbnail: React.FC<TemplateThumbnailProps> = ({ type, isAc
     );
   }
 
+  if (type === 'latex') {
+    // LaTeX thumbnail - centered name + Title-Case ruled section headers (serif feel)
+    return (
+      <div className={`w-14 h-18 border ${borderColor} bg-white p-1.5 flex flex-col gap-1`}>
+        {/* Centered name + contact */}
+        <div className="flex flex-col items-center gap-0.5">
+          <div className={`h-1.5 ${lineColor} w-2/3`}></div>
+          <div className={`h-0.5 ${lineColor} w-1/2 opacity-60`}></div>
+        </div>
+        {/* Sections: each header is a full-width line with a bottom rule */}
+        <div className="flex-1 space-y-1 mt-1">
+          <div className={`h-0.5 ${lineColor} w-2/5 border-b ${borderColor} pb-1`}></div>
+          <div className={`h-0.5 ${lineColor} w-5/6 opacity-50`}></div>
+          <div className={`h-0.5 ${lineColor} w-4/6 opacity-50`}></div>
+          <div className="h-0.5"></div>
+          <div className={`h-0.5 ${lineColor} w-1/3 border-b ${borderColor} pb-1`}></div>
+          <div className={`h-0.5 ${lineColor} w-5/6 opacity-50`}></div>
+        </div>
+      </div>
+    );
+  }
+
   if (type === 'modern') {
     // Modern template thumbnail - with accent color highlights
     return (

--- a/apps/frontend/components/builder/template-selector.tsx
+++ b/apps/frontend/components/builder/template-selector.tsx
@@ -139,6 +139,28 @@ export const TemplateThumbnail: React.FC<TemplateThumbnailProps> = ({ type, isAc
     );
   }
 
+  if (type === 'clean') {
+    // Clean thumbnail - centered light name + large understated gray uppercase headers
+    return (
+      <div className={`w-14 h-18 border ${borderColor} bg-white p-1.5 flex flex-col gap-1`}>
+        {/* Centered light name + contact line */}
+        <div className="flex flex-col items-center gap-0.5">
+          <div className={`h-1.5 ${lineColor} w-1/2 opacity-70`}></div>
+          <div className={`h-0.5 ${lineColor} w-2/3 opacity-40`}></div>
+        </div>
+        {/* Large gray section headers (taller, lower opacity) + thin rule */}
+        <div className="flex-1 space-y-1 mt-1">
+          <div className={`h-1 ${lineColor} w-1/2 opacity-30 border-b ${borderColor}`}></div>
+          <div className={`h-0.5 ${lineColor} w-5/6 opacity-50`}></div>
+          <div className={`h-0.5 ${lineColor} w-4/6 opacity-50`}></div>
+          <div className="h-0.5"></div>
+          <div className={`h-1 ${lineColor} w-2/5 opacity-30 border-b ${borderColor}`}></div>
+          <div className={`h-0.5 ${lineColor} w-5/6 opacity-50`}></div>
+        </div>
+      </div>
+    );
+  }
+
   if (type === 'modern') {
     // Modern template thumbnail - with accent color highlights
     return (

--- a/apps/frontend/components/builder/template-selector.tsx
+++ b/apps/frontend/components/builder/template-selector.tsx
@@ -34,6 +34,18 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({ value, onCha
       name: t('builder.formatting.templates.modernTwoColumn.name'),
       description: t('builder.formatting.templates.modernTwoColumn.description'),
     },
+    latex: {
+      name: t('builder.formatting.templates.latex.name'),
+      description: t('builder.formatting.templates.latex.description'),
+    },
+    clean: {
+      name: t('builder.formatting.templates.clean.name'),
+      description: t('builder.formatting.templates.clean.description'),
+    },
+    vivid: {
+      name: t('builder.formatting.templates.vivid.name'),
+      description: t('builder.formatting.templates.vivid.description'),
+    },
   };
 
   return (

--- a/apps/frontend/components/builder/template-selector.tsx
+++ b/apps/frontend/components/builder/template-selector.tsx
@@ -220,6 +220,45 @@ export const TemplateThumbnail: React.FC<TemplateThumbnailProps> = ({ type, isAc
     );
   }
 
+  if (type === 'vivid') {
+    // Vivid thumbnail - two-tone accent name + accent headers + accent arrow bullets
+    return (
+      <div className={`w-14 h-18 border ${borderColor} bg-white p-1.5 flex flex-col gap-1`}>
+        {/* Two-tone name (left-aligned) */}
+        <div className="flex items-center gap-0.5">
+          <div className={`h-1.5 ${accentColor} w-1/3`}></div>
+          <div className={`h-1.5 ${accentColor} w-1/4 opacity-50`}></div>
+        </div>
+        <div className={`h-0.5 ${lineColor} w-2/3 opacity-40`}></div>
+        {/* Two columns (no divider) */}
+        <div className="flex-1 flex gap-1 mt-0.5">
+          {/* Left column with arrow ticks */}
+          <div className="w-2/3 space-y-0.5">
+            <div className={`h-0.5 ${accentColor} w-1/2`}></div>
+            <div className="flex items-center gap-0.5">
+              <div className={`h-0.5 w-0.5 ${accentColor}`}></div>
+              <div className={`h-0.5 ${lineColor} w-5/6 opacity-50`}></div>
+            </div>
+            <div className="flex items-center gap-0.5">
+              <div className={`h-0.5 w-0.5 ${accentColor}`}></div>
+              <div className={`h-0.5 ${lineColor} w-4/6 opacity-50`}></div>
+            </div>
+            <div className="h-0.5"></div>
+            <div className={`h-0.5 ${accentColor} w-2/5`}></div>
+          </div>
+          {/* Right column (sidebar) */}
+          <div className="w-1/3 space-y-0.5">
+            <div className={`h-0.5 ${accentColor} w-full`}></div>
+            <div className={`h-0.5 ${lineColor} w-4/5 opacity-50`}></div>
+            <div className="h-0.5"></div>
+            <div className={`h-0.5 ${accentColor} w-full`}></div>
+            <div className={`h-0.5 ${lineColor} w-3/5 opacity-50`}></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // Two column thumbnail (swiss-two-column)
   return (
     <div className={`w-14 h-18 border ${borderColor} bg-white p-1.5 flex flex-col gap-1`}>

--- a/apps/frontend/components/dashboard/resume-component.tsx
+++ b/apps/frontend/components/dashboard/resume-component.tsx
@@ -4,6 +4,7 @@ import {
   ResumeTwoColumn,
   ResumeModern,
   ResumeModernTwoColumn,
+  ResumeLatex,
 } from '@/components/resume';
 import {
   type TemplateSettings,
@@ -203,6 +204,13 @@ const Resume: React.FC<ResumeProps> = ({
           showContactIcons={mergedSettings.showContactIcons}
           sectionHeadings={sectionHeadings}
           fallbackLabels={fallbackLabels}
+        />
+      )}
+      {mergedSettings.template === 'latex' && (
+        <ResumeLatex
+          data={resumeData}
+          showContactIcons={mergedSettings.showContactIcons}
+          additionalSectionLabels={additionalSectionLabels}
         />
       )}
     </div>

--- a/apps/frontend/components/dashboard/resume-component.tsx
+++ b/apps/frontend/components/dashboard/resume-component.tsx
@@ -6,6 +6,7 @@ import {
   ResumeModernTwoColumn,
   ResumeLatex,
   ResumeClean,
+  ResumeVivid,
 } from '@/components/resume';
 import {
   type TemplateSettings,
@@ -219,6 +220,14 @@ const Resume: React.FC<ResumeProps> = ({
           data={resumeData}
           showContactIcons={mergedSettings.showContactIcons}
           additionalSectionLabels={additionalSectionLabels}
+        />
+      )}
+      {mergedSettings.template === 'vivid' && (
+        <ResumeVivid
+          data={resumeData}
+          showContactIcons={mergedSettings.showContactIcons}
+          sectionHeadings={sectionHeadings}
+          fallbackLabels={fallbackLabels}
         />
       )}
     </div>

--- a/apps/frontend/components/dashboard/resume-component.tsx
+++ b/apps/frontend/components/dashboard/resume-component.tsx
@@ -5,6 +5,7 @@ import {
   ResumeModern,
   ResumeModernTwoColumn,
   ResumeLatex,
+  ResumeClean,
 } from '@/components/resume';
 import {
   type TemplateSettings,
@@ -208,6 +209,13 @@ const Resume: React.FC<ResumeProps> = ({
       )}
       {mergedSettings.template === 'latex' && (
         <ResumeLatex
+          data={resumeData}
+          showContactIcons={mergedSettings.showContactIcons}
+          additionalSectionLabels={additionalSectionLabels}
+        />
+      )}
+      {mergedSettings.template === 'clean' && (
+        <ResumeClean
           data={resumeData}
           showContactIcons={mergedSettings.showContactIcons}
           additionalSectionLabels={additionalSectionLabels}

--- a/apps/frontend/components/resume/index.ts
+++ b/apps/frontend/components/resume/index.ts
@@ -2,3 +2,4 @@ export { ResumeSingleColumn } from './resume-single-column';
 export { ResumeTwoColumn } from './resume-two-column';
 export { ResumeModern } from './resume-modern';
 export { ResumeModernTwoColumn } from './resume-modern-two-column';
+export { ResumeLatex } from './resume-latex';

--- a/apps/frontend/components/resume/index.ts
+++ b/apps/frontend/components/resume/index.ts
@@ -3,3 +3,4 @@ export { ResumeTwoColumn } from './resume-two-column';
 export { ResumeModern } from './resume-modern';
 export { ResumeModernTwoColumn } from './resume-modern-two-column';
 export { ResumeLatex } from './resume-latex';
+export { ResumeClean } from './resume-clean';

--- a/apps/frontend/components/resume/index.ts
+++ b/apps/frontend/components/resume/index.ts
@@ -4,3 +4,4 @@ export { ResumeModern } from './resume-modern';
 export { ResumeModernTwoColumn } from './resume-modern-two-column';
 export { ResumeLatex } from './resume-latex';
 export { ResumeClean } from './resume-clean';
+export { ResumeVivid } from './resume-vivid';

--- a/apps/frontend/components/resume/resume-clean.tsx
+++ b/apps/frontend/components/resume/resume-clean.tsx
@@ -107,7 +107,9 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
   ) => {
     const meta = [location, dates ? formatDateRange(dates) : undefined].filter(Boolean).join(' | ');
     return (
-      <div className={`flex justify-between items-baseline gap-3 ${baseStyles['resume-row-tight']}`}>
+      <div
+        className={`flex justify-between items-baseline gap-3 ${baseStyles['resume-row-tight']}`}
+      >
         <span className="min-w-0">
           <span className={styles.entryCompany}>{primary}</span>
           {role && (
@@ -289,7 +291,9 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
       {personalInfo && (
         <header className={`text-center ${baseStyles['resume-header']}`}>
           {personalInfo.name && <h1 className={`${styles.name} mb-1`}>{personalInfo.name}</h1>}
-          {personalInfo.title && <div className={`${styles.tagline} mb-1`}>{personalInfo.title}</div>}
+          {personalInfo.title && (
+            <div className={`${styles.tagline} mb-1`}>{personalInfo.title}</div>
+          )}
           {contactItems.length > 0 && (
             <div
               className={`flex flex-wrap justify-center items-center gap-x-2 gap-y-1 ${styles.contactRow}`}

--- a/apps/frontend/components/resume/resume-clean.tsx
+++ b/apps/frontend/components/resume/resume-clean.tsx
@@ -1,0 +1,424 @@
+import React from 'react';
+import { Mail, Phone, MapPin, Globe, Linkedin, Github, ExternalLink } from 'lucide-react';
+import type {
+  ResumeData,
+  SectionMeta,
+  AdditionalSectionLabels,
+} from '@/components/dashboard/resume-component';
+import { getSortedSections } from '@/lib/utils/section-helpers';
+import { formatDateRange } from '@/lib/utils';
+import { SafeHtml } from './safe-html';
+import baseStyles from './styles/_base.module.css';
+import styles from './styles/clean.module.css';
+
+interface ResumeCleanProps {
+  data: ResumeData;
+  showContactIcons?: boolean;
+  additionalSectionLabels?: Partial<AdditionalSectionLabels>;
+}
+
+/**
+ * Clean Resume Template
+ *
+ * Minimal modern sans layout: centered light-weight name, a single pipe-separated
+ * contact line, large understated gray UPPERCASE section headers with a thin rule,
+ * and single-line entries (COMPANY | Role on the left, Location | Dates on the right).
+ *
+ * Single-typeface design: all text inherits `--body-font` (sans by default), so the
+ * Body Font control drives the whole template. ATS-safe (all text is real DOM nodes).
+ *
+ * Section order: Determined by sectionMeta ordering.
+ */
+export const ResumeClean: React.FC<ResumeCleanProps> = ({
+  data,
+  showContactIcons = false,
+  additionalSectionLabels,
+}) => {
+  const { personalInfo, summary, workExperience, education, personalProjects, additional } = data;
+
+  const sortedSections = getSortedSections(data);
+
+  const contactIcons: Record<string, React.ReactNode> = {
+    Email: <Mail size={12} />,
+    Phone: <Phone size={12} />,
+    Location: <MapPin size={12} />,
+    Website: <Globe size={12} />,
+    LinkedIn: <Linkedin size={12} />,
+    GitHub: <Github size={12} />,
+  };
+
+  const renderContactDetail = (label: string, value?: string, hrefPrefix: string = '') => {
+    if (!value) return null;
+
+    let finalHrefPrefix = hrefPrefix;
+    if (
+      ['Website', 'LinkedIn', 'GitHub'].includes(label) &&
+      !value.startsWith('http') &&
+      !value.startsWith('//')
+    ) {
+      finalHrefPrefix = 'https://';
+    }
+
+    const href = finalHrefPrefix + value;
+    const isLink =
+      finalHrefPrefix.startsWith('http') ||
+      finalHrefPrefix.startsWith('mailto:') ||
+      finalHrefPrefix.startsWith('tel:');
+
+    let displayText = value;
+    if (isLink && (label === 'LinkedIn' || label === 'GitHub' || label === 'Website')) {
+      displayText = value.replace(/^https?:\/\//, '').replace(/^www\./, '');
+    }
+
+    return (
+      <span className="inline-flex items-center gap-1">
+        {showContactIcons && contactIcons[label]}
+        {isLink ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${baseStyles['resume-link']} hover:underline`}
+          >
+            {displayText}
+          </a>
+        ) : (
+          <span>{displayText}</span>
+        )}
+      </span>
+    );
+  };
+
+  const contactItems = [
+    renderContactDetail('Location', personalInfo?.location),
+    renderContactDetail('Phone', personalInfo?.phone, 'tel:'),
+    renderContactDetail('Email', personalInfo?.email, 'mailto:'),
+    renderContactDetail('LinkedIn', personalInfo?.linkedin),
+    renderContactDetail('GitHub', personalInfo?.github),
+    renderContactDetail('Website', personalInfo?.website),
+  ].filter(Boolean);
+
+  // Single-line entry header: COMPANY | Role (left), Location | Dates (right).
+  const renderEntryHeader = (
+    primary?: string,
+    role?: string,
+    location?: string,
+    dates?: string
+  ) => {
+    const meta = [location, dates ? formatDateRange(dates) : undefined].filter(Boolean).join(' | ');
+    return (
+      <div className={`flex justify-between items-baseline gap-3 ${baseStyles['resume-row-tight']}`}>
+        <span className="min-w-0">
+          <span className={styles.entryCompany}>{primary}</span>
+          {role && (
+            <>
+              <span className={styles.sep}>|</span>
+              <span className={styles.entryRole}>{role}</span>
+            </>
+          )}
+        </span>
+        {meta && <span className={styles.entryMeta}>{meta}</span>}
+      </div>
+    );
+  };
+
+  const renderBullets = (items?: string[]) => {
+    if (!items || items.length === 0) return null;
+    return (
+      <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
+        {items.map((desc, index) => (
+          <li key={index} className="flex">
+            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
+            <span>
+              <SafeHtml html={desc} />
+            </span>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
+  const renderSection = (section: SectionMeta) => {
+    switch (section.key) {
+      case 'personalInfo':
+        return null;
+
+      case 'summary':
+        if (!summary) return null;
+        return (
+          <div key={section.id} className={baseStyles['resume-section']}>
+            <h3 className={styles.sectionTitle}>{section.displayName}</h3>
+            <p className={`text-justify ${baseStyles['resume-text']}`}>{summary}</p>
+          </div>
+        );
+
+      case 'workExperience':
+        if (!workExperience || workExperience.length === 0) return null;
+        return (
+          <div key={section.id} className={baseStyles['resume-section']}>
+            <h3 className={styles.sectionTitle}>{section.displayName}</h3>
+            <div className={baseStyles['resume-items']}>
+              {workExperience.map((exp) => (
+                <div key={exp.id} className={baseStyles['resume-item']}>
+                  {renderEntryHeader(exp.company, exp.title, exp.location, exp.years)}
+                  {renderBullets(exp.description)}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+
+      case 'personalProjects':
+        if (!personalProjects || personalProjects.length === 0) return null;
+        return (
+          <div key={section.id} className={baseStyles['resume-section']}>
+            <h3 className={styles.sectionTitle}>{section.displayName}</h3>
+            <div className={baseStyles['resume-items']}>
+              {personalProjects.map((project) => (
+                <div key={project.id} className={baseStyles['resume-item']}>
+                  <div
+                    className={`flex justify-between items-baseline gap-3 ${baseStyles['resume-row-tight']}`}
+                  >
+                    <span className="flex items-baseline gap-2 min-w-0">
+                      <span className={styles.entryCompany}>{project.name}</span>
+                      {project.role && (
+                        <>
+                          <span className={styles.sep}>|</span>
+                          <span className={styles.entryRole}>{project.role}</span>
+                        </>
+                      )}
+                      {(project.github || project.website) && (
+                        <span className="flex gap-1.5">
+                          {project.github && (
+                            <a
+                              href={
+                                project.github.startsWith('http')
+                                  ? project.github
+                                  : `https://${project.github}`
+                              }
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={baseStyles['resume-link-pill']}
+                            >
+                              <Github size={10} />
+                              {project.github
+                                .replace(/^https?:\/\//, '')
+                                .replace(/^www\./, '')
+                                .replace(/\/$/, '')}
+                            </a>
+                          )}
+                          {project.website && (
+                            <a
+                              href={
+                                project.website.startsWith('http')
+                                  ? project.website
+                                  : `https://${project.website}`
+                              }
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={baseStyles['resume-link-pill']}
+                            >
+                              <ExternalLink size={10} />
+                              {project.website
+                                .replace(/^https?:\/\//, '')
+                                .replace(/^www\./, '')
+                                .replace(/\/$/, '')}
+                            </a>
+                          )}
+                        </span>
+                      )}
+                    </span>
+                    {project.years && (
+                      <span className={styles.entryMeta}>{formatDateRange(project.years)}</span>
+                    )}
+                  </div>
+                  {renderBullets(project.description)}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+
+      case 'education':
+        if (!education || education.length === 0) return null;
+        return (
+          <div key={section.id} className={baseStyles['resume-section']}>
+            <h3 className={styles.sectionTitle}>{section.displayName}</h3>
+            <div className={baseStyles['resume-items']}>
+              {education.map((edu) => (
+                <div key={edu.id} className={baseStyles['resume-item']}>
+                  {renderEntryHeader(edu.institution, edu.degree, undefined, edu.years)}
+                  {edu.description && (
+                    <p className={baseStyles['resume-text-sm']}>{edu.description}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+
+      case 'additional':
+        if (!additional) return null;
+        return (
+          <AdditionalSection
+            key={section.id}
+            additional={additional}
+            displayName={section.displayName}
+            labels={additionalSectionLabels}
+          />
+        );
+
+      default:
+        if (!section.isDefault) {
+          return (
+            <DynamicResumeSectionClean
+              key={section.id}
+              sectionMeta={section}
+              resumeData={data}
+              renderBullets={renderBullets}
+              renderEntryHeader={renderEntryHeader}
+            />
+          );
+        }
+        return null;
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      {personalInfo && (
+        <header className={`text-center ${baseStyles['resume-header']}`}>
+          {personalInfo.name && <h1 className={`${styles.name} mb-1`}>{personalInfo.name}</h1>}
+          {personalInfo.title && <div className={`${styles.tagline} mb-1`}>{personalInfo.title}</div>}
+          {contactItems.length > 0 && (
+            <div
+              className={`flex flex-wrap justify-center items-center gap-x-2 gap-y-1 ${styles.contactRow}`}
+            >
+              {contactItems.map((item, index) => (
+                <React.Fragment key={index}>
+                  {index > 0 && <span className={styles.sep}>|</span>}
+                  {item}
+                </React.Fragment>
+              ))}
+            </div>
+          )}
+        </header>
+      )}
+
+      {sortedSections
+        .filter((section) => section.key !== 'personalInfo')
+        .map((section) => renderSection(section))}
+    </div>
+  );
+};
+
+/**
+ * Additional info section (skills, languages, certifications, awards).
+ * Bold inline label followed by comma-joined items, one line per category.
+ */
+const AdditionalSection: React.FC<{
+  additional: ResumeData['additional'];
+  displayName?: string;
+  labels?: Partial<AdditionalSectionLabels>;
+}> = ({ additional, displayName = 'Skills & Awards', labels }) => {
+  if (!additional) return null;
+
+  const clean = (items?: string[]) =>
+    (items ?? []).filter((item): item is string => typeof item === 'string' && item.trim() !== '');
+
+  const technicalSkills = clean(additional.technicalSkills);
+  const languages = clean(additional.languages);
+  const certificationsTraining = clean(additional.certificationsTraining);
+  const awards = clean(additional.awards);
+
+  const mergedLabels: AdditionalSectionLabels = {
+    technicalSkills: labels?.technicalSkills ?? 'Technical Skills:',
+    languages: labels?.languages ?? 'Languages:',
+    certifications: labels?.certifications ?? 'Certifications:',
+    awards: labels?.awards ?? 'Awards:',
+  };
+
+  const hasContent =
+    technicalSkills.length > 0 ||
+    languages.length > 0 ||
+    certificationsTraining.length > 0 ||
+    awards.length > 0;
+
+  if (!hasContent) return null;
+
+  const line = (label: string, items: string[]) =>
+    items.length > 0 ? (
+      <div>
+        <span className={styles.skillLabel}>{label}</span> {items.join(', ')}
+      </div>
+    ) : null;
+
+  return (
+    <div className={baseStyles['resume-section']}>
+      <h3 className={styles.sectionTitle}>{displayName}</h3>
+      <div className={`${baseStyles['resume-stack']} ${baseStyles['resume-text-sm']}`}>
+        {line(mergedLabels.technicalSkills, technicalSkills)}
+        {line(mergedLabels.languages, languages)}
+        {line(mergedLabels.certifications, certificationsTraining)}
+        {line(mergedLabels.awards, awards)}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Dynamic (custom) section wrapper for the Clean template.
+ */
+const DynamicResumeSectionClean: React.FC<{
+  sectionMeta: SectionMeta;
+  resumeData: ResumeData;
+  renderBullets: (items?: string[]) => React.ReactNode;
+  renderEntryHeader: (
+    primary?: string,
+    role?: string,
+    location?: string,
+    dates?: string
+  ) => React.ReactNode;
+}> = ({ sectionMeta, resumeData, renderBullets, renderEntryHeader }) => {
+  const customSection = resumeData.customSections?.[sectionMeta.key];
+  if (!customSection) return null;
+
+  const hasContent = (() => {
+    switch (sectionMeta.sectionType) {
+      case 'text':
+        return Boolean(customSection.text?.trim());
+      case 'itemList':
+        return Boolean(customSection.items?.length);
+      case 'stringList':
+        return Boolean(customSection.strings?.length);
+      default:
+        return false;
+    }
+  })();
+
+  if (!hasContent) return null;
+
+  return (
+    <div className={baseStyles['resume-section']}>
+      <h3 className={styles.sectionTitle}>{sectionMeta.displayName}</h3>
+      {sectionMeta.sectionType === 'text' && customSection.text?.trim() && (
+        <p className={`text-justify ${baseStyles['resume-text']}`}>{customSection.text}</p>
+      )}
+      {sectionMeta.sectionType === 'itemList' && customSection.items?.length ? (
+        <div className={baseStyles['resume-items']}>
+          {customSection.items.map((item) => (
+            <div key={item.id} className={baseStyles['resume-item']}>
+              {renderEntryHeader(item.title, item.subtitle, item.location, item.years)}
+              {renderBullets(item.description)}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {sectionMeta.sectionType === 'stringList' && customSection.strings?.length ? (
+        <div className={baseStyles['resume-text-sm']}>{customSection.strings.join(', ')}</div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ResumeClean;

--- a/apps/frontend/components/resume/resume-latex.tsx
+++ b/apps/frontend/components/resume/resume-latex.tsx
@@ -1,0 +1,431 @@
+import React from 'react';
+import { Mail, Phone, MapPin, Globe, Linkedin, Github, ExternalLink } from 'lucide-react';
+import type {
+  ResumeData,
+  SectionMeta,
+  AdditionalSectionLabels,
+} from '@/components/dashboard/resume-component';
+import { getSortedSections } from '@/lib/utils/section-helpers';
+import { formatDateRange } from '@/lib/utils';
+import { SafeHtml } from './safe-html';
+import baseStyles from './styles/_base.module.css';
+import styles from './styles/latex.module.css';
+
+interface ResumeLatexProps {
+  data: ResumeData;
+  showContactIcons?: boolean;
+  additionalSectionLabels?: Partial<AdditionalSectionLabels>;
+}
+
+/**
+ * LaTeX Resume Template
+ *
+ * Classic serif academic layout reminiscent of the popular LaTeX résumé templates:
+ * centered small-caps name, Title-Case section headers with a full-width rule, and
+ * company-first two-line entries (company + dates, then italic role + location).
+ *
+ * Single-typeface design: all text inherits `--header-font` (serif by default), so the
+ * Header Font control drives the whole template. ATS-safe (all text is real DOM nodes).
+ *
+ * Section order: Determined by sectionMeta ordering.
+ */
+export const ResumeLatex: React.FC<ResumeLatexProps> = ({
+  data,
+  showContactIcons = false,
+  additionalSectionLabels,
+}) => {
+  const { personalInfo, summary, workExperience, education, personalProjects, additional } = data;
+
+  const sortedSections = getSortedSections(data);
+
+  const contactIcons: Record<string, React.ReactNode> = {
+    Email: <Mail size={12} />,
+    Phone: <Phone size={12} />,
+    Location: <MapPin size={12} />,
+    Website: <Globe size={12} />,
+    LinkedIn: <Linkedin size={12} />,
+    GitHub: <Github size={12} />,
+  };
+
+  const renderContactDetail = (label: string, value?: string, hrefPrefix: string = '') => {
+    if (!value) return null;
+
+    let finalHrefPrefix = hrefPrefix;
+    if (
+      ['Website', 'LinkedIn', 'GitHub'].includes(label) &&
+      !value.startsWith('http') &&
+      !value.startsWith('//')
+    ) {
+      finalHrefPrefix = 'https://';
+    }
+
+    const href = finalHrefPrefix + value;
+    const isLink =
+      finalHrefPrefix.startsWith('http') ||
+      finalHrefPrefix.startsWith('mailto:') ||
+      finalHrefPrefix.startsWith('tel:');
+
+    let displayText = value;
+    if (isLink && (label === 'LinkedIn' || label === 'GitHub' || label === 'Website')) {
+      displayText = value.replace(/^https?:\/\//, '').replace(/^www\./, '');
+    }
+
+    return (
+      <span className="inline-flex items-center gap-1">
+        {showContactIcons && contactIcons[label]}
+        {isLink ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${baseStyles['resume-link']} hover:underline`}
+          >
+            {displayText}
+          </a>
+        ) : (
+          <span>{displayText}</span>
+        )}
+      </span>
+    );
+  };
+
+  // Build the contact row (phone, email, linkedin, github, website) joined by middots.
+  const contactItems = [
+    renderContactDetail('Phone', personalInfo?.phone, 'tel:'),
+    renderContactDetail('Email', personalInfo?.email, 'mailto:'),
+    renderContactDetail('LinkedIn', personalInfo?.linkedin),
+    renderContactDetail('GitHub', personalInfo?.github),
+    renderContactDetail('Website', personalInfo?.website),
+  ].filter(Boolean);
+
+  // Company-first entry header: bold company / bold dates, then italic role / italic location.
+  const renderEntryHeader = (
+    primary?: string,
+    dates?: string,
+    secondary?: string,
+    location?: string
+  ) => (
+    <>
+      <div className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}>
+        <span className={styles.entryPrimary}>{primary}</span>
+        {dates && <span className={`${styles.entryDates} ml-4`}>{formatDateRange(dates)}</span>}
+      </div>
+      {(secondary || location) && (
+        <div className={`flex justify-between items-baseline ${baseStyles['resume-row']}`}>
+          {secondary && <span className={styles.entrySecondary}>{secondary}</span>}
+          {location && <span className={`${styles.entrySecondary} ml-4`}>{location}</span>}
+        </div>
+      )}
+    </>
+  );
+
+  const renderBullets = (items?: string[]) => {
+    if (!items || items.length === 0) return null;
+    return (
+      <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
+        {items.map((desc, index) => (
+          <li key={index} className="flex">
+            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
+            <span>
+              <SafeHtml html={desc} />
+            </span>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
+  const renderSection = (section: SectionMeta) => {
+    switch (section.key) {
+      case 'personalInfo':
+        return null;
+
+      case 'summary':
+        if (!summary) return null;
+        return (
+          <div key={section.id} className={baseStyles['resume-section']}>
+            <h3 className={styles.sectionTitle}>{section.displayName}</h3>
+            <p className={`text-justify ${baseStyles['resume-text']}`}>{summary}</p>
+          </div>
+        );
+
+      case 'workExperience':
+        if (!workExperience || workExperience.length === 0) return null;
+        return (
+          <div key={section.id} className={baseStyles['resume-section']}>
+            <h3 className={styles.sectionTitle}>{section.displayName}</h3>
+            <div className={baseStyles['resume-items']}>
+              {workExperience.map((exp) => (
+                <div key={exp.id} className={baseStyles['resume-item']}>
+                  {renderEntryHeader(exp.company, exp.years, exp.title, exp.location)}
+                  {renderBullets(exp.description)}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+
+      case 'personalProjects':
+        if (!personalProjects || personalProjects.length === 0) return null;
+        return (
+          <div key={section.id} className={baseStyles['resume-section']}>
+            <h3 className={styles.sectionTitle}>{section.displayName}</h3>
+            <div className={baseStyles['resume-items']}>
+              {personalProjects.map((project) => (
+                <div key={project.id} className={baseStyles['resume-item']}>
+                  <div
+                    className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}
+                  >
+                    <div className="flex items-baseline gap-2">
+                      <span className={styles.entryPrimary}>{project.name}</span>
+                      {(project.github || project.website) && (
+                        <span className="flex gap-1.5">
+                          {project.github && (
+                            <a
+                              href={
+                                project.github.startsWith('http')
+                                  ? project.github
+                                  : `https://${project.github}`
+                              }
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={baseStyles['resume-link-pill']}
+                            >
+                              <Github size={10} />
+                              {project.github
+                                .replace(/^https?:\/\//, '')
+                                .replace(/^www\./, '')
+                                .replace(/\/$/, '')}
+                            </a>
+                          )}
+                          {project.website && (
+                            <a
+                              href={
+                                project.website.startsWith('http')
+                                  ? project.website
+                                  : `https://${project.website}`
+                              }
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={baseStyles['resume-link-pill']}
+                            >
+                              <ExternalLink size={10} />
+                              {project.website
+                                .replace(/^https?:\/\//, '')
+                                .replace(/^www\./, '')
+                                .replace(/\/$/, '')}
+                            </a>
+                          )}
+                        </span>
+                      )}
+                    </div>
+                    {project.years && (
+                      <span className={`${styles.entryDates} ml-4`}>
+                        {formatDateRange(project.years)}
+                      </span>
+                    )}
+                  </div>
+                  {project.role && (
+                    <div className={baseStyles['resume-row']}>
+                      <span className={styles.entrySecondary}>{project.role}</span>
+                    </div>
+                  )}
+                  {renderBullets(project.description)}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+
+      case 'education':
+        if (!education || education.length === 0) return null;
+        return (
+          <div key={section.id} className={baseStyles['resume-section']}>
+            <h3 className={styles.sectionTitle}>{section.displayName}</h3>
+            <div className={baseStyles['resume-items']}>
+              {education.map((edu) => (
+                <div key={edu.id} className={baseStyles['resume-item']}>
+                  {renderEntryHeader(edu.institution, edu.years, edu.degree)}
+                  {edu.description && (
+                    <p className={baseStyles['resume-text-sm']}>{edu.description}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+
+      case 'additional':
+        if (!additional) return null;
+        return (
+          <AdditionalSection
+            key={section.id}
+            additional={additional}
+            displayName={section.displayName}
+            labels={additionalSectionLabels}
+          />
+        );
+
+      default:
+        if (!section.isDefault) {
+          return (
+            <DynamicResumeSectionLatex
+              key={section.id}
+              sectionMeta={section}
+              resumeData={data}
+              renderBullets={renderBullets}
+            />
+          );
+        }
+        return null;
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      {personalInfo && (
+        <header className={`text-center ${baseStyles['resume-header']}`}>
+          {personalInfo.name && <h1 className={`${styles.name} mb-1`}>{personalInfo.name}</h1>}
+          {personalInfo.location && (
+            <div className={`${styles.locationLine} mb-1`}>{personalInfo.location}</div>
+          )}
+          {personalInfo.title && <div className={`${styles.tagline} mb-1`}>{personalInfo.title}</div>}
+          {contactItems.length > 0 && (
+            <div className={`flex flex-wrap justify-center items-center gap-x-2 gap-y-1 ${styles.contactRow}`}>
+              {contactItems.map((item, index) => (
+                <React.Fragment key={index}>
+                  {index > 0 && <span className={styles.contactSep}>·</span>}
+                  {item}
+                </React.Fragment>
+              ))}
+            </div>
+          )}
+        </header>
+      )}
+
+      {sortedSections
+        .filter((section) => section.key !== 'personalInfo')
+        .map((section) => renderSection(section))}
+    </div>
+  );
+};
+
+/**
+ * Additional info section (skills, languages, certifications, awards).
+ * Bold inline category label followed by comma-joined items, one line per category.
+ */
+const AdditionalSection: React.FC<{
+  additional: ResumeData['additional'];
+  displayName?: string;
+  labels?: Partial<AdditionalSectionLabels>;
+}> = ({ additional, displayName = 'Skills & Awards', labels }) => {
+  if (!additional) return null;
+
+  const clean = (items?: string[]) =>
+    (items ?? []).filter((item): item is string => typeof item === 'string' && item.trim() !== '');
+
+  const technicalSkills = clean(additional.technicalSkills);
+  const languages = clean(additional.languages);
+  const certificationsTraining = clean(additional.certificationsTraining);
+  const awards = clean(additional.awards);
+
+  const mergedLabels: AdditionalSectionLabels = {
+    technicalSkills: labels?.technicalSkills ?? 'Technical Skills:',
+    languages: labels?.languages ?? 'Languages:',
+    certifications: labels?.certifications ?? 'Certifications:',
+    awards: labels?.awards ?? 'Awards:',
+  };
+
+  const hasContent =
+    technicalSkills.length > 0 ||
+    languages.length > 0 ||
+    certificationsTraining.length > 0 ||
+    awards.length > 0;
+
+  if (!hasContent) return null;
+
+  const line = (label: string, items: string[]) =>
+    items.length > 0 ? (
+      <div>
+        <span className="font-bold">{label}</span> {items.join(', ')}
+      </div>
+    ) : null;
+
+  return (
+    <div className={baseStyles['resume-section']}>
+      <h3 className={styles.sectionTitle}>{displayName}</h3>
+      <div className={`${baseStyles['resume-stack']} ${baseStyles['resume-text-sm']}`}>
+        {line(mergedLabels.technicalSkills, technicalSkills)}
+        {line(mergedLabels.languages, languages)}
+        {line(mergedLabels.certifications, certificationsTraining)}
+        {line(mergedLabels.awards, awards)}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Dynamic (custom) section wrapper for the LaTeX template.
+ */
+const DynamicResumeSectionLatex: React.FC<{
+  sectionMeta: SectionMeta;
+  resumeData: ResumeData;
+  renderBullets: (items?: string[]) => React.ReactNode;
+}> = ({ sectionMeta, resumeData, renderBullets }) => {
+  const customSection = resumeData.customSections?.[sectionMeta.key];
+  if (!customSection) return null;
+
+  const hasContent = (() => {
+    switch (sectionMeta.sectionType) {
+      case 'text':
+        return Boolean(customSection.text?.trim());
+      case 'itemList':
+        return Boolean(customSection.items?.length);
+      case 'stringList':
+        return Boolean(customSection.strings?.length);
+      default:
+        return false;
+    }
+  })();
+
+  if (!hasContent) return null;
+
+  return (
+    <div className={baseStyles['resume-section']}>
+      <h3 className={styles.sectionTitle}>{sectionMeta.displayName}</h3>
+      {sectionMeta.sectionType === 'text' && customSection.text?.trim() && (
+        <p className={`text-justify ${baseStyles['resume-text']}`}>{customSection.text}</p>
+      )}
+      {sectionMeta.sectionType === 'itemList' && customSection.items?.length ? (
+        <div className={baseStyles['resume-items']}>
+          {customSection.items.map((item) => (
+            <div key={item.id} className={baseStyles['resume-item']}>
+              <div
+                className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}
+              >
+                <span className={styles.entryPrimary}>{item.title}</span>
+                {item.years && (
+                  <span className={`${styles.entryDates} ml-4`}>{formatDateRange(item.years)}</span>
+                )}
+              </div>
+              {(item.subtitle || item.location) && (
+                <div className={`flex justify-between items-baseline ${baseStyles['resume-row']}`}>
+                  {item.subtitle && <span className={styles.entrySecondary}>{item.subtitle}</span>}
+                  {item.location && (
+                    <span className={`${styles.entrySecondary} ml-4`}>{item.location}</span>
+                  )}
+                </div>
+              )}
+              {renderBullets(item.description)}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {sectionMeta.sectionType === 'stringList' && customSection.strings?.length ? (
+        <div className={baseStyles['resume-text-sm']}>{customSection.strings.join(', ')}</div>
+      ) : null}
+    </div>
+  );
+};
+
+export default ResumeLatex;

--- a/apps/frontend/components/resume/resume-latex.tsx
+++ b/apps/frontend/components/resume/resume-latex.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Mail, Phone, MapPin, Globe, Linkedin, Github, ExternalLink } from 'lucide-react';
+import { Mail, Phone, Globe, Linkedin, Github, ExternalLink } from 'lucide-react';
 import type {
   ResumeData,
   SectionMeta,
@@ -38,10 +38,10 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
 
   const sortedSections = getSortedSections(data);
 
+  // LaTeX renders location as its own centered line, so it is not a contact-row item.
   const contactIcons: Record<string, React.ReactNode> = {
     Email: <Mail size={12} />,
     Phone: <Phone size={12} />,
-    Location: <MapPin size={12} />,
     Website: <Globe size={12} />,
     LinkedIn: <Linkedin size={12} />,
     GitHub: <Github size={12} />,
@@ -286,11 +286,11 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
       {personalInfo && (
         <header className={`text-center ${baseStyles['resume-header']}`}>
           {personalInfo.name && <h1 className={`${styles.name} mb-1`}>{personalInfo.name}</h1>}
-          {personalInfo.location && (
-            <div className={`${styles.locationLine} mb-1`}>{personalInfo.location}</div>
-          )}
           {personalInfo.title && (
             <div className={`${styles.tagline} mb-1`}>{personalInfo.title}</div>
+          )}
+          {personalInfo.location && (
+            <div className={`${styles.locationLine} mb-1`}>{personalInfo.location}</div>
           )}
           {contactItems.length > 0 && (
             <div

--- a/apps/frontend/components/resume/resume-latex.tsx
+++ b/apps/frontend/components/resume/resume-latex.tsx
@@ -289,9 +289,13 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
           {personalInfo.location && (
             <div className={`${styles.locationLine} mb-1`}>{personalInfo.location}</div>
           )}
-          {personalInfo.title && <div className={`${styles.tagline} mb-1`}>{personalInfo.title}</div>}
+          {personalInfo.title && (
+            <div className={`${styles.tagline} mb-1`}>{personalInfo.title}</div>
+          )}
           {contactItems.length > 0 && (
-            <div className={`flex flex-wrap justify-center items-center gap-x-2 gap-y-1 ${styles.contactRow}`}>
+            <div
+              className={`flex flex-wrap justify-center items-center gap-x-2 gap-y-1 ${styles.contactRow}`}
+            >
               {contactItems.map((item, index) => (
                 <React.Fragment key={index}>
                   {index > 0 && <span className={styles.contactSep}>·</span>}

--- a/apps/frontend/components/resume/resume-vivid.tsx
+++ b/apps/frontend/components/resume/resume-vivid.tsx
@@ -1,0 +1,373 @@
+import React from 'react';
+import { Mail, Phone, MapPin, Globe, Linkedin, Github, ExternalLink } from 'lucide-react';
+import type {
+  ResumeData,
+  ResumeSectionHeadings,
+  ResumeFallbackLabels,
+} from '@/components/dashboard/resume-component';
+import { getSortedSections, getSectionMeta } from '@/lib/utils/section-helpers';
+import { formatDateRange } from '@/lib/utils';
+import { DynamicResumeSection } from './dynamic-resume-section';
+import { SafeHtml } from './safe-html';
+import baseStyles from './styles/_base.module.css';
+import styles from './styles/vivid.module.css';
+
+interface ResumeVividProps {
+  data: ResumeData;
+  showContactIcons?: boolean;
+  sectionHeadings?: Partial<ResumeSectionHeadings>;
+  fallbackLabels?: Partial<ResumeFallbackLabels>;
+}
+
+/**
+ * Vivid Resume Template
+ *
+ * Colorful two-column layout in the "Awesome-CV" lineage: a two-tone accent name,
+ * a monospace title + contact row with circular icon chips, accent small-caps section
+ * headers, and accent arrow (➜) bullet markers. Reads the accent-color control
+ * (default blue). ATS-safe (all text is real DOM nodes).
+ *
+ * Main Column (63%): Summary, Experience, Projects, Certifications/Training, Custom Sections
+ * Sidebar (37%): Skills, Languages, Education, Awards, Links
+ */
+export const ResumeVivid: React.FC<ResumeVividProps> = ({
+  data,
+  showContactIcons = false,
+  sectionHeadings,
+  fallbackLabels,
+}) => {
+  const { personalInfo, summary, workExperience, education, personalProjects, additional } = data;
+
+  const clean = (items?: string[]) =>
+    (items ?? []).filter((item): item is string => typeof item === 'string' && item.trim() !== '');
+
+  const technicalSkills = clean(additional?.technicalSkills);
+  const languages = clean(additional?.languages);
+  const certificationsTraining = clean(additional?.certificationsTraining);
+  const awards = clean(additional?.awards);
+
+  const sortedSections = getSortedSections(data);
+  const allSections = getSectionMeta(data);
+
+  const headingFallbacks: ResumeSectionHeadings = {
+    summary: sectionHeadings?.summary ?? 'Summary',
+    experience: sectionHeadings?.experience ?? 'Experience',
+    education: sectionHeadings?.education ?? 'Education',
+    projects: sectionHeadings?.projects ?? 'Projects',
+    certifications: sectionHeadings?.certifications ?? 'Training & Certifications',
+    skills: sectionHeadings?.skills ?? 'Skills',
+    languages: sectionHeadings?.languages ?? 'Languages',
+    awards: sectionHeadings?.awards ?? 'Awards',
+    links: sectionHeadings?.links ?? 'Links',
+  };
+
+  const nameFallback = fallbackLabels?.name ?? 'Your Name';
+
+  const getSectionDisplayName = (sectionKey: string, fallback: string): string => {
+    const section = sortedSections.find((s) => s.key === sectionKey);
+    return section?.displayName || fallback;
+  };
+
+  const isSectionVisible = (sectionKey: string): boolean => {
+    const section = allSections.find((s) => s.key === sectionKey);
+    return section?.isVisible ?? true;
+  };
+
+  const customSections = sortedSections.filter((s) => !s.isDefault);
+
+  // Two-tone name: bold accent first token, lighter accent for the rest.
+  const fullName = personalInfo?.name || nameFallback;
+  const firstSpace = fullName.indexOf(' ');
+  const nameFirst = firstSpace === -1 ? fullName : fullName.slice(0, firstSpace);
+  const nameRest = firstSpace === -1 ? '' : fullName.slice(firstSpace + 1);
+
+  const contactIcons: Record<string, React.ReactNode> = {
+    Email: <Mail size={11} />,
+    Phone: <Phone size={11} />,
+    Location: <MapPin size={11} />,
+    Website: <Globe size={11} />,
+    LinkedIn: <Linkedin size={11} />,
+    GitHub: <Github size={11} />,
+  };
+
+  const renderContactDetail = (label: string, value?: string, hrefPrefix: string = '') => {
+    if (!value) return null;
+
+    let finalHrefPrefix = hrefPrefix;
+    if (
+      ['Website', 'LinkedIn', 'GitHub'].includes(label) &&
+      !value.startsWith('http') &&
+      !value.startsWith('//')
+    ) {
+      finalHrefPrefix = 'https://';
+    }
+
+    const href = finalHrefPrefix + value;
+    const isLink =
+      finalHrefPrefix.startsWith('http') ||
+      finalHrefPrefix.startsWith('mailto:') ||
+      finalHrefPrefix.startsWith('tel:');
+
+    let displayText = value;
+    if (isLink && (label === 'LinkedIn' || label === 'GitHub' || label === 'Website')) {
+      displayText = value.replace(/^https?:\/\//, '').replace(/^www\./, '');
+    }
+
+    return (
+      <span className={styles.contactChip}>
+        {showContactIcons && <span className={styles.iconCircle}>{contactIcons[label]}</span>}
+        {isLink ? (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${baseStyles['resume-link']} hover:underline`}
+          >
+            {displayText}
+          </a>
+        ) : (
+          <span>{displayText}</span>
+        )}
+      </span>
+    );
+  };
+
+  const renderArrowBullets = (items?: string[], textClass: string = baseStyles['resume-text-xs']) => {
+    if (!items || items.length === 0) return null;
+    return (
+      <ul className={`ml-4 ${baseStyles['resume-list']} ${textClass}`}>
+        {items.map((desc, index) => (
+          <li key={index} className="flex">
+            <span className={`mr-1.5 ${styles.arrow}`}>➜&nbsp;</span>
+            <span>
+              <SafeHtml html={desc} />
+            </span>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
+  return (
+    <>
+      {/* Header */}
+      <div className={baseStyles['resume-header']}>
+        <h1 className={baseStyles['resume-name']}>
+          <span className={styles.nameFirst}>{nameFirst}</span>
+          {nameRest && <span className={styles.nameRest}> {nameRest}</span>}
+        </h1>
+        {personalInfo?.title && <div className={styles.titleLine}>{personalInfo.title}</div>}
+        {personalInfo && (
+          <div className={`flex flex-wrap gap-x-4 gap-y-1 mt-2 ${styles.contactRow}`}>
+            {renderContactDetail('Website', personalInfo.website)}
+            {renderContactDetail('LinkedIn', personalInfo.linkedin)}
+            {renderContactDetail('GitHub', personalInfo.github)}
+            {renderContactDetail('Email', personalInfo.email, 'mailto:')}
+            {renderContactDetail('Phone', personalInfo.phone, 'tel:')}
+            {renderContactDetail('Location', personalInfo.location)}
+          </div>
+        )}
+      </div>
+
+      {/* Two-Column Grid */}
+      <div className={styles.grid}>
+        {/* Main Column - Left */}
+        <div className={styles.mainColumn}>
+          {isSectionVisible('summary') && summary && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitle}>
+                {getSectionDisplayName('summary', headingFallbacks.summary)}
+              </h3>
+              <p className={`text-justify ${baseStyles['resume-text']}`}>{summary}</p>
+            </div>
+          )}
+
+          {isSectionVisible('workExperience') && workExperience && workExperience.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitle}>
+                {getSectionDisplayName('workExperience', headingFallbacks.experience)}
+              </h3>
+              <div className={baseStyles['resume-items']}>
+                {workExperience.map((exp) => (
+                  <div key={exp.id} className={baseStyles['resume-item']}>
+                    <div className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}>
+                      <span>
+                        <span className={styles.entryCompany}>{exp.company}</span>
+                        {exp.title && (
+                          <>
+                            <span className={styles.entrySep}>|</span>
+                            <span className={styles.entryRole}>{exp.title}</span>
+                          </>
+                        )}
+                      </span>
+                    </div>
+                    <div className={`${baseStyles['resume-row-tight']} ${styles.entryMeta}`}>
+                      {formatDateRange(exp.years)}
+                      {exp.location && <> | {exp.location}</>}
+                    </div>
+                    {renderArrowBullets(exp.description)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {isSectionVisible('personalProjects') && personalProjects && personalProjects.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitle}>
+                {getSectionDisplayName('personalProjects', headingFallbacks.projects)}
+              </h3>
+              <div className={baseStyles['resume-items']}>
+                {personalProjects.map((project) => (
+                  <div key={project.id} className={baseStyles['resume-item']}>
+                    <div className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}>
+                      <span className="flex items-baseline gap-1.5 min-w-0">
+                        <span className={styles.entryCompany}>{project.name}</span>
+                        {project.role && (
+                          <>
+                            <span className={styles.entrySep}>|</span>
+                            <span className={styles.entryRole}>{project.role}</span>
+                          </>
+                        )}
+                        {(project.github || project.website) && (
+                          <span className="flex gap-1">
+                            {project.github && (
+                              <a
+                                href={
+                                  project.github.startsWith('http')
+                                    ? project.github
+                                    : `https://${project.github}`
+                                }
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={baseStyles['resume-link-pill']}
+                              >
+                                <Github size={9} />
+                                {project.github
+                                  .replace(/^https?:\/\//, '')
+                                  .replace(/^www\./, '')
+                                  .replace(/\/$/, '')}
+                              </a>
+                            )}
+                            {project.website && (
+                              <a
+                                href={
+                                  project.website.startsWith('http')
+                                    ? project.website
+                                    : `https://${project.website}`
+                                }
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={baseStyles['resume-link-pill']}
+                              >
+                                <ExternalLink size={9} />
+                                {project.website
+                                  .replace(/^https?:\/\//, '')
+                                  .replace(/^www\./, '')
+                                  .replace(/\/$/, '')}
+                              </a>
+                            )}
+                          </span>
+                        )}
+                      </span>
+                      {project.years && (
+                        <span className={`${styles.entryMeta} ml-2`}>
+                          {formatDateRange(project.years)}
+                        </span>
+                      )}
+                    </div>
+                    {renderArrowBullets(project.description)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {isSectionVisible('additional') && certificationsTraining.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitle}>{headingFallbacks.certifications}</h3>
+              {renderArrowBullets(certificationsTraining)}
+            </div>
+          )}
+
+          {customSections.map((section) => (
+            <DynamicResumeSection key={section.id} sectionMeta={section} resumeData={data} />
+          ))}
+        </div>
+
+        {/* Sidebar Column - Right */}
+        <div className={styles.sidebarColumn}>
+          {isSectionVisible('additional') && technicalSkills.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitleSm}>{headingFallbacks.skills}</h3>
+              <p className={baseStyles['resume-text-xs']}>{technicalSkills.join(' • ')}</p>
+            </div>
+          )}
+
+          {isSectionVisible('additional') && languages.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitleSm}>{headingFallbacks.languages}</h3>
+              <p className={baseStyles['resume-text-xs']}>{languages.join(' • ')}</p>
+            </div>
+          )}
+
+          {isSectionVisible('education') && education && education.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitleSm}>
+                {getSectionDisplayName('education', headingFallbacks.education)}
+              </h3>
+              <div className={baseStyles['resume-stack']}>
+                {education.map((edu) => (
+                  <div key={edu.id}>
+                    <h4 className={`${baseStyles['resume-item-title-sm']} ${baseStyles['sidebar-text-wrap']}`}>
+                      {edu.institution}
+                    </h4>
+                    <p className={baseStyles['resume-item-subtitle-sm']}>{edu.degree}</p>
+                    {edu.years && (
+                      <p className={`${baseStyles['resume-meta-sm']}`}>{formatDateRange(edu.years)}</p>
+                    )}
+                    {edu.description && (
+                      <p className={`${baseStyles['resume-text-xs']} ${baseStyles['resume-meta']}`}>
+                        {edu.description}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {isSectionVisible('additional') && awards.length > 0 && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitleSm}>{headingFallbacks.awards}</h3>
+              <ul className={baseStyles['resume-list']}>
+                {awards.map((award, index) => (
+                  <li key={index} className={baseStyles['resume-text-xs']}>
+                    {award}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {personalInfo && (personalInfo.website || personalInfo.linkedin || personalInfo.github) && (
+            <div className={baseStyles['resume-section']}>
+              <h3 className={styles.sectionTitleSm}>{headingFallbacks.links}</h3>
+              <div className={`${baseStyles['resume-stack-tight']} ${baseStyles['resume-meta-sm']}`}>
+                {personalInfo.linkedin && (
+                  <div>{renderContactDetail('LinkedIn', personalInfo.linkedin)}</div>
+                )}
+                {personalInfo.github && <div>{renderContactDetail('GitHub', personalInfo.github)}</div>}
+                {personalInfo.website && (
+                  <div>{renderContactDetail('Website', personalInfo.website)}</div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ResumeVivid;

--- a/apps/frontend/components/resume/resume-vivid.tsx
+++ b/apps/frontend/components/resume/resume-vivid.tsx
@@ -132,7 +132,10 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
     );
   };
 
-  const renderArrowBullets = (items?: string[], textClass: string = baseStyles['resume-text-xs']) => {
+  const renderArrowBullets = (
+    items?: string[],
+    textClass: string = baseStyles['resume-text-xs']
+  ) => {
     if (!items || items.length === 0) return null;
     return (
       <ul className={`ml-4 ${baseStyles['resume-list']} ${textClass}`}>
@@ -190,7 +193,9 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
               <div className={baseStyles['resume-items']}>
                 {workExperience.map((exp) => (
                   <div key={exp.id} className={baseStyles['resume-item']}>
-                    <div className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}>
+                    <div
+                      className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}
+                    >
                       <span>
                         <span className={styles.entryCompany}>{exp.company}</span>
                         {exp.title && (
@@ -212,76 +217,80 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
             </div>
           )}
 
-          {isSectionVisible('personalProjects') && personalProjects && personalProjects.length > 0 && (
-            <div className={baseStyles['resume-section']}>
-              <h3 className={styles.sectionTitle}>
-                {getSectionDisplayName('personalProjects', headingFallbacks.projects)}
-              </h3>
-              <div className={baseStyles['resume-items']}>
-                {personalProjects.map((project) => (
-                  <div key={project.id} className={baseStyles['resume-item']}>
-                    <div className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}>
-                      <span className="flex items-baseline gap-1.5 min-w-0">
-                        <span className={styles.entryCompany}>{project.name}</span>
-                        {project.role && (
-                          <>
-                            <span className={styles.entrySep}>|</span>
-                            <span className={styles.entryRole}>{project.role}</span>
-                          </>
-                        )}
-                        {(project.github || project.website) && (
-                          <span className="flex gap-1">
-                            {project.github && (
-                              <a
-                                href={
-                                  project.github.startsWith('http')
-                                    ? project.github
-                                    : `https://${project.github}`
-                                }
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className={baseStyles['resume-link-pill']}
-                              >
-                                <Github size={9} />
-                                {project.github
-                                  .replace(/^https?:\/\//, '')
-                                  .replace(/^www\./, '')
-                                  .replace(/\/$/, '')}
-                              </a>
-                            )}
-                            {project.website && (
-                              <a
-                                href={
-                                  project.website.startsWith('http')
-                                    ? project.website
-                                    : `https://${project.website}`
-                                }
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className={baseStyles['resume-link-pill']}
-                              >
-                                <ExternalLink size={9} />
-                                {project.website
-                                  .replace(/^https?:\/\//, '')
-                                  .replace(/^www\./, '')
-                                  .replace(/\/$/, '')}
-                              </a>
-                            )}
+          {isSectionVisible('personalProjects') &&
+            personalProjects &&
+            personalProjects.length > 0 && (
+              <div className={baseStyles['resume-section']}>
+                <h3 className={styles.sectionTitle}>
+                  {getSectionDisplayName('personalProjects', headingFallbacks.projects)}
+                </h3>
+                <div className={baseStyles['resume-items']}>
+                  {personalProjects.map((project) => (
+                    <div key={project.id} className={baseStyles['resume-item']}>
+                      <div
+                        className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}
+                      >
+                        <span className="flex items-baseline gap-1.5 min-w-0">
+                          <span className={styles.entryCompany}>{project.name}</span>
+                          {project.role && (
+                            <>
+                              <span className={styles.entrySep}>|</span>
+                              <span className={styles.entryRole}>{project.role}</span>
+                            </>
+                          )}
+                          {(project.github || project.website) && (
+                            <span className="flex gap-1">
+                              {project.github && (
+                                <a
+                                  href={
+                                    project.github.startsWith('http')
+                                      ? project.github
+                                      : `https://${project.github}`
+                                  }
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className={baseStyles['resume-link-pill']}
+                                >
+                                  <Github size={9} />
+                                  {project.github
+                                    .replace(/^https?:\/\//, '')
+                                    .replace(/^www\./, '')
+                                    .replace(/\/$/, '')}
+                                </a>
+                              )}
+                              {project.website && (
+                                <a
+                                  href={
+                                    project.website.startsWith('http')
+                                      ? project.website
+                                      : `https://${project.website}`
+                                  }
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className={baseStyles['resume-link-pill']}
+                                >
+                                  <ExternalLink size={9} />
+                                  {project.website
+                                    .replace(/^https?:\/\//, '')
+                                    .replace(/^www\./, '')
+                                    .replace(/\/$/, '')}
+                                </a>
+                              )}
+                            </span>
+                          )}
+                        </span>
+                        {project.years && (
+                          <span className={`${styles.entryMeta} ml-2`}>
+                            {formatDateRange(project.years)}
                           </span>
                         )}
-                      </span>
-                      {project.years && (
-                        <span className={`${styles.entryMeta} ml-2`}>
-                          {formatDateRange(project.years)}
-                        </span>
-                      )}
+                      </div>
+                      {renderArrowBullets(project.description)}
                     </div>
-                    {renderArrowBullets(project.description)}
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
           {isSectionVisible('additional') && certificationsTraining.length > 0 && (
             <div className={baseStyles['resume-section']}>
@@ -319,12 +328,16 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
               <div className={baseStyles['resume-stack']}>
                 {education.map((edu) => (
                   <div key={edu.id}>
-                    <h4 className={`${baseStyles['resume-item-title-sm']} ${baseStyles['sidebar-text-wrap']}`}>
+                    <h4
+                      className={`${baseStyles['resume-item-title-sm']} ${baseStyles['sidebar-text-wrap']}`}
+                    >
                       {edu.institution}
                     </h4>
                     <p className={baseStyles['resume-item-subtitle-sm']}>{edu.degree}</p>
                     {edu.years && (
-                      <p className={`${baseStyles['resume-meta-sm']}`}>{formatDateRange(edu.years)}</p>
+                      <p className={`${baseStyles['resume-meta-sm']}`}>
+                        {formatDateRange(edu.years)}
+                      </p>
                     )}
                     {edu.description && (
                       <p className={`${baseStyles['resume-text-xs']} ${baseStyles['resume-meta']}`}>
@@ -350,20 +363,25 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
             </div>
           )}
 
-          {personalInfo && (personalInfo.website || personalInfo.linkedin || personalInfo.github) && (
-            <div className={baseStyles['resume-section']}>
-              <h3 className={styles.sectionTitleSm}>{headingFallbacks.links}</h3>
-              <div className={`${baseStyles['resume-stack-tight']} ${baseStyles['resume-meta-sm']}`}>
-                {personalInfo.linkedin && (
-                  <div>{renderContactDetail('LinkedIn', personalInfo.linkedin)}</div>
-                )}
-                {personalInfo.github && <div>{renderContactDetail('GitHub', personalInfo.github)}</div>}
-                {personalInfo.website && (
-                  <div>{renderContactDetail('Website', personalInfo.website)}</div>
-                )}
+          {personalInfo &&
+            (personalInfo.website || personalInfo.linkedin || personalInfo.github) && (
+              <div className={baseStyles['resume-section']}>
+                <h3 className={styles.sectionTitleSm}>{headingFallbacks.links}</h3>
+                <div
+                  className={`${baseStyles['resume-stack-tight']} ${baseStyles['resume-meta-sm']}`}
+                >
+                  {personalInfo.linkedin && (
+                    <div>{renderContactDetail('LinkedIn', personalInfo.linkedin)}</div>
+                  )}
+                  {personalInfo.github && (
+                    <div>{renderContactDetail('GitHub', personalInfo.github)}</div>
+                  )}
+                  {personalInfo.website && (
+                    <div>{renderContactDetail('Website', personalInfo.website)}</div>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
+            )}
         </div>
       </div>
     </>

--- a/apps/frontend/components/resume/resume-vivid.tsx
+++ b/apps/frontend/components/resume/resume-vivid.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { Mail, Phone, MapPin, Globe, Linkedin, Github, ExternalLink } from 'lucide-react';
 import type {
   ResumeData,
+  SectionMeta,
   ResumeSectionHeadings,
   ResumeFallbackLabels,
 } from '@/components/dashboard/resume-component';
 import { getSortedSections, getSectionMeta } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { DynamicResumeSection } from './dynamic-resume-section';
 import { SafeHtml } from './safe-html';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/vivid.module.css';
@@ -207,8 +207,7 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
                       </span>
                     </div>
                     <div className={`${baseStyles['resume-row-tight']} ${styles.entryMeta}`}>
-                      {formatDateRange(exp.years)}
-                      {exp.location && <> | {exp.location}</>}
+                      {[formatDateRange(exp.years), exp.location].filter(Boolean).join(' | ')}
                     </div>
                     {renderArrowBullets(exp.description)}
                   </div>
@@ -300,7 +299,12 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
           )}
 
           {customSections.map((section) => (
-            <DynamicResumeSection key={section.id} sectionMeta={section} resumeData={data} />
+            <DynamicResumeSectionVivid
+              key={section.id}
+              sectionMeta={section}
+              resumeData={data}
+              renderArrowBullets={renderArrowBullets}
+            />
           ))}
         </div>
 
@@ -385,6 +389,74 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
         </div>
       </div>
     </>
+  );
+};
+
+/**
+ * Dynamic (custom) section wrapper for the Vivid template.
+ * Uses the accent small-caps section title and accent arrow bullets so custom
+ * sections match the rest of the template (rather than the plain shared styling).
+ */
+const DynamicResumeSectionVivid: React.FC<{
+  sectionMeta: SectionMeta;
+  resumeData: ResumeData;
+  renderArrowBullets: (items?: string[], textClass?: string) => React.ReactNode;
+}> = ({ sectionMeta, resumeData, renderArrowBullets }) => {
+  const customSection = resumeData.customSections?.[sectionMeta.key];
+  if (!customSection) return null;
+
+  const hasContent = (() => {
+    switch (sectionMeta.sectionType) {
+      case 'text':
+        return Boolean(customSection.text?.trim());
+      case 'itemList':
+        return Boolean(customSection.items?.length);
+      case 'stringList':
+        return Boolean(customSection.strings?.length);
+      default:
+        return false;
+    }
+  })();
+
+  if (!hasContent) return null;
+
+  return (
+    <div className={baseStyles['resume-section']}>
+      <h3 className={styles.sectionTitle}>{sectionMeta.displayName}</h3>
+      {sectionMeta.sectionType === 'text' && customSection.text?.trim() && (
+        <p className={`text-justify ${baseStyles['resume-text']}`}>{customSection.text}</p>
+      )}
+      {sectionMeta.sectionType === 'itemList' && customSection.items?.length ? (
+        <div className={baseStyles['resume-items']}>
+          {customSection.items.map((item) => (
+            <div key={item.id} className={baseStyles['resume-item']}>
+              <div
+                className={`flex justify-between items-baseline ${baseStyles['resume-row-tight']}`}
+              >
+                <span className="min-w-0">
+                  <span className={styles.entryCompany}>{item.title}</span>
+                  {item.subtitle && (
+                    <>
+                      <span className={styles.entrySep}>|</span>
+                      <span className={styles.entryRole}>{item.subtitle}</span>
+                    </>
+                  )}
+                </span>
+                {(item.years || item.location) && (
+                  <span className={`${styles.entryMeta} ml-2`}>
+                    {[formatDateRange(item.years), item.location].filter(Boolean).join(' | ')}
+                  </span>
+                )}
+              </div>
+              {renderArrowBullets(item.description)}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {sectionMeta.sectionType === 'stringList' && customSection.strings?.length ? (
+        <p className={baseStyles['resume-text-xs']}>{customSection.strings.join(' • ')}</p>
+      ) : null}
+    </div>
   );
 };
 

--- a/apps/frontend/components/resume/styles/clean.module.css
+++ b/apps/frontend/components/resume/styles/clean.module.css
@@ -13,19 +13,22 @@
   width: 100%;
 }
 
-/* Force the single sans typeface across the whole template. */
+/*
+  Body text is driven by the Body Font control; the name + section headers are driven
+  by the Header Font control. Both controls are live; selecting Clean seeds sans/sans
+  (see TEMPLATE_FONT_PRESETS) so the default look stays all-sans.
+*/
 .container,
 .container :global(p),
 .container :global(li),
 .container :global(a),
 .container :global(span),
-.container :global(div),
-.container :global(h1),
-.container :global(h3) {
+.container :global(div) {
   font-family: var(--body-font);
 }
 
 .name {
+  font-family: var(--header-font);
   font-size: calc(var(--font-size-base) * var(--header-scale));
   font-weight: 400;
   letter-spacing: 0.01em;
@@ -49,6 +52,7 @@
 
 /* Large, understated, gray uppercase header with a thin rule. */
 .sectionTitle {
+  font-family: var(--header-font);
   font-size: calc(var(--font-size-base) * var(--section-header-scale) * 1.15);
   font-weight: 600;
   text-transform: uppercase;

--- a/apps/frontend/components/resume/styles/clean.module.css
+++ b/apps/frontend/components/resume/styles/clean.module.css
@@ -1,0 +1,95 @@
+@import './_tokens.css';
+
+/*
+  Clean Template
+  ID: clean
+
+  Minimal modern sans layout. Single-typeface design: all text inherits --body-font
+  (sans by default), so the Body Font control drives the whole template. Large
+  understated gray UPPERCASE section headers, single-line entries.
+*/
+
+.container {
+  width: 100%;
+}
+
+/* Force the single sans typeface across the whole template. */
+.container,
+.container :global(p),
+.container :global(li),
+.container :global(a),
+.container :global(span),
+.container :global(div),
+.container :global(h1),
+.container :global(h3) {
+  font-family: var(--body-font);
+}
+
+.name {
+  font-size: calc(var(--font-size-base) * var(--header-scale));
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  color: var(--resume-text-primary);
+}
+
+.tagline {
+  font-size: calc(var(--font-size-base) * 1.05);
+  color: var(--resume-text-tertiary);
+}
+
+.contactRow {
+  font-size: calc(var(--font-size-base) * 0.85);
+  color: var(--resume-text-body);
+}
+
+.sep {
+  color: var(--resume-text-tertiary);
+  padding: 0 0.4em;
+}
+
+/* Large, understated, gray uppercase header with a thin rule. */
+.sectionTitle {
+  font-size: calc(var(--font-size-base) * var(--section-header-scale) * 1.15);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--resume-text-tertiary);
+  border-bottom: 1px solid var(--resume-border-secondary);
+  padding-bottom: 0.15rem;
+  margin-bottom: var(--item-gap);
+  break-after: avoid;
+  page-break-after: avoid;
+  orphans: 3;
+  widows: 3;
+}
+
+.entryCompany {
+  font-weight: 700;
+  color: var(--resume-text-primary);
+}
+
+.entryRole {
+  font-variant: small-caps;
+  letter-spacing: 0.02em;
+  color: var(--resume-text-tertiary);
+}
+
+.entryMeta {
+  font-size: calc(var(--font-size-base) * 0.85);
+  color: var(--resume-text-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.skillLabel {
+  font-weight: 700;
+  color: var(--resume-text-primary);
+}
+
+@media print {
+  .sectionTitle {
+    break-after: avoid !important;
+    page-break-after: avoid !important;
+  }
+}

--- a/apps/frontend/components/resume/styles/latex.module.css
+++ b/apps/frontend/components/resume/styles/latex.module.css
@@ -1,0 +1,97 @@
+@import './_tokens.css';
+
+/*
+  LaTeX Template
+  ID: latex
+
+  Classic serif academic layout. Single-typeface design: all text inherits
+  --header-font (serif by default), so the Header Font control drives the whole
+  template. Title-Case ruled section headers, company-first two-line entries.
+*/
+
+.container {
+  width: 100%;
+}
+
+/* Force the single serif typeface across the whole template. */
+.container,
+.container :global(p),
+.container :global(li),
+.container :global(a),
+.container :global(span),
+.container :global(div),
+.container :global(h1),
+.container :global(h3) {
+  font-family: var(--header-font);
+}
+
+.name {
+  font-family: var(--header-font);
+  font-size: calc(var(--font-size-base) * var(--header-scale));
+  font-weight: 700;
+  font-variant: small-caps;
+  letter-spacing: 0.02em;
+  color: var(--resume-text-primary);
+}
+
+.locationLine {
+  font-size: var(--font-size-base);
+  color: var(--resume-text-body);
+}
+
+.tagline {
+  font-style: italic;
+  font-size: calc(var(--font-size-base) * 1.05);
+  color: var(--resume-text-body);
+}
+
+.contactRow {
+  font-size: calc(var(--font-size-base) * 0.95);
+  color: var(--resume-text-body);
+}
+
+.contactSep {
+  color: var(--resume-text-tertiary);
+}
+
+/* Title-Case section header with a full-width rule (overrides base uppercase). */
+.sectionTitle {
+  font-family: var(--header-font);
+  font-size: calc(var(--font-size-base) * var(--section-header-scale));
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--resume-text-primary);
+  border-bottom: 1px solid var(--resume-text-primary);
+  padding-bottom: 0.1rem;
+  margin-bottom: var(--item-gap);
+  break-after: avoid;
+  page-break-after: avoid;
+  orphans: 3;
+  widows: 3;
+}
+
+.entryPrimary {
+  font-weight: 700;
+  color: var(--resume-text-primary);
+}
+
+.entryDates {
+  font-weight: 700;
+  color: var(--resume-text-primary);
+  white-space: nowrap;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.entrySecondary {
+  font-style: italic;
+  color: var(--resume-text-body);
+}
+
+@media print {
+  .sectionTitle {
+    break-after: avoid !important;
+    page-break-after: avoid !important;
+  }
+}

--- a/apps/frontend/components/resume/styles/latex.module.css
+++ b/apps/frontend/components/resume/styles/latex.module.css
@@ -13,16 +13,18 @@
   width: 100%;
 }
 
-/* Force the single serif typeface across the whole template. */
+/*
+  Body text is driven by the Body Font control; the name + section headers are driven
+  by the Header Font control. Both controls are live; selecting LaTeX seeds serif/serif
+  (see TEMPLATE_FONT_PRESETS) so the default look stays all-serif.
+*/
 .container,
 .container :global(p),
 .container :global(li),
 .container :global(a),
 .container :global(span),
-.container :global(div),
-.container :global(h1),
-.container :global(h3) {
-  font-family: var(--header-font);
+.container :global(div) {
+  font-family: var(--body-font);
 }
 
 .name {

--- a/apps/frontend/components/resume/styles/vivid.module.css
+++ b/apps/frontend/components/resume/styles/vivid.module.css
@@ -1,0 +1,155 @@
+@import './_tokens.css';
+
+/*
+  Vivid Template
+  ID: vivid
+
+  Colorful two-column "Awesome-CV" lineage: two-tone accent name, monospace title +
+  circular-icon contact row, accent small-caps section headers, accent arrow bullets.
+  Reads the accent-color control (--resume-accent-primary, default blue).
+*/
+
+.grid {
+  display: grid;
+  grid-template-columns: 63% 37%;
+  gap: calc(var(--section-gap) * 1.25);
+  margin-top: var(--section-gap);
+  align-items: start;
+}
+
+.mainColumn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--section-gap);
+  padding-right: 0.875rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.sidebarColumn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--section-gap);
+  padding-left: 0.75rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Two-tone name */
+.nameFirst {
+  font-weight: 800;
+  color: var(--resume-accent-primary);
+}
+
+.nameRest {
+  font-weight: 400;
+  color: var(--resume-accent-primary);
+  opacity: 0.6;
+}
+
+/* Monospace title + contact row */
+.titleLine {
+  font-family: var(--resume-font-mono);
+  font-size: calc(var(--font-size-base) * 1.05);
+  color: var(--resume-text-tertiary);
+  margin-top: 0.15rem;
+  letter-spacing: 0.01em;
+}
+
+.contactRow {
+  font-family: var(--resume-font-mono);
+  font-size: calc(var(--font-size-base) * 0.8);
+  color: var(--resume-text-body);
+}
+
+.contactChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.iconCircle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1px solid var(--resume-border-primary);
+  border-radius: 9999px;
+  color: var(--resume-text-tertiary);
+  flex-shrink: 0;
+}
+
+/* Accent small-caps section headers */
+.sectionTitle {
+  font-family: var(--header-font);
+  font-size: calc(var(--font-size-base) * var(--section-header-scale) * 1.1);
+  font-weight: 700;
+  font-variant: small-caps;
+  letter-spacing: 0.03em;
+  color: var(--resume-accent-primary);
+  margin-bottom: var(--item-gap);
+  break-after: avoid;
+  page-break-after: avoid;
+  orphans: 3;
+  widows: 3;
+}
+
+.sectionTitleSm {
+  font-family: var(--header-font);
+  font-size: calc(var(--font-size-base) * var(--section-header-scale) * 0.95);
+  font-weight: 700;
+  font-variant: small-caps;
+  letter-spacing: 0.03em;
+  color: var(--resume-accent-primary);
+  margin-bottom: var(--item-gap);
+  break-after: avoid;
+  page-break-after: avoid;
+}
+
+.arrow {
+  color: var(--resume-accent-primary);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.entryCompany {
+  font-weight: 700;
+  color: var(--resume-text-primary);
+}
+
+.entrySep {
+  color: var(--resume-text-tertiary);
+  padding: 0 0.4em;
+}
+
+.entryRole {
+  font-variant: small-caps;
+  letter-spacing: 0.02em;
+  color: var(--resume-text-tertiary);
+}
+
+.entryMeta {
+  font-family: var(--resume-font-mono);
+  font-size: calc(var(--font-size-base) * 0.72);
+  font-weight: 700;
+  color: var(--resume-text-tertiary);
+}
+
+@media print {
+  .nameFirst,
+  .nameRest,
+  .sectionTitle,
+  .sectionTitleSm,
+  .arrow {
+    color: var(--resume-accent-primary) !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
+  .sectionTitle,
+  .sectionTitleSm {
+    break-after: avoid !important;
+    page-break-after: avoid !important;
+  }
+}

--- a/apps/frontend/lib/types/template-settings.ts
+++ b/apps/frontend/lib/types/template-settings.ts
@@ -248,3 +248,36 @@ export const TEMPLATE_OPTIONS: TemplateInfo[] = [
     description: 'Colorful two-column layout with accent headers and arrow bullets',
   },
 ];
+
+/**
+ * Signature font presets for single-typeface templates.
+ *
+ * LaTeX and Clean bind their headers to `--header-font` and body to `--body-font`, so
+ * both font controls are live. Selecting one of these templates applies its signature
+ * fonts (so it matches its reference look by default); the user can then override either
+ * control. Templates not listed here keep the current font settings on selection.
+ */
+export const TEMPLATE_FONT_PRESETS: Partial<
+  Record<TemplateType, { headerFont: HeaderFontFamily; bodyFont: BodyFontFamily }>
+> = {
+  latex: { headerFont: 'serif', bodyFont: 'serif' },
+  clean: { headerFont: 'sans-serif', bodyFont: 'sans-serif' },
+};
+
+/**
+ * Return settings with the given template applied, seeding the template's signature
+ * fonts when it has a preset. Use this at every template-change entry point so the
+ * single-typeface templates render their reference look by default.
+ */
+export function applyTemplatePreset(
+  settings: TemplateSettings,
+  template: TemplateType
+): TemplateSettings {
+  const preset = TEMPLATE_FONT_PRESETS[template];
+  if (!preset) return { ...settings, template };
+  return {
+    ...settings,
+    template,
+    fontSize: { ...settings.fontSize, headerFont: preset.headerFont, bodyFont: preset.bodyFont },
+  };
+}

--- a/apps/frontend/lib/types/template-settings.ts
+++ b/apps/frontend/lib/types/template-settings.ts
@@ -5,7 +5,14 @@
  * These settings affect both the live preview and PDF generation.
  */
 
-export type TemplateType = 'swiss-single' | 'swiss-two-column' | 'modern' | 'modern-two-column';
+export type TemplateType =
+  | 'swiss-single'
+  | 'swiss-two-column'
+  | 'modern'
+  | 'modern-two-column'
+  | 'latex'
+  | 'clean'
+  | 'vivid';
 
 export type PageSize = 'A4' | 'LETTER';
 
@@ -224,5 +231,20 @@ export const TEMPLATE_OPTIONS: TemplateInfo[] = [
     id: 'modern-two-column',
     name: 'Modern Two Column',
     description: 'Two-column layout with modern colorful accents and themes',
+  },
+  {
+    id: 'latex',
+    name: 'LaTeX',
+    description: 'Classic serif academic layout with ruled section headers',
+  },
+  {
+    id: 'clean',
+    name: 'Clean',
+    description: 'Minimal sans layout with large understated section headers',
+  },
+  {
+    id: 'vivid',
+    name: 'Vivid',
+    description: 'Colorful two-column layout with accent headers and arrow bullets',
   },
 ];

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -369,6 +369,18 @@
         "modernTwoColumn": {
           "name": "Modern Two Column",
           "description": "Two-column layout with modern colorful accents and themes"
+        },
+        "latex": {
+          "name": "LaTeX",
+          "description": "Classic serif academic layout with ruled section headers"
+        },
+        "clean": {
+          "name": "Clean",
+          "description": "Minimal sans layout with large understated section headers"
+        },
+        "vivid": {
+          "name": "Vivid",
+          "description": "Colorful two-column layout with accent headers and arrow bullets"
         }
       },
       "accentColor": "Accent Color",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -369,6 +369,18 @@
         "modernTwoColumn": {
           "name": "Moderno de dos columnas",
           "description": "Diseño de dos columnas moderno con acentos coloridos y temas"
+        },
+        "latex": {
+          "name": "LaTeX",
+          "description": "Diseño académico clásico con tipografía serif y encabezados con líneas"
+        },
+        "clean": {
+          "name": "Limpio",
+          "description": "Diseño minimalista sans con encabezados grandes y sobrios"
+        },
+        "vivid": {
+          "name": "Vívido",
+          "description": "Diseño de dos columnas colorido con encabezados de acento y viñetas de flecha"
         }
       },
       "accentColor": "Color de acento",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -369,6 +369,18 @@
         "modernTwoColumn": {
           "name": "モダン2カラム",
           "description": "モダンな2カラムとカラフルなアクセント"
+        },
+        "latex": {
+          "name": "LaTeX",
+          "description": "罫線付き見出しのクラシックなセリフ体レイアウト"
+        },
+        "clean": {
+          "name": "クリーン",
+          "description": "大きく控えめな見出しのミニマルなサンセリフ体レイアウト"
+        },
+        "vivid": {
+          "name": "ビビッド",
+          "description": "アクセント見出しと矢印箇条書きのカラフルな2カラムレイアウト"
         }
       },
       "accentColor": "アクセントカラー",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -367,6 +367,18 @@
         "modernTwoColumn": {
           "name": "Moderno Duas Colunas",
           "description": "Layout de duas colunas com acentos coloridos modernos e temas"
+        },
+        "latex": {
+          "name": "LaTeX",
+          "description": "Layout acadêmico clássico em serifa com cabeçalhos com linhas"
+        },
+        "clean": {
+          "name": "Limpo",
+          "description": "Layout minimalista sem serifa com cabeçalhos grandes e discretos"
+        },
+        "vivid": {
+          "name": "Vívido",
+          "description": "Layout de duas colunas colorido com cabeçalhos de destaque e marcadores em seta"
         }
       },
       "accentColors": {

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -369,6 +369,18 @@
         "modernTwoColumn": {
           "name": "现代双栏",
           "description": "现代双栏布局，带彩色点缀与主题色"
+        },
+        "latex": {
+          "name": "LaTeX",
+          "description": "经典衬线学术版式，带分隔线的栏目标题"
+        },
+        "clean": {
+          "name": "简洁",
+          "description": "极简无衬线版式，栏目标题大而低调"
+        },
+        "vivid": {
+          "name": "鲜明",
+          "description": "彩色双栏布局，强调色标题与箭头项目符号"
         }
       },
       "accentColor": "强调色",

--- a/apps/frontend/tests/resume-clean.test.tsx
+++ b/apps/frontend/tests/resume-clean.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ResumeClean } from '@/components/resume/resume-clean';
+import type { ResumeData } from '@/components/dashboard/resume-component';
+
+vi.mock('@/lib/i18n', () => ({ useTranslations: () => ({ t: (k: string) => k }) }));
+
+const data: ResumeData = {
+  personalInfo: { name: 'Saurabh Rai', email: 'a@b.com', phone: '+91-700' },
+  workExperience: [
+    {
+      id: 1,
+      title: 'DevRel Engineer',
+      company: 'Apideck',
+      location: 'Remote',
+      years: '2025-Present',
+      description: ['Lead client demos.'],
+    },
+  ],
+  additional: { technicalSkills: ['Python', 'TypeScript'] },
+} as ResumeData;
+
+describe('ResumeClean', () => {
+  it('renders name, company, role and a bullet', () => {
+    render(<ResumeClean data={data} />);
+    expect(screen.getByText('Saurabh Rai')).toBeInTheDocument();
+    expect(screen.getByText('Apideck')).toBeInTheDocument();
+    expect(screen.getByText('DevRel Engineer')).toBeInTheDocument();
+    expect(screen.getByText('Lead client demos.')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/tests/resume-latex.test.tsx
+++ b/apps/frontend/tests/resume-latex.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ResumeLatex } from '@/components/resume/resume-latex';
+import type { ResumeData } from '@/components/dashboard/resume-component';
+
+vi.mock('@/lib/i18n', () => ({ useTranslations: () => ({ t: (k: string) => k }) }));
+
+const data: ResumeData = {
+  personalInfo: { name: 'Saurabh Rai', location: 'Delhi, India', email: 'a@b.com' },
+  workExperience: [
+    {
+      id: 1,
+      title: 'DevRel Engineer',
+      company: 'Apideck',
+      location: 'Remote',
+      years: '2025-Present',
+      description: ['Lead client demos.'],
+    },
+  ],
+  additional: { technicalSkills: ['Python', '', 'TypeScript'] },
+} as ResumeData;
+
+describe('ResumeLatex', () => {
+  it('renders name, company-first entry, role and a bullet', () => {
+    render(<ResumeLatex data={data} />);
+    expect(screen.getByText('Saurabh Rai')).toBeInTheDocument();
+    expect(screen.getByText('Delhi, India')).toBeInTheDocument();
+    expect(screen.getByText('Apideck')).toBeInTheDocument();
+    expect(screen.getByText('DevRel Engineer')).toBeInTheDocument();
+    expect(screen.getByText('Lead client demos.')).toBeInTheDocument();
+  });
+
+  it('drops blank additional entries (issue #763 parity)', () => {
+    render(<ResumeLatex data={data} />);
+    expect(screen.getByText(/Python, TypeScript/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/tests/resume-vivid.test.tsx
+++ b/apps/frontend/tests/resume-vivid.test.tsx
@@ -33,4 +33,15 @@ describe('ResumeVivid', () => {
     render(<ResumeVivid data={data} />);
     expect(screen.getByText('Python • TypeScript')).toBeInTheDocument();
   });
+
+  it('does not render an orphaned leading pipe when years is missing but location exists', () => {
+    const noYears: ResumeData = {
+      personalInfo: { name: 'Saurabh Rai' },
+      workExperience: [{ id: 1, title: 'Engineer', company: 'Apideck', location: 'Remote' }],
+    } as ResumeData;
+    render(<ResumeVivid data={noYears} />);
+    // Meta should be just the location, never "| Remote".
+    expect(screen.getByText('Remote')).toBeInTheDocument();
+    expect(screen.queryByText('| Remote')).toBeNull();
+  });
 });

--- a/apps/frontend/tests/resume-vivid.test.tsx
+++ b/apps/frontend/tests/resume-vivid.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ResumeVivid } from '@/components/resume/resume-vivid';
+import type { ResumeData } from '@/components/dashboard/resume-component';
+
+vi.mock('@/lib/i18n', () => ({ useTranslations: () => ({ t: (k: string) => k }) }));
+
+const data: ResumeData = {
+  personalInfo: { name: 'Saurabh Rai', title: 'Solutions Architect', email: 'a@b.com' },
+  workExperience: [
+    {
+      id: 1,
+      title: 'DevRel Engineer',
+      company: 'Apideck',
+      years: '2025-Present',
+      description: ['Lead client demos.'],
+    },
+  ],
+  additional: { technicalSkills: ['Python', 'TypeScript'] },
+} as ResumeData;
+
+describe('ResumeVivid', () => {
+  it('splits the name into two tones and renders company + bullet', () => {
+    render(<ResumeVivid data={data} />);
+    expect(screen.getByText('Saurabh')).toBeInTheDocument(); // first token only
+    expect(screen.getByText('Rai')).toBeInTheDocument(); // remaining tokens
+    expect(screen.getByText('Apideck')).toBeInTheDocument();
+    expect(screen.getByText('Solutions Architect')).toBeInTheDocument();
+    expect(screen.getByText('Lead client demos.')).toBeInTheDocument();
+  });
+
+  it('renders skills joined with bullet separators in the sidebar', () => {
+    render(<ResumeVivid data={data} />);
+    expect(screen.getByText('Python • TypeScript')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/tests/template-registration.test.ts
+++ b/apps/frontend/tests/template-registration.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { TEMPLATE_OPTIONS, type TemplateType } from '@/lib/types/template-settings';
+import {
+  TEMPLATE_OPTIONS,
+  applyTemplatePreset,
+  DEFAULT_TEMPLATE_SETTINGS,
+  type TemplateType,
+  type TemplateSettings,
+} from '@/lib/types/template-settings';
 
 describe('template registration', () => {
   it('includes all seven templates with non-empty metadata', () => {
@@ -26,5 +32,42 @@ describe('template registration', () => {
   it('has unique template ids', () => {
     const ids = TEMPLATE_OPTIONS.map((t) => t.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('applyTemplatePreset', () => {
+  it('seeds signature fonts for single-typeface templates', () => {
+    const clean = applyTemplatePreset(DEFAULT_TEMPLATE_SETTINGS, 'clean');
+    expect(clean.template).toBe('clean');
+    expect(clean.fontSize.headerFont).toBe('sans-serif');
+    expect(clean.fontSize.bodyFont).toBe('sans-serif');
+
+    const latex = applyTemplatePreset(DEFAULT_TEMPLATE_SETTINGS, 'latex');
+    expect(latex.template).toBe('latex');
+    expect(latex.fontSize.headerFont).toBe('serif');
+    expect(latex.fontSize.bodyFont).toBe('serif');
+  });
+
+  it('leaves fonts untouched for templates without a preset', () => {
+    const custom: TemplateSettings = {
+      ...DEFAULT_TEMPLATE_SETTINGS,
+      fontSize: { ...DEFAULT_TEMPLATE_SETTINGS.fontSize, headerFont: 'mono', bodyFont: 'mono' },
+    };
+    const modern = applyTemplatePreset(custom, 'modern');
+    expect(modern.template).toBe('modern');
+    expect(modern.fontSize.headerFont).toBe('mono');
+    expect(modern.fontSize.bodyFont).toBe('mono');
+  });
+
+  it('preserves unrelated settings when applying a preset', () => {
+    const custom: TemplateSettings = {
+      ...DEFAULT_TEMPLATE_SETTINGS,
+      pageSize: 'LETTER',
+      compactMode: true,
+    };
+    const clean = applyTemplatePreset(custom, 'clean');
+    expect(clean.pageSize).toBe('LETTER');
+    expect(clean.compactMode).toBe(true);
+    expect(clean.margins).toEqual(custom.margins);
   });
 });

--- a/apps/frontend/tests/template-registration.test.ts
+++ b/apps/frontend/tests/template-registration.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { TEMPLATE_OPTIONS, type TemplateType } from '@/lib/types/template-settings';
+
+describe('template registration', () => {
+  it('includes all seven templates with non-empty metadata', () => {
+    const ids = TEMPLATE_OPTIONS.map((t) => t.id);
+    expect(ids).toEqual(
+      expect.arrayContaining<TemplateType>([
+        'swiss-single',
+        'swiss-two-column',
+        'modern',
+        'modern-two-column',
+        'latex',
+        'clean',
+        'vivid',
+      ])
+    );
+    expect(ids).toHaveLength(7);
+
+    for (const opt of TEMPLATE_OPTIONS) {
+      expect(opt.name.length).toBeGreaterThan(0);
+      expect(opt.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has unique template ids', () => {
+    const ids = TEMPLATE_OPTIONS.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/docs/agent/design/template-system.md
+++ b/docs/agent/design/template-system.md
@@ -4,40 +4,64 @@
 
 ## Templates
 
-| Template | Layout | Best For |
-|----------|--------|----------|
-| swiss-single | Full-width vertical | 1-2 page resumes |
-| swiss-two-column | 65% main + 35% sidebar | Dense content |
-| modern | Single column, accent headers | Colorful single-column |
-| modern-two-column | 65% main + 35% sidebar, accent | Colorful dense content |
-| latex | Single column, serif, ruled headers | Classic/academic résumés |
-| clean | Single column, minimal sans | Understated modern résumés |
-| vivid | 63% main + 37% sidebar, accent | Colorful Awesome-CV style (accent color) |
+| Template          | Layout                              | Best For                                 |
+| ----------------- | ----------------------------------- | ---------------------------------------- |
+| swiss-single      | Full-width vertical                 | 1-2 page resumes                         |
+| swiss-two-column  | 65% main + 35% sidebar              | Dense content                            |
+| modern            | Single column, accent headers       | Colorful single-column                   |
+| modern-two-column | 65% main + 35% sidebar, accent      | Colorful dense content                   |
+| latex             | Single column, serif, ruled headers | Classic/academic résumés                 |
+| clean             | Single column, minimal sans         | Understated modern résumés               |
+| vivid             | 63% main + 37% sidebar, accent      | Colorful Awesome-CV style (accent color) |
 
 ## File Structure
 
 ```
 components/resume/
-├── index.ts                    # Re-exports all templates
-├── resume-single-column.tsx    # Single column template
-└── resume-two-column.tsx       # Two column template
+├── index.ts                      # Re-exports all templates
+├── resume-single-column.tsx      # swiss-single
+├── resume-two-column.tsx         # swiss-two-column
+├── resume-modern.tsx             # modern
+├── resume-modern-two-column.tsx  # modern-two-column
+├── resume-latex.tsx              # latex
+├── resume-clean.tsx              # clean
+├── resume-vivid.tsx              # vivid
+├── dynamic-resume-section.tsx    # shared custom-section renderer
+├── safe-html.tsx                 # sanitized rich-text renderer
+└── styles/                       # *.module.css per template + _base/_tokens
 ```
 
 ## Template Settings
 
+Authoritative definition: `apps/frontend/lib/types/template-settings.ts` (`TemplateSettings`,
+`DEFAULT_TEMPLATE_SETTINGS`, and the CSS-variable maps). Current shape:
+
 ```typescript
 interface TemplateSettings {
-  template: 'swiss-single' | 'swiss-two-column';
-  pageSize: 'A4' | 'LETTER';
-  marginTop: number;    // 5-25mm
-  marginBottom: number;
-  marginLeft: number;
-  marginRight: number;
-  sectionSpacing: 1-5;  // Inter-section gap
-  itemSpacing: 1-5;     // Item gap
-  lineHeight: 1-5;
-  fontSize: 1-5;        // Base font scale
-  headerScale: 1-5;     // Header size scale
+  template:
+    | "swiss-single"
+    | "swiss-two-column"
+    | "modern"
+    | "modern-two-column"
+    | "latex"
+    | "clean"
+    | "vivid";
+  pageSize: "A4" | "LETTER";
+  margins: { top: number; bottom: number; left: number; right: number }; // 5-25mm each
+  spacing: {
+    section: 1 | 2 | 3 | 4 | 5;
+    item: 1 | 2 | 3 | 4 | 5;
+    lineHeight: 1 | 2 | 3 | 4 | 5;
+  };
+  fontSize: {
+    base: 1 | 2 | 3 | 4 | 5;
+    headerScale: 1 | 2 | 3 | 4 | 5;
+    headerFont: "serif" | "sans-serif" | "mono";
+    bodyFont: "serif" | "sans-serif" | "mono";
+  };
+  compactMode: boolean;
+  showContactIcons: boolean;
+  accentColor: "blue" | "green" | "orange" | "red"; // modern, modern-two-column, vivid
 }
 ```
 
@@ -60,7 +84,7 @@ interface ResumeData {
   education: Education[];
   personalProjects: Project[];
   additional: AdditionalInfo;
-  sectionMeta: SectionMeta[];      // Order, visibility
+  sectionMeta: SectionMeta[]; // Order, visibility
   customSections: CustomSection[]; // User-added sections
 }
 ```
@@ -69,11 +93,11 @@ interface ResumeData {
 
 Users can add custom sections via `AddSectionDialog`:
 
-| Type | Component | Use Case |
-|------|-----------|----------|
-| text | `GenericTextForm` | Objective, statement |
-| itemList | `GenericItemForm` | Publications, research |
-| stringList | `GenericListForm` | Hobbies, interests |
+| Type       | Component         | Use Case               |
+| ---------- | ----------------- | ---------------------- |
+| text       | `GenericTextForm` | Objective, statement   |
+| itemList   | `GenericItemForm` | Publications, research |
+| stringList | `GenericListForm` | Hobbies, interests     |
 
 ## CSS Classes
 

--- a/docs/agent/design/template-system.md
+++ b/docs/agent/design/template-system.md
@@ -8,6 +8,11 @@
 |----------|--------|----------|
 | swiss-single | Full-width vertical | 1-2 page resumes |
 | swiss-two-column | 65% main + 35% sidebar | Dense content |
+| modern | Single column, accent headers | Colorful single-column |
+| modern-two-column | 65% main + 35% sidebar, accent | Colorful dense content |
+| latex | Single column, serif, ruled headers | Classic/academic résumés |
+| clean | Single column, minimal sans | Understated modern résumés |
+| vivid | 63% main + 37% sidebar, accent | Colorful Awesome-CV style (accent color) |
 
 ## File Structure
 

--- a/docs/agent/features/resume-templates.md
+++ b/docs/agent/features/resume-templates.md
@@ -10,6 +10,9 @@
 | `swiss-two-column` | 65%/35% split with experience in main column, skills in sidebar |
 | `modern` | Single-column with colorful accent headers and customizable theme colors |
 | `modern-two-column` | Two-column layout combining modern accents with space-efficient design |
+| `latex` | Classic serif single-column with Title-Case ruled headers and company-first entries (LaTeX-style). Single-typeface — driven by the Header Font control |
+| `clean` | Minimal sans single-column with large understated gray UPPERCASE headers and single-line entries. Single-typeface — driven by the Body Font control |
+| `vivid` | Colorful two-column (Awesome-CV lineage): two-tone accent name, monospace contact with circular icons, accent small-caps headers, accent arrow bullets. Supports the Accent Color control |
 
 ## Formatting Controls
 
@@ -25,7 +28,7 @@
 | Body Font | serif/sans-serif/mono | sans-serif | Font family for body text |
 | Compact Mode | boolean | false | Apply 0.6x spacing multiplier (spacing only; margins unchanged) |
 | Contact Icons | boolean | false | Show icons next to contact info |
-| Accent Color | blue/green/orange/red | blue | Accent color for Modern templates (modern, modern-two-column) |
+| Accent Color | blue/green/orange/red | blue | Accent color for color templates (modern, modern-two-column, vivid) |
 
 ## Key Files
 

--- a/docs/superpowers/plans/2026-06-03-resume-templates-latex-clean-vivid.md
+++ b/docs/superpowers/plans/2026-06-03-resume-templates-latex-clean-vivid.md
@@ -1,0 +1,553 @@
+# LaTeX, Clean, Vivid Resume Templates — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three new resume templates — `latex` (single-column serif), `clean` (single-column minimal sans), `vivid` (two-column colorful Awesome-CV style) — each faithful to a maintainer-provided reference image, wired through the existing template selection / preview / PDF pipeline.
+
+**Architecture:** Each template is a React component reading `ResumeData` via `getSortedSections`, styled by a co-located CSS module using shared `_base.module.css` classes plus template-specific overrides. Registration mirrors how `modern` was added: extend `TemplateType` + `TEMPLATE_OPTIONS`, add a dispatcher branch in `resume-component.tsx`, a `TemplateThumbnail` case, label maps, the print-route allow-list, and i18n in 5 locales. `vivid` reuses the existing accent-color control + two-column grid; `latex`/`clean` are monochrome single-column.
+
+**Tech Stack:** Next.js 16 / React 19, CSS modules, TypeScript, vitest + @testing-library/react (jsdom), i18n JSON (en/es/zh/ja/pt).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-resume-templates-latex-clean-vivid-design.md`
+
+**Environment note:** Do NOT run `npm`/`npx` in this shell (nvm issues). After implementation, hand the maintainer: `cd apps/frontend && npm run test && npm run lint && npm run build`.
+
+**Always-compiling rule:** Each task leaves the codebase type-valid. Task 1 registers all three IDs *and* their label/thumbnail/footer/accent wiring with placeholder behavior (default thumbnail, blank dispatcher body) so nothing breaks; Tasks 2–4 fill in each real component + thumbnail + dispatcher branch.
+
+---
+
+## Task 1: Register the three templates (types, options, allow-lists, i18n, controls)
+
+**Files:**
+- Modify: `apps/frontend/lib/types/template-settings.ts`
+- Modify: `apps/frontend/components/builder/template-selector.tsx`
+- Modify: `apps/frontend/components/builder/formatting-controls.tsx`
+- Modify: `apps/frontend/components/builder/resume-builder.tsx`
+- Modify: `apps/frontend/app/print/resumes/[id]/page.tsx`
+- Modify: `apps/backend/app/routers/resumes.py`
+- Modify: `apps/frontend/messages/{en,es,zh,ja,pt}.json`
+- Test: `apps/frontend/tests/template-registration.test.ts`
+
+- [ ] **Step 1: Write the failing test** — `apps/frontend/tests/template-registration.test.ts`
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { TEMPLATE_OPTIONS, type TemplateType } from '@/lib/types/template-settings';
+
+describe('template registration', () => {
+  it('includes all seven templates with non-empty metadata', () => {
+    const ids = TEMPLATE_OPTIONS.map((t) => t.id);
+    expect(ids).toEqual(
+      expect.arrayContaining<TemplateType>([
+        'swiss-single',
+        'swiss-two-column',
+        'modern',
+        'modern-two-column',
+        'latex',
+        'clean',
+        'vivid',
+      ])
+    );
+    for (const opt of TEMPLATE_OPTIONS) {
+      expect(opt.name.length).toBeGreaterThan(0);
+      expect(opt.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect FAIL** — `npm run test -- template-registration` → FAIL (ids missing).
+
+- [ ] **Step 3: Extend the type + options** in `template-settings.ts`:
+
+```ts
+export type TemplateType =
+  | 'swiss-single'
+  | 'swiss-two-column'
+  | 'modern'
+  | 'modern-two-column'
+  | 'latex'
+  | 'clean'
+  | 'vivid';
+```
+
+Append to `TEMPLATE_OPTIONS`:
+
+```ts
+  {
+    id: 'latex',
+    name: 'LaTeX',
+    description: 'Classic serif academic layout with ruled section headers',
+  },
+  {
+    id: 'clean',
+    name: 'Clean',
+    description: 'Minimal sans layout with large understated section headers',
+  },
+  {
+    id: 'vivid',
+    name: 'Vivid',
+    description: 'Colorful two-column layout with accent headers and arrow bullets',
+  },
+```
+
+- [ ] **Step 4: Add label entries** to the `templateLabels` object in BOTH `template-selector.tsx` and `formatting-controls.tsx` (append inside the object literal):
+
+```ts
+    latex: {
+      name: t('builder.formatting.templates.latex.name'),
+      description: t('builder.formatting.templates.latex.description'),
+    },
+    clean: {
+      name: t('builder.formatting.templates.clean.name'),
+      description: t('builder.formatting.templates.clean.description'),
+    },
+    vivid: {
+      name: t('builder.formatting.templates.vivid.name'),
+      description: t('builder.formatting.templates.vivid.description'),
+    },
+```
+
+- [ ] **Step 5: Footer single/two-column logic** — `resume-builder.tsx` (~line 946). Change the single-column condition to include the new single-column IDs:
+
+```tsx
+                {templateSettings.template === 'swiss-single' ||
+                templateSettings.template === 'modern' ||
+                templateSettings.template === 'latex' ||
+                templateSettings.template === 'clean'
+                  ? t('builder.footer.singleColumn')
+                  : t('builder.footer.twoColumn')}
+```
+
+- [ ] **Step 6: Accent-color visibility** — `formatting-controls.tsx` (~line 207). Add `vivid` so the accent control shows for it:
+
+```tsx
+          {(settings.template === 'modern' ||
+            settings.template === 'modern-two-column' ||
+            settings.template === 'vivid') && (
+```
+
+- [ ] **Step 7: Print-route allow-list** — `app/print/resumes/[id]/page.tsx` `parseTemplate`:
+
+```ts
+  if (
+    value === 'swiss-single' ||
+    value === 'swiss-two-column' ||
+    value === 'modern' ||
+    value === 'modern-two-column' ||
+    value === 'latex' ||
+    value === 'clean' ||
+    value === 'vivid'
+  ) {
+    return value;
+  }
+  return 'swiss-single';
+```
+
+- [ ] **Step 8: Backend docstring** — `apps/backend/app/routers/resumes.py` line ~1433 comment, update to:
+
+```python
+    - template: swiss-single, swiss-two-column, modern, modern-two-column, latex, clean, or vivid
+```
+
+- [ ] **Step 9: i18n** — in each of `messages/{en,es,zh,ja,pt}.json`, add under `builder.formatting.templates` three keys `latex`, `clean`, `vivid`, each `{ "name", "description" }`. English values match Step 3; other locales use a translated name + description (keep `LaTeX` as a proper noun untranslated; translate `Clean`/`Vivid` descriptively where natural, else transliterate). Preserve existing key ordering and JSON validity.
+
+- [ ] **Step 10: Run the registration test, expect PASS** — `npm run test -- template-registration` (maintainer runs). Code still compiles; selecting a new template currently shows the default thumbnail + blank preview body (filled in Tasks 2–4).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add apps/frontend/lib/types/template-settings.ts apps/frontend/components/builder/template-selector.tsx apps/frontend/components/builder/formatting-controls.tsx apps/frontend/components/builder/resume-builder.tsx "apps/frontend/app/print/resumes/[id]/page.tsx" apps/backend/app/routers/resumes.py apps/frontend/messages/en.json apps/frontend/messages/es.json apps/frontend/messages/zh.json apps/frontend/messages/ja.json apps/frontend/messages/pt.json apps/frontend/tests/template-registration.test.ts
+git commit -m "feat(templates): register latex, clean, vivid template IDs + controls/i18n"
+```
+
+---
+
+## Task 2: LaTeX template (single-column serif)
+
+**Files:**
+- Create: `apps/frontend/components/resume/resume-latex.tsx`
+- Create: `apps/frontend/components/resume/styles/latex.module.css`
+- Modify: `apps/frontend/components/resume/index.ts`
+- Modify: `apps/frontend/components/dashboard/resume-component.tsx`
+- Modify: `apps/frontend/components/builder/template-selector.tsx` (thumbnail case)
+- Test: `apps/frontend/tests/resume-latex.test.tsx`
+
+**Component spec (adapt from `resume-modern.tsx`, single-column flow):**
+- Reads `getSortedSections`, renders `personalInfo` header + sections in order; uses `SafeHtml` for bullet HTML; `formatDateRange` for dates; honors `showContactIcons`.
+- Header centered: `<h1>` name with class `styles.name` (serif, `font-variant: small-caps`, size `calc(var(--font-size-base) * var(--header-scale))`). Optional `personalInfo.title` → centered italic `styles.tagline`. `personalInfo.location` → centered `styles.locationLine`. Contact row centered using the same `renderContactDetail` helper as `resume-modern.tsx` but separated by a middle dot, icons gated on `showContactIcons`.
+- Section header: `<h3 className={styles.sectionTitle}>` (Title-Case, serif, bold, full-width 1px rule).
+- Experience/itemList entries (company-first):
+  - Row 1: `flex justify-between` → `<span styles.entryPrimary>{company}</span>` (bold) · `<span styles.entryDates>{formatDateRange(years)}</span>` (bold).
+  - Row 2: `flex justify-between` → `<span styles.entrySecondary>{title}</span>` (italic) · `<span styles.entrySecondary>{location}</span>` (italic).
+  - Bullets: `<ul className={baseStyles['resume-list']}>` with `•&nbsp;` markers (reuse modern's list markup).
+- Projects: name (bold) + tech/links; dates right; bullets. Education: institution (bold) · dates right; degree italic. Additional: bold `Category:` labels + comma-joined items (reuse modern's `AdditionalSection`, swapping the title class for `styles.sectionTitle`). Custom sections via a `DynamicResumeSectionLatex` wrapper (copy modern's pattern, use `styles.sectionTitle`).
+
+**CSS spec (`latex.module.css`):**
+
+```css
+@import './_tokens.css';
+
+/* LaTeX template — single-typeface serif, driven by --header-font */
+.container { width: 100%; }
+
+.container,
+.container :global(p),
+.container :global(li),
+.container :global(span) {
+  font-family: var(--header-font);
+}
+
+.name {
+  font-family: var(--header-font);
+  font-size: calc(var(--font-size-base) * var(--header-scale));
+  font-weight: 700;
+  font-variant: small-caps;
+  letter-spacing: 0.02em;
+  color: var(--resume-text-primary);
+}
+
+.tagline {
+  font-family: var(--header-font);
+  font-style: italic;
+  font-size: calc(var(--font-size-base) * 1.05);
+  color: var(--resume-text-body);
+}
+
+.locationLine {
+  font-family: var(--header-font);
+  font-size: var(--font-size-base);
+  color: var(--resume-text-body);
+}
+
+.sectionTitle {
+  font-family: var(--header-font);
+  font-size: calc(var(--font-size-base) * var(--section-header-scale));
+  font-weight: 700;
+  text-transform: none;            /* Title-Case, override base uppercase */
+  letter-spacing: 0;
+  color: var(--resume-text-primary);
+  border-bottom: 1px solid var(--resume-text-primary);
+  padding-bottom: 0.1rem;
+  margin-bottom: var(--item-gap);
+  break-after: avoid;
+  page-break-after: avoid;
+  orphans: 3;
+  widows: 3;
+}
+
+.entryPrimary { font-weight: 700; color: var(--resume-text-primary); }
+.entryDates { font-weight: 700; color: var(--resume-text-primary); white-space: nowrap; }
+.entrySecondary { font-style: italic; color: var(--resume-text-body); }
+
+@media print {
+  .sectionTitle { break-after: avoid !important; page-break-after: avoid !important; }
+}
+```
+
+- [ ] **Step 1: Write the failing test** — `apps/frontend/tests/resume-latex.test.tsx`
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ResumeLatex } from '@/components/resume/resume-latex';
+import type { ResumeData } from '@/components/dashboard/resume-component';
+
+vi.mock('@/lib/i18n', () => ({ useTranslations: () => ({ t: (k: string) => k }) }));
+
+const data: ResumeData = {
+  personalInfo: { name: 'Saurabh Rai', location: 'Delhi, India', email: 'a@b.com' },
+  workExperience: [
+    { id: 1, title: 'DevRel Engineer', company: 'Apideck', location: 'Remote', years: '2025-Present', description: ['Lead client demos.'] },
+  ],
+  additional: { technicalSkills: ['Python', 'TypeScript'] },
+} as ResumeData;
+
+describe('ResumeLatex', () => {
+  it('renders name, company, title and a bullet', () => {
+    render(<ResumeLatex data={data} />);
+    expect(screen.getByText('Saurabh Rai')).toBeInTheDocument();
+    expect(screen.getByText('Apideck')).toBeInTheDocument();
+    expect(screen.getByText('DevRel Engineer')).toBeInTheDocument();
+    expect(screen.getByText('Lead client demos.')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect FAIL** — `npm run test -- resume-latex` → FAIL (module not found).
+- [ ] **Step 3: Create `resume-latex.tsx` + `latex.module.css`** per the specs above.
+- [ ] **Step 4: Export** — add to `components/resume/index.ts`: `export { ResumeLatex } from './resume-latex';`
+- [ ] **Step 5: Dispatcher branch** — in `resume-component.tsx` import `ResumeLatex` and add:
+
+```tsx
+      {mergedSettings.template === 'latex' && (
+        <ResumeLatex
+          data={resumeData}
+          showContactIcons={mergedSettings.showContactIcons}
+          additionalSectionLabels={additionalSectionLabels}
+        />
+      )}
+```
+
+- [ ] **Step 6: Thumbnail** — in `template-selector.tsx` add a `if (type === 'latex')` branch returning a single-column thumbnail with a centered name bar, a serif-feel ruled header line, and stacked content lines (reuse swiss-single thumbnail markup; add a centered top bar + an underline rule under each section line via `border-b`).
+- [ ] **Step 7: Run test, expect PASS** — `npm run test -- resume-latex`.
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/frontend/components/resume/resume-latex.tsx apps/frontend/components/resume/styles/latex.module.css apps/frontend/components/resume/index.ts apps/frontend/components/dashboard/resume-component.tsx apps/frontend/components/builder/template-selector.tsx apps/frontend/tests/resume-latex.test.tsx
+git commit -m "feat(templates): add LaTeX single-column serif template"
+```
+
+---
+
+## Task 3: Clean template (single-column minimal sans)
+
+**Files:**
+- Create: `apps/frontend/components/resume/resume-clean.tsx`
+- Create: `apps/frontend/components/resume/styles/clean.module.css`
+- Modify: `apps/frontend/components/resume/index.ts`
+- Modify: `apps/frontend/components/dashboard/resume-component.tsx`
+- Modify: `apps/frontend/components/builder/template-selector.tsx`
+- Test: `apps/frontend/tests/resume-clean.test.tsx`
+
+**Component spec (adapt from `resume-latex.tsx`, single-typeface sans):**
+- Header centered: `<h1 className={styles.name}>` (light weight, sans). Contact rendered as one `|`-separated line via a helper that joins the present `renderContactDetail` spans with `<span className={styles.sep}> | </span>`; icons gated on `showContactIcons`.
+- Section header `styles.sectionTitle` (large, UPPERCASE, gray, letter-spaced, thin rule).
+- Entries single-line: `<div className="flex justify-between">` → left: `<span styles.entryCompany>{company}</span>` (bold) + `<span styles.sep> | </span>` + `<span styles.entryRole>{title}</span>` (small-caps gray); right: `<span styles.entryMeta>{location} | {formatDateRange(years)}</span>`. Bullets below.
+- Education/Projects analogous. Additional: `**Label:** items`.
+
+**CSS spec (`clean.module.css`):**
+
+```css
+@import './_tokens.css';
+
+/* Clean template — single-typeface sans, driven by --body-font */
+.container { width: 100%; }
+.container,
+.container :global(p),
+.container :global(li),
+.container :global(span),
+.container :global(h1),
+.container :global(h3) {
+  font-family: var(--body-font);
+}
+
+.name {
+  font-size: calc(var(--font-size-base) * var(--header-scale));
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  color: var(--resume-text-primary);
+}
+
+.sep { color: var(--resume-text-tertiary); padding: 0 0.4em; }
+
+.sectionTitle {
+  font-size: calc(var(--font-size-base) * var(--section-header-scale) * 1.15);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--resume-text-tertiary);
+  border-bottom: 1px solid var(--resume-border-secondary);
+  padding-bottom: 0.15rem;
+  margin-bottom: var(--item-gap);
+  break-after: avoid;
+  page-break-after: avoid;
+  orphans: 3;
+  widows: 3;
+}
+
+.entryCompany { font-weight: 700; color: var(--resume-text-primary); }
+.entryRole { font-variant: small-caps; color: var(--resume-text-tertiary); }
+.entryMeta { color: var(--resume-text-tertiary); white-space: nowrap; }
+
+@media print {
+  .sectionTitle { break-after: avoid !important; page-break-after: avoid !important; }
+}
+```
+
+- [ ] **Step 1: Write the failing test** — `apps/frontend/tests/resume-clean.test.tsx` (same shape as Task 2 test, importing `ResumeClean`, asserting name/company/title/bullet render).
+- [ ] **Step 2: Run test, expect FAIL.**
+- [ ] **Step 3: Create `resume-clean.tsx` + `clean.module.css`.**
+- [ ] **Step 4: Export** from `index.ts`: `export { ResumeClean } from './resume-clean';`
+- [ ] **Step 5: Dispatcher branch** for `'clean'` in `resume-component.tsx` (same shape as Task 2 Step 5).
+- [ ] **Step 6: Thumbnail** — `if (type === 'clean')` branch: centered light name bar + large gray uppercase header lines (use `opacity-60` gray bars + thin rule).
+- [ ] **Step 7: Run test, expect PASS.**
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/frontend/components/resume/resume-clean.tsx apps/frontend/components/resume/styles/clean.module.css apps/frontend/components/resume/index.ts apps/frontend/components/dashboard/resume-component.tsx apps/frontend/components/builder/template-selector.tsx apps/frontend/tests/resume-clean.test.tsx
+git commit -m "feat(templates): add Clean single-column minimal template"
+```
+
+---
+
+## Task 4: Vivid template (two-column colorful)
+
+**Files:**
+- Create: `apps/frontend/components/resume/resume-vivid.tsx`
+- Create: `apps/frontend/components/resume/styles/vivid.module.css`
+- Modify: `apps/frontend/components/resume/index.ts`
+- Modify: `apps/frontend/components/dashboard/resume-component.tsx`
+- Modify: `apps/frontend/components/builder/template-selector.tsx`
+- Test: `apps/frontend/tests/resume-vivid.test.tsx`
+
+**Component spec (adapt from `resume-modern-two-column.tsx`):**
+- Reuse the column-split logic, `getSortedSections`/`getSectionMeta`, `sectionHeadings`, `fallbackLabels`, and grid (`styles.grid` / `styles.mainColumn` / `styles.sidebarColumn`).
+- Header (full width, left-aligned, above grid): two-tone name — split `personalInfo.name` on first space: `<span className={styles.nameFirst}>{first}</span>` + `<span className={styles.nameRest}>{rest}</span>`. `personalInfo.title` → `<div className={styles.titleLine}>` (monospace). Contact row: monospace, each item wrapped `<span className={styles.contactChip}>` with a circular-icon wrapper `<span className={styles.iconCircle}>{icon}</span>` shown when `showContactIcons`, else text only.
+- Section titles use `styles.sectionTitle` (main) and `styles.sectionTitleSm` (sidebar): accent color, `font-variant: small-caps`, bold.
+- Bullets: replace `•&nbsp;` markers with `<span className={styles.arrow}>➜&nbsp;</span>` (accent color). Apply in main-column experience/projects and any bulleted lists.
+- Sidebar skills: render each group as bold label + `•`-joined wrapping list (reuse modern-two-column sidebar markup; recolor label via default text).
+
+**CSS spec (`vivid.module.css`):** copy the grid + responsive widths from `modern-two-column.module.css`, then:
+
+```css
+@import './_tokens.css';
+
+.container { width: 100%; }
+.grid { display: grid; grid-template-columns: 63% 37%; gap: calc(var(--section-gap) * 1.25); }
+.mainColumn { min-width: 0; }
+.sidebarColumn { min-width: 0; }
+
+.nameFirst {
+  font-size: calc(var(--font-size-base) * var(--header-scale) * 1.2);
+  font-weight: 800;
+  color: var(--resume-accent-primary);
+  font-family: var(--body-font);
+}
+.nameRest {
+  font-size: calc(var(--font-size-base) * var(--header-scale) * 1.2);
+  font-weight: 400;
+  color: var(--resume-accent-primary);
+  opacity: 0.6;
+  font-family: var(--body-font);
+}
+
+.titleLine {
+  font-family: var(--resume-font-mono);
+  font-size: calc(var(--font-size-base) * 1.05);
+  color: var(--resume-text-tertiary);
+  margin-top: 0.1rem;
+}
+
+.contactChip {
+  font-family: var(--resume-font-mono);
+  font-size: calc(var(--font-size-base) * 0.8);
+  color: var(--resume-text-body);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.iconCircle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 1px solid var(--resume-border-primary);
+  border-radius: 9999px;
+  color: var(--resume-text-tertiary);
+}
+
+.sectionTitle {
+  font-family: var(--header-font);
+  font-size: calc(var(--font-size-base) * var(--section-header-scale) * 1.1);
+  font-weight: 700;
+  font-variant: small-caps;
+  letter-spacing: 0.03em;
+  color: var(--resume-accent-primary);
+  margin-bottom: var(--item-gap);
+  break-after: avoid;
+  page-break-after: avoid;
+}
+.sectionTitleSm { font-family: var(--header-font); font-size: calc(var(--font-size-base) * var(--section-header-scale) * 0.95); font-weight: 700; font-variant: small-caps; color: var(--resume-accent-primary); margin-bottom: var(--item-gap); break-after: avoid; page-break-after: avoid; }
+
+.arrow { color: var(--resume-accent-primary); font-weight: 700; flex-shrink: 0; }
+
+@media print {
+  .nameFirst, .nameRest, .sectionTitle, .sectionTitleSm, .arrow {
+    color: var(--resume-accent-primary) !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+  .sectionTitle, .sectionTitleSm { break-after: avoid !important; page-break-after: avoid !important; }
+}
+```
+
+- [ ] **Step 1: Write the failing test** — `apps/frontend/tests/resume-vivid.test.tsx`
+
+```tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ResumeVivid } from '@/components/resume/resume-vivid';
+import type { ResumeData } from '@/components/dashboard/resume-component';
+
+vi.mock('@/lib/i18n', () => ({ useTranslations: () => ({ t: (k: string) => k }) }));
+
+const data: ResumeData = {
+  personalInfo: { name: 'Saurabh Rai', title: 'Solutions Architect', email: 'a@b.com' },
+  workExperience: [
+    { id: 1, title: 'DevRel Engineer', company: 'Apideck', years: '2025-Present', description: ['Lead client demos.'] },
+  ],
+  additional: { technicalSkills: ['Python'] },
+} as ResumeData;
+
+describe('ResumeVivid', () => {
+  it('renders a two-tone name, company and bullet', () => {
+    render(<ResumeVivid data={data} />);
+    expect(screen.getByText('Saurabh')).toBeInTheDocument(); // first token only
+    expect(screen.getByText('Rai')).toBeInTheDocument();     // remaining tokens
+    expect(screen.getByText('Apideck')).toBeInTheDocument();
+    expect(screen.getByText('Lead client demos.')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect FAIL.**
+- [ ] **Step 3: Create `resume-vivid.tsx` + `vivid.module.css`.**
+- [ ] **Step 4: Export** from `index.ts`: `export { ResumeVivid } from './resume-vivid';`
+- [ ] **Step 5: Dispatcher branch** for `'vivid'` in `resume-component.tsx`, passing `sectionHeadings` and `fallbackLabels` like `modern-two-column`.
+- [ ] **Step 6: Thumbnail** — `if (type === 'vivid')` branch: two-column thumbnail with an accent top bar (two-tone), accent section header bars, and accent arrow-tick marks on left column lines (reuse `modern-two-column` thumbnail markup, recolor to accent).
+- [ ] **Step 7: Run test, expect PASS.**
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/frontend/components/resume/resume-vivid.tsx apps/frontend/components/resume/styles/vivid.module.css apps/frontend/components/resume/index.ts apps/frontend/components/dashboard/resume-component.tsx apps/frontend/components/builder/template-selector.tsx apps/frontend/tests/resume-vivid.test.tsx
+git commit -m "feat(templates): add Vivid two-column colorful template"
+```
+
+---
+
+## Task 5: parseTemplate test + docs
+
+**Files:**
+- Test: `apps/frontend/tests/print-route-parse.test.ts` (only if `parseTemplate` is exported; otherwise fold the allow-list assertion into `template-registration.test.ts` by re-testing `TEMPLATE_OPTIONS` ids — see Step 1)
+- Modify: `docs/agent/design/template-system.md`
+- Modify: `docs/agent/features/resume-templates.md`
+
+- [ ] **Step 1: parseTemplate coverage.** `parseTemplate` is a module-local function in `page.tsx` (not exported). Do NOT export server-route internals just for a test. Instead assert the allow-list intent at the type/options layer: confirm `template-registration.test.ts` (Task 1) already pins the seven IDs, which is the source of truth `parseTemplate` mirrors. Add a comment in `parseTemplate` referencing `TEMPLATE_OPTIONS` so the two stay in sync. No new test file.
+- [ ] **Step 2: Update docs tables.** In `docs/agent/design/template-system.md` and `docs/agent/features/resume-templates.md`, add `latex`, `clean`, `vivid` rows to the template tables with one-line descriptions matching `TEMPLATE_OPTIONS`. Note `vivid` supports the accent-color control.
+- [ ] **Step 3: Commit**
+
+```bash
+git add "apps/frontend/app/print/resumes/[id]/page.tsx" docs/agent/design/template-system.md docs/agent/features/resume-templates.md
+git commit -m "docs(templates): document latex, clean, vivid templates"
+```
+
+---
+
+## Final Verification (maintainer runs — npm avoided in agent shell)
+
+```bash
+cd apps/frontend
+npm run test     # all suites incl. template-registration + 3 component smoke tests
+npm run lint
+npm run build
+```
+
+Then visually confirm in the builder: select LaTeX / Clean / Vivid, verify live preview matches the reference images, toggle Contact Icons, change accent color (Vivid), and export a PDF via the print route for each.
+
+## Self-Review
+
+- **Spec coverage:** types/options (T1), 3 components+CSS (T2–T4), dispatcher/thumbnail/labels/footer/accent/print-allow-list (T1+T2–T4), i18n×5 (T1), backend docstring (T1), tests (T1–T4), docs (T5). All spec sections mapped. ✓
+- **Placeholders:** wiring/test/CSS code is inline and complete; component bodies are specified as precise deltas from named existing files (`resume-modern.tsx`, `resume-modern-two-column.tsx`) — acceptable given they are direct structural analogues. ✓
+- **Type consistency:** IDs `latex`/`clean`/`vivid`, components `ResumeLatex`/`ResumeClean`/`ResumeVivid`, classes `styles.sectionTitle`/`styles.name`/`styles.arrow`/`styles.nameFirst`/`styles.nameRest` referenced consistently across tasks. ✓

--- a/docs/superpowers/specs/2026-06-03-resume-templates-latex-clean-vivid-design.md
+++ b/docs/superpowers/specs/2026-06-03-resume-templates-latex-clean-vivid-design.md
@@ -1,0 +1,153 @@
+# Design: Three New Resume Templates — LaTeX, Clean, Vivid
+
+> **Status:** Approved (design). **Date:** 2026-06-03. **Branch:** `feat/resume-templates-latex-clean-vivid`
+
+## Goal
+
+Add three new resume templates to Resume Matcher, each a faithful reproduction of a
+reference image the maintainer provided:
+
+| ID | Display | Layout | Reference |
+|----|---------|--------|-----------|
+| `latex` | LaTeX | Single column | Classic serif/LaTeX resume (centered small-caps name, ruled Title-Case section headers, company-first two-line entries) |
+| `clean` | Clean | Single column | Minimal modern sans (centered light name, `\|`-separated contact line, large gray UPPERCASE section headers, single-line entries) |
+| `vivid` | Vivid | Two column | Colorful Awesome-CV lineage (two-tone colored name, monospace title + circular-icon contact row, accent small-caps headers, accent ➜ bullet markers) |
+
+Guiding principle (maintainer steer): **match the reference images by default; expose the
+existing universal controls so users can tweak the rest the way they like.** Do not
+over-engineer beyond faithful reproduction.
+
+## Non-Goals
+
+- No new global controls in `TemplateSettings` (reuse existing margins / spacing / size /
+  page-size / fonts / contact-icons / accent-color).
+- No changes to the two-column column-assignment engine — `vivid` reuses the established
+  split (main 65%: summary, experience, projects, certifications, custom; sidebar 35%:
+  education, skills, languages, awards). Custom-section placement follows the existing
+  convention; reordering remains a user action.
+- No backend business-logic change. The PDF endpoint accepts `template` as a free string;
+  only its docstring/allow-list comment and the frontend `parseTemplate` allow-list need the
+  new IDs.
+- No accent-color wiring for `latex`/`clean` (both are monochrome by design).
+
+## Typography Approach (the one real wrinkle)
+
+The maintainer chose "respect the font controls" over "enforce + hide the dropdowns," and
+"the reference look is the default." Global font defaults are `headerFont: serif`,
+`bodyFont: sans-serif`. To make each reference look the **default** while keeping the
+dropdowns live and **without mutating settings on template switch**, each template binds to
+existing font CSS variables per its design:
+
+- **LaTeX** — single-typeface serif. Bind all text to `var(--header-font)` (default serif ✓).
+  The **Header Font** dropdown drives the whole template; **Body Font** is inert for LaTeX.
+- **Clean** — single-typeface sans. Bind all text to `var(--body-font)` (default sans ✓).
+  The **Body Font** dropdown drives the whole template; **Header Font** is inert for Clean.
+- **Vivid** — multi-font by design. Name + bullet body use `var(--body-font)` (sans default,
+  Body Font drives body). Title line + contact row use a fixed **monospace** stack
+  (`var(--resume-font-mono)`) to match the reference. Section headers + small-caps subtitles
+  use `var(--header-font)` for the family with `font-variant: small-caps`.
+
+Trade-off accepted: for the single-typeface templates one of the two font dropdowns is a
+no-op. This is consistent with how accent-color is inert (and hidden) for non-color templates.
+
+## Template Specifications
+
+All three are pure DOM text (ATS-safe), follow the `resume-modern.tsx` /
+`resume-modern-two-column.tsx` patterns, render sections in `sectionMeta` order via
+`getSortedSections`, and reuse the shared `_base.module.css` spacing/typography classes so
+margins/spacing/size controls apply.
+
+### LaTeX (`latex`) — single column
+
+- **Header (centered):** serif name with `font-variant: small-caps` at `--header-scale`;
+  optional `personalInfo.title` as a centered italic tagline; `personalInfo.location` as a
+  centered sub-name line; contact row centered, icons shown only when the global
+  `showContactIcons` toggle is on, links underlined.
+- **Section header:** serif, bold, **Title-Case** (override base `text-transform: uppercase`
+  → `none`), full-width 1px bottom rule; `break-after: avoid`.
+- **Experience / item entries (company-first):**
+  - Line 1: **Company** bold (left) · **dates** bold (right).
+  - Line 2: *Title* italic (left) · *Location* italic (right).
+  - Bullets with `•` markers.
+- **Projects:** name bold + tech/links; dates right; bullets.
+- **Education:** institution bold (left) · dates right; degree italic line.
+- **Skills/Additional:** `**Category**: comma-joined items` lines (bold category labels).
+
+### Clean (`clean`) — single column
+
+- **Header (centered):** light-weight sans name (font-weight ~400), larger; contact rendered
+  as a single `\|`-separated line, small, links underlined; icons honor `showContactIcons`.
+- **Section header:** large gray (`--resume-text-tertiary`) **UPPERCASE** sans, letter-spaced,
+  thin bottom rule; `break-after: avoid`.
+- **Entries (single line):** **COMPANY** bold ` \| ` Title (small-caps gray) on the left;
+  `Location \| Dates` gray on the right; bullets below.
+- **Education / Projects:** analogous single-line headers.
+- **Skills/Additional:** `**Label:** items` lines.
+
+### Vivid (`vivid`) — two column
+
+- **Accent wired:** reads `--resume-accent-primary` (default blue); appears in the
+  accent-color control alongside `modern`/`modern-two-column`.
+- **Header (full width, left-aligned):** two-tone name — first token bold in accent-primary,
+  remaining tokens in a lighter accent tone; `personalInfo.title` on a monospace line; contact
+  row in monospace with **circular-outlined** icon chips (icons honor `showContactIcons`;
+  when off, show monospace text only).
+- **Section header:** accent-colored, `font-variant: small-caps`, bold (used in both columns;
+  sidebar variant slightly smaller, matching the existing `-sm` convention).
+- **Bullet markers:** accent ➜ arrow instead of `•`.
+- **Columns:** reuse `modern-two-column` grid (main 65% / sidebar 35%) and section split.
+  Sidebar skills render as `•`-separated wrapping lists (matching the reference).
+- **Print:** accent colors forced with `-webkit-print-color-adjust: exact` (mirror
+  `modern.module.css` / `modern-two-column.module.css`).
+
+## Integration Points (mirrors how `modern` was added)
+
+1. **`apps/frontend/lib/types/template-settings.ts`** — extend `TemplateType` union with
+   `'latex' | 'clean' | 'vivid'`; append three `TEMPLATE_OPTIONS` entries.
+2. **`apps/frontend/components/resume/`** — new `resume-latex.tsx`, `resume-clean.tsx`,
+   `resume-vivid.tsx`; new `styles/latex.module.css`, `styles/clean.module.css`,
+   `styles/vivid.module.css`; export all three from `index.ts`.
+3. **`apps/frontend/components/dashboard/resume-component.tsx`** — import + three conditional
+   render branches in the dispatcher.
+4. **`apps/frontend/components/builder/template-selector.tsx`** — three new
+   `TemplateThumbnail` variants + `templateLabels` entries.
+5. **`apps/frontend/components/builder/formatting-controls.tsx`** — `templateLabels` entries;
+   add `vivid` to the accent-color visibility condition.
+6. **`apps/frontend/components/builder/resume-builder.tsx`** — footer single/two-column label
+   logic: add `latex`, `clean` to the single-column condition (`vivid` falls through to
+   two-column).
+7. **`apps/frontend/app/print/resumes/[id]/page.tsx`** — add three IDs to `parseTemplate`.
+8. **`apps/backend/app/routers/resumes.py`** — update the `/generate` docstring template
+   allow-list comment (no logic change).
+9. **i18n** — add `builder.formatting.templates.{latex,clean,vivid}` `{name, description}` to
+   all five locales: `messages/{en,es,zh,ja,pt}.json`.
+10. **Docs** — update `docs/agent/design/template-system.md` and
+    `docs/agent/features/resume-templates.md` template tables.
+
+## Testing
+
+Currently there are **no** frontend template tests, so this establishes the pattern. Add
+deterministic vitest + Testing Library tests (jsdom) that fail if the templates break:
+
+- **Component render/smoke tests** (`components/resume/__tests__/` or co-located, following
+  existing vitest conventions): render each of `ResumeLatex`, `ResumeClean`, `ResumeVivid`
+  with a representative `ResumeData` fixture and assert key text appears (name, a section
+  heading, a company, a bullet). For `vivid`, assert the two-tone name splits and an accent
+  marker/element is present.
+- **`parseTemplate` test**: the three new IDs round-trip; an unknown value still falls back to
+  `swiss-single`.
+- **`TEMPLATE_OPTIONS` test**: includes all seven IDs with non-empty name/description.
+
+Verification commands are handed to the maintainer to run (shell `npm`/`npx` is avoided per
+environment constraints): `cd apps/frontend && npm run test`, `npm run lint`, `npm run build`.
+Locale parity is covered by the existing pre-push check.
+
+## Definition of Done
+
+- Three templates selectable in the builder, render in live preview and PDF print route.
+- Each matches its reference image by default; universal controls (margins, spacing, size,
+  page size, applicable font dropdown, contact-icon toggle, and accent color for `vivid`)
+  function.
+- Allow-lists (`parseTemplate`, backend docstring) and i18n (5 locales) updated.
+- New deterministic tests pass; lint and build clean.
+- Docs tables updated.


### PR DESCRIPTION
## Summary

Adds **three new résumé templates**, each a faithful reproduction of a maintainer-provided reference image, wired through the existing template selection → live preview → PDF pipeline.

| Template | `id` | Layout | Look |
|---|---|---|---|
| **LaTeX** | `latex` | Single column | Classic serif/academic: centered small-caps name, Title-Case ruled section headers, company-first two-line entries |
| **Clean** | `clean` | Single column | Minimal sans: light name, `\|`-separated contact line, large gray UPPERCASE headers, single-line entries |
| **Vivid** | `vivid` | Two column | Awesome-CV lineage: two-tone accent name, monospace contact with circular icons, accent small-caps headers, accent ➜ bullets. Wired to the **accent-color** control (default blue) |

All three are pure DOM text (ATS-safe) and respond to the existing controls (margins, spacing, size, page size, contact-icon toggle, applicable font dropdown, and accent color for Vivid).

## Design decisions
- **Typography respects the existing controls** — the reference look is the default, not enforced. LaTeX is a single serif typeface driven by the Header Font control; Clean a single sans typeface driven by the Body Font control; Vivid uses a monospace contact/title with a sans body.
- **Contact icons honor the global toggle**; **Vivid reuses the accent-color control** rather than introducing new settings.
- No new global `TemplateSettings`, no backend logic change (PDF endpoint already accepts `template` as a string — only the docstring + frontend allow-list updated), and no change to the two-column column-assignment engine (Vivid reuses the established main/sidebar split).

## Changes
- Types/registration: `TemplateType` + `TEMPLATE_OPTIONS`, `parseTemplate` allow-list, backend docstring.
- New components + CSS modules: `resume-{latex,clean,vivid}.tsx` + `styles/{latex,clean,vivid}.module.css`, exported from `index.ts`, dispatched in `resume-component.tsx`.
- Builder UI: three new `TemplateThumbnail` variants, label maps, accent-control visibility for Vivid, footer single/two-column logic, and `flex-wrap` on the thumbnail rows so 7 options don't overflow.
- i18n: `latex`/`clean`/`vivid` labels added to **all 5 locales** (en/es/zh/ja/pt-BR), structurally parity-checked.
- Docs: `template-system.md` + `resume-templates.md` tables updated. Spec + plan under `docs/superpowers/`.

## Testing
- New deterministic vitest specs: `template-registration` + render smoke tests for each template (the first frontend template tests).
- `tsc --noEmit` clean · `eslint` (incl. Prettier) clean · **`vitest run` → 139/139 pass** (incl. the locale-parity guard).
- Maintainer has visually verified the three templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three résumé templates — LaTeX (serif), Clean (minimal sans), and Vivid (colorful two‑column) — wired to template selection, live preview, and PDF export. Fixes Clean/LaTeX font binding so both font controls are live; selection seeds their signature fonts via `applyTemplatePreset`.

- **New Features**
  - LaTeX (`latex`): single-column, classic serif, ruled headers, company-first entries.
  - Clean (`clean`): single-column, minimal sans, large understated headers, single-line entries.
  - Vivid (`vivid`): two-column, two-tone name, accent headers, arrow bullets, monospace contact row.

- **Integration and QA**
  - Registered in `TemplateType`/`TEMPLATE_OPTIONS`, print allow-list, and backend PDF docstring; dispatcher added in the resume component.
  - Builder: new thumbnails, accent control shown for Vivid, footer single/two‑column indicator, and flex-wrap to prevent thumbnail overflow.
  - i18n labels added for en/es/zh/ja/pt‑BR; docs refreshed for template system/options and fixed file structure + `TemplateSettings` shape.
  - QA and fixes: Vivid guards missing-year pipes and adds a custom-section wrapper for accent headers/bullets; LaTeX header order set to Name → Title → Location → Contact; Clean/LaTeX split header/body font binding with `applyTemplatePreset` seeding; regression test added alongside registration and render smoke tests.

<sup>Written for commit 7571c327e21e7df5d2798eb0c65804eb452813aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

