### PR TITLE
fix(status): graceful degradation for the /status endpoint

### DIFF
--- a/apps/backend/app/routers/health.py
+++ b/apps/backend/app/routers/health.py
@@ -1,12 +1,25 @@
 """Health check and status endpoints."""
 
+import logging
+
 from fastapi import APIRouter
 
 from app.database import db
 from app.llm import check_llm_health, get_llm_config
 from app.schemas import HealthResponse, StatusResponse
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["Health"])
+
+# Returned for database_stats when the stats query itself fails, so /status can
+# still respond (degraded) instead of 500-ing.
+_EMPTY_DB_STATS = {
+    "total_resumes": 0,
+    "total_jobs": 0,
+    "total_improvements": 0,
+    "has_master_resume": False,
+}
 
 
 @router.get("/health", response_model=HealthResponse)
@@ -22,19 +35,32 @@ async def health_check() -> HealthResponse:
 async def get_status() -> StatusResponse:
     """Get comprehensive application status.
 
-    Returns:
-        - LLM configuration status
-        - Master resume existence
-        - Database statistics
+    Each subsystem check is isolated: a failure in the LLM health probe or the
+    database stats query degrades only its own field instead of 500-ing the
+    whole endpoint, so the status page can still report partial/degraded state.
     """
-    config = get_llm_config()
-    llm_status = await check_llm_health(config)
-    db_stats = await db.get_stats()
+    llm_configured = False
+    llm_healthy = False
+    try:
+        config = get_llm_config()
+        llm_configured = bool(config.api_key) or config.provider == "ollama"
+        llm_status = await check_llm_health(config)
+        llm_healthy = bool(llm_status.get("healthy"))
+    except Exception as e:
+        logger.error("Status: LLM health check failed: %s", e)
+
+    db_stats: dict = dict(_EMPTY_DB_STATS)
+    try:
+        db_stats = await db.get_stats()
+    except Exception as e:
+        logger.error("Status: database stats failed: %s", e)
+
+    has_master_resume = bool(db_stats.get("has_master_resume"))
 
     return StatusResponse(
-        status="ready" if llm_status["healthy"] and db_stats["has_master_resume"] else "setup_required",
-        llm_configured=bool(config.api_key) or config.provider == "ollama",
-        llm_healthy=llm_status["healthy"],
-        has_master_resume=db_stats["has_master_resume"],
+        status="ready" if llm_healthy and has_master_resume else "setup_required",
+        llm_configured=llm_configured,
+        llm_healthy=llm_healthy,
+        has_master_resume=has_master_resume,
         database_stats=db_stats,
     )

--- a/apps/backend/app/routers/health.py
+++ b/apps/backend/app/routers/health.py
@@ -43,17 +43,18 @@ async def get_status() -> StatusResponse:
     llm_healthy = False
     try:
         config = get_llm_config()
-        llm_configured = bool(config.api_key) or config.provider == "ollama"
+        # ollama / openai_compatible run without a key, matching check_llm_health.
+        llm_configured = bool(config.api_key) or config.provider in ("ollama", "openai_compatible")
         llm_status = await check_llm_health(config)
         llm_healthy = bool(llm_status.get("healthy"))
-    except Exception as e:
-        logger.error("Status: LLM health check failed: %s", e)
+    except Exception:
+        logger.exception("Status: LLM health check failed")
 
     db_stats: dict = dict(_EMPTY_DB_STATS)
     try:
         db_stats = await db.get_stats()
-    except Exception as e:
-        logger.error("Status: database stats failed: %s", e)
+    except Exception:
+        logger.exception("Status: database stats failed")
 
     has_master_resume = bool(db_stats.get("has_master_resume"))
 

--- a/apps/backend/tests/integration/test_health_api.py
+++ b/apps/backend/tests/integration/test_health_api.py
@@ -82,3 +82,46 @@ class TestStatusEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "setup_required"
+
+    @patch("app.routers.health.db", new_callable=AsyncMock)
+    @patch("app.routers.health.check_llm_health", new_callable=AsyncMock)
+    @patch("app.routers.health.get_llm_config")
+    async def test_status_degrades_when_llm_check_fails(
+        self, mock_config, mock_health, mock_db, client
+    ):
+        """A failing LLM health probe degrades llm_healthy, not the endpoint:
+        /status still returns 200 and the DB check still runs."""
+        mock_config.return_value = type("C", (), {"api_key": "sk-test", "provider": "openai"})()
+        mock_health.side_effect = RuntimeError("llm boom")
+        mock_db.get_stats.return_value = {
+            "total_resumes": 2,
+            "total_jobs": 0,
+            "total_improvements": 0,
+            "has_master_resume": True,
+        }
+        async with client:
+            resp = await client.get("/api/v1/status")
+        assert resp.status_code == 200  # not 500
+        data = resp.json()
+        assert data["llm_healthy"] is False
+        assert data["has_master_resume"] is True  # DB check still ran
+        assert data["database_stats"]["total_resumes"] == 2
+
+    @patch("app.routers.health.db", new_callable=AsyncMock)
+    @patch("app.routers.health.check_llm_health", new_callable=AsyncMock)
+    @patch("app.routers.health.get_llm_config")
+    async def test_status_degrades_when_db_stats_fails(
+        self, mock_config, mock_health, mock_db, client
+    ):
+        """A failing DB stats query degrades its fields, not the endpoint:
+        /status still returns 200 and the LLM check still runs."""
+        mock_config.return_value = type("C", (), {"api_key": "sk-test", "provider": "openai"})()
+        mock_health.return_value = {"healthy": True}
+        mock_db.get_stats.side_effect = RuntimeError("db boom")
+        async with client:
+            resp = await client.get("/api/v1/status")
+        assert resp.status_code == 200  # not 500
+        data = resp.json()
+        assert data["llm_healthy"] is True  # LLM check still ran
+        assert data["has_master_resume"] is False
+        assert data["database_stats"]["total_resumes"] == 0

--- a/apps/backend/tests/integration/test_health_api.py
+++ b/apps/backend/tests/integration/test_health_api.py
@@ -125,3 +125,26 @@ class TestStatusEndpoint:
         assert data["llm_healthy"] is True  # LLM check still ran
         assert data["has_master_resume"] is False
         assert data["database_stats"]["total_resumes"] == 0
+
+    @patch("app.routers.health.db", new_callable=AsyncMock)
+    @patch("app.routers.health.check_llm_health", new_callable=AsyncMock)
+    @patch("app.routers.health.get_llm_config")
+    async def test_status_openai_compatible_is_configured_without_key(
+        self, mock_config, mock_health, mock_db, client
+    ):
+        """openai_compatible (like ollama) runs without an API key, so it must
+        report llm_configured=True to stay consistent with the health check."""
+        mock_config.return_value = type(
+            "C", (), {"api_key": "", "provider": "openai_compatible"}
+        )()
+        mock_health.return_value = {"healthy": True}
+        mock_db.get_stats.return_value = {
+            "total_resumes": 0,
+            "total_jobs": 0,
+            "total_improvements": 0,
+            "has_master_resume": False,
+        }
+        async with client:
+            resp = await client.get("/api/v1/status")
+        assert resp.status_code == 200
+        assert resp.json()["llm_configured"] is True


### PR DESCRIPTION
## Summary
Follow-up from PR #841 review: the `/status` endpoint called `check_llm_health` and `db.get_stats` unguarded, so a failure in **either** check returned a 500 and masked the other subsystem's result.

Now each check is isolated in its own `try/except`:
- An **LLM-probe failure** degrades `llm_healthy` (→ false) but the DB check still runs.
- A **DB-stats failure** degrades `has_master_resume` (→ false) + empty `database_stats` but the LLM check still runs.
- `/status` always returns **200** with the best partial/degraded state it can assemble.

## Tests
Adds `test_status_degrades_when_llm_check_fails` and `test_status_degrades_when_db_stats_fails` (assert 200, not 500, and that the *other* check still ran). Full backend suite: **443 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully degrades the `/status` endpoint so LLM or DB probe failures no longer return 500; it now always returns 200 with the best partial status. Also fixes `llm_configured` to handle key-optional providers like `ollama` and `openai_compatible`.

- **Bug Fixes**
  - Isolated `check_llm_health` and `db.get_stats` in try/excepts; log with `logger.exception` and fallback to `_EMPTY_DB_STATS` on DB errors.
  - Always return 200; `status` is `ready` only when both `llm_healthy` and `has_master_resume` are true.
  - Aligned `llm_configured` with key-optional providers and added tests for both degradation paths and the `openai_compatible` case.

<sup>Written for commit 288081c7df65573eaab30883c315df6aeb7249b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

