### PR TITLE
docs: sync agent context for SQLite, encrypted keys & application tracker

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,13 +6,13 @@
 
 ## Project Overview
 
-Resume Matcher is an AI-powered application for tailoring resumes to job descriptions.
+Resume Matcher is an AI-powered application for tailoring resumes to job descriptions, with a Kanban Application Tracker for managing the job-application pipeline.
 
 | Layer | Stack |
 |-------|-------|
 | **Backend** | FastAPI + Python 3.13+, LiteLLM (multi-provider AI) |
 | **Frontend** | Next.js 16 + React 19, Tailwind CSS v4 |
-| **Database** | TinyDB (JSON file storage) |
+| **Database** | SQLite (SQLAlchemy 2.0 async / aiosqlite) |
 | **PDF** | Headless Chromium via Playwright |
 
 ---
@@ -41,7 +41,7 @@ Before exploring code, read [docs/agent/README.md](../docs/agent/README.md) for 
 cd apps/backend
 uv sync --extra dev                                  # Install Python deps (incl. test deps)
 uv run uvicorn app.main:app --reload --port 8000     # FastAPI on :8000
-uv run pytest                                        # Run backend tests (~320; LLM evals excluded)
+uv run pytest                                        # Run backend tests (~444; LLM evals excluded)
 
 # Frontend (from repo root, in a separate terminal)
 cd apps/frontend
@@ -67,18 +67,22 @@ apps/
 │   ├── app/
 │   │   ├── main.py          # Entry point
 │   │   ├── config.py        # Environment settings
-│   │   ├── database.py      # TinyDB wrapper
+│   │   ├── database.py      # Async SQLAlchemy/SQLite facade
+│   │   ├── models.py        # SQLAlchemy ORM models (Resume/Job/Improvement/Application/ApiKey)
+│   │   ├── db_engine.py     # Async + sync SQLite engines (WAL/FK pragmas)
+│   │   ├── crypto.py        # Fernet encrypt/decrypt for API keys at rest
 │   │   ├── llm.py           # LiteLLM wrapper
-│   │   ├── routers/         # API endpoints
+│   │   ├── routers/         # API endpoints (incl. applications.py = tracker)
 │   │   ├── services/        # Business logic
-│   │   ├── schemas/         # Pydantic models
-│   │   └── prompts/         # LLM prompt templates
-│   └── data/                # Database storage
+│   │   ├── schemas/         # Pydantic models (incl. applications.py)
+│   │   ├── prompts/         # LLM prompt templates
+│   │   └── scripts/         # One-time TinyDB→SQLite migration (runs on startup)
+│   └── data/                # resume_matcher.db (SQLite) + encrypted API keys + .secret_key
 │
 └── frontend/                # Next.js + React
-    ├── app/                 # Pages (dashboard, builder, tailor, print)
-    ├── components/          # UI components
-    ├── lib/                 # Utilities, API client
+    ├── app/                 # Pages (dashboard, builder, tailor, tracker, print)
+    ├── components/          # UI components (incl. tracker/)
+    ├── lib/                 # Utilities, API client (incl. api/tracker.ts)
     ├── hooks/               # Custom React hooks
     └── messages/            # i18n translations (en, es, zh, ja, pt)
 ```
@@ -109,6 +113,7 @@ apps/
 ### For Features
 | Feature | Documentation |
 |---------|---------------|
+| Application tracker | [application-tracker.md](../docs/agent/features/application-tracker.md) |
 | Custom sections | [custom-sections.md](../docs/agent/features/custom-sections.md) |
 | Resume templates | [resume-templates.md](../docs/agent/features/resume-templates.md) |
 | i18n | [i18n.md](../docs/agent/features/i18n.md) |

--- a/apps/backend/e2e_monitor/README.md
+++ b/apps/backend/e2e_monitor/README.md
@@ -29,7 +29,7 @@ uv run python -m e2e_monitor sweep
 The harness gate requires **both** `RM_E2E_MONITOR=1` and a configured LLM key (via `LLM_API_KEY` or the project's config). If either is absent the gate refuses with an explanatory message — nothing runs.
 
 The sweep:
-1. Seeds an isolated `DATA_DIR` (your real TinyDB is never touched).
+1. Seeds an isolated `DATA_DIR` (your real SQLite DB is never touched).
 2. Boots the backend in-process.
 3. Tailors the master resume against 3–4 bundled JDs.
 4. Attempts PDF renders (skipped/degraded if `node` or the frontend is absent).

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -16,7 +16,8 @@ App Router under `app/`. A `(default)` route group wraps the main app in provide
 | `/dashboard` | `app/(default)/dashboard/page.tsx` | Client | Resume list, upload, delete, retry, status grid |
 | `/builder` | `app/(default)/builder/page.tsx` | Client wrapper → `components/builder/resume-builder.tsx` | Master-resume editor (forms, drag-drop sections, templates, AI regenerate, cover letter / outreach) |
 | `/tailor` | `app/(default)/tailor/page.tsx` | Client | Paste JD → preview/confirm tailored resume (diff modal) |
-| `/settings` | `app/(default)/settings/page.tsx` | Client | LLM provider/model/key, API keys, features, prompts, language, reset DB |
+| `/tracker` | `app/(default)/tracker/page.tsx` | Client | Kanban application tracker — 7-column board (drag/drop, bulk ops, manual add) |
+| `/settings` | `app/(default)/settings/page.tsx` | Client | LLM provider/model/key, per-provider API keys, features, prompts, language, reset DB |
 | `/resumes/[id]` | `app/(default)/resumes/[id]/page.tsx` | Client | View one resume, download PDF, rename, enrichment modal |
 | `/print/resumes/[id]` | `app/print/resumes/[id]/page.tsx` | **Server** | Print-only resume render for PDF (reads `searchParams` for template settings + `lang`) |
 | `/print/cover-letter/[id]` | `app/print/cover-letter/[id]/page.tsx` | **Server** | Print-only cover-letter render for PDF |
@@ -38,6 +39,9 @@ components/
   builder/           # builder page UI + forms/ (per-section form components)
   dashboard/         # resume list/card, upload dialog
   tailor/            # diff-preview-modal
+  tracker/           # kanban-board, kanban-column, application-card,
+                     #   card-detail-modal, bulk-action-bar,
+                     #   manual-add-application-dialog, reorder.ts (pure planMove)
   enrichment/        # AI enrichment wizard modal/steps
   resume/            # resume render templates (single/two-column, modern) + styles/*.module.css
   preview/           # paginated A4/Letter preview (use-pagination.ts)
@@ -68,8 +72,9 @@ All backend calls go through **`lib/api/`** — never call `fetch` to the backen
   - Base URL: `NEXT_PUBLIC_API_URL` (default `'/'`) → `API_BASE` becomes `/api/v1`. On the **server** a `/`-relative base is rewritten to `http://127.0.0.1:8000/api/v1` (`INTERNAL_API_ORIGIN`); browser uses the relative path (proxied by `next.config.ts` rewrites to `BACKEND_ORIGIN`).
   - Default request timeout **240_000ms** (matches backend `wait_for` hard limit). `AbortError` → friendly "Request timed out" message.
 - `lib/api/resume.ts` — resumes/jobs: upload, improve / improve.preview / improve.confirm, fetch, list, update (PATCH), PDF URLs + blob download, delete, cover-letter / outreach generate+update, rename, retry-processing, fetch JD.
-- `lib/api/config.ts` — LLM config, `testLlmConnection`, system `/status`, feature flags, prompt config, **feature prompts** (`FeaturePromptsError` for 422 `missing_placeholders`), API-key management, language config, `resetDatabase`. `PROVIDER_INFO` lists supported providers + default models.
+- `lib/api/config.ts` — LLM config, `testLlmConnection`, system `/status`, feature flags, prompt config, **feature prompts** (`FeaturePromptsError` for 422 `missing_placeholders`), **per-provider API-key management** (each provider's key persists independently — switching the active provider no longer wipes another's; stored encrypted server-side), language config, `resetDatabase`. `PROVIDER_INFO` lists supported providers + default models.
 - `lib/api/enrichment.ts` — AI enrichment (analyze/enhance/apply) and AI regenerate (regenerate/apply-regenerated).
+- `lib/api/tracker.ts` — application-tracker CRUD/bulk over `apiFetch/apiPost/apiPatch/apiDelete`: grouped list, detail (JD + resume), manual add, status/position/notes PATCH, bulk move, delete, bulk-delete.
 - `lib/api/index.ts` — barrel re-export (note: not everything is re-exported; some functions are imported from `./resume` / `./config` / `./enrichment` directly).
 
 **Contracts:** `lib/api/*` interfaces mirror backend Pydantic schemas. See [front-end-apis.md](../../docs/agent/apis/front-end-apis.md) and [api-flow-maps.md](../../docs/agent/apis/api-flow-maps.md).
@@ -77,6 +82,8 @@ All backend calls go through **`lib/api/`** — never call `fetch` to the backen
 **Shared client state (React Context, not a fetch lib):**
 - `StatusCacheProvider` (`lib/context/status-cache.tsx`) — caches `/status` (LLM health 30min, DB stats 5min stale), with optimistic counter updates. Use `useStatusCache()` / `useIsStatusStale()`.
 - `LanguageProvider` (`lib/context/language-context.tsx`) — UI + content language, localStorage + backend sync. Use `useLanguage()`.
+
+> The **tracker board owns its state locally** — `components/tracker/kanban-board.tsx` holds the columns in `useState` and owns the single `@dnd-kit` `DndContext`. There is **no** `TrackerProvider` / tracker context; don't look for one.
 
 ---
 
@@ -104,6 +111,8 @@ const allMessages: Record<Locale, Messages> = { en, es, zh, ja, pt };
 Because every locale is typed as `Messages` (= the exact shape of `en.json`), **every locale JSON must structurally match `en.json` exactly.** Add a key to `en.json` and the production `tsc` / `next build` FAILS until that same key path exists in `es`, `zh`, `ja`, and `pt-BR`. (A real build break was caused by exactly this.)
 
 **When editing translations:** any key you add/remove/rename in `en.json` MUST be mirrored in all 5 files (`en`, `es`, `zh`, `ja`, `pt-BR`) with identical structure. `npm run dev` may tolerate drift; the build will not.
+
+The tracker ships a `tracker.*` key tree (`columns`, `modal`, `manualAdd`, `bulk`, `errors`, `scroll`) plus `nav.applicationTracker`, present in all 5 locale files — subject to the same parity rule.
 
 See [i18n.md](../../docs/agent/features/i18n.md), [i18n-preparation.md](../../docs/agent/features/i18n-preparation.md).
 

--- a/docs/agent/apis/api-flow-maps.md
+++ b/docs/agent/apis/api-flow-maps.md
@@ -43,18 +43,18 @@ GET /api/v1/resumes/{id}/pdf
 
 ```
 GET /api/v1/health
-├── check_llm_health() → 30s timeout
-└── Return {healthy, provider, model}
+└── Return {status: "healthy"}        # pure liveness — does NOT call the LLM
 ```
 
 ## System Status
 
 ```
-GET /api/v1/status
-├── get_llm_config()
-├── check_llm_health()
-├── db.get_stats()
-└── Return {status, llm_healthy, database_stats}
+GET /api/v1/status                    # each check isolated → 200 (partial/degraded), never 500
+├── try: get_llm_config()
+│   ├── llm_configured = api_key set OR provider ∈ {ollama, openai_compatible}
+│   └── check_llm_health() → llm_healthy   # failure here degrades only this field
+├── try: db.get_stats()                     # failure → empty stats, still 200
+└── Return {status, llm_configured, llm_healthy, has_master_resume, database_stats}
 ```
 
 ## Configuration Update
@@ -62,10 +62,25 @@ GET /api/v1/status
 ```
 PUT /api/v1/config/llm-api-key
 ├── _load_config()
-├── Merge new values
-├── check_llm_health() → Validate
+├── Merge new NON-SECRET values (provider/model/base/...)
+├── (no longer persists any key — keys go through /config/api-keys)
 ├── _save_config()
 └── Return masked config
+```
+
+## API Keys (per-provider, encrypted)
+
+```
+GET /api/v1/config/api-keys
+└── Return {providers: [{provider, configured, masked_key}]}   # always masked
+
+POST /api/v1/config/api-keys
+├── For each provided provider key:
+│   └── Fernet-encrypt → upsert into SQLite `api_keys` table   # other providers' keys untouched
+└── Return {message, updated_providers}
+
+DELETE /api/v1/config/api-keys/{provider}      # remove one provider's key
+DELETE /api/v1/config/api-keys?confirm=...     # clear all keys
 ```
 
 ## Job Upload
@@ -85,3 +100,31 @@ POST /api/v1/jobs/upload
 | `GET /resumes/list` | db.list_resumes() |
 | `PATCH /resumes/{id}` | db.update_resume() |
 | `DELETE /resumes/{id}` | db.delete_resume() |
+
+## Application Tracker
+
+```
+GET /api/v1/applications
+├── db.list_applications()
+└── Return {columns}        # grouped by the 7 status keys (all present):
+                            #   saved/applied/no_response/response/interview/accepted/rejected
+
+POST /api/v1/applications   # manual add from a pasted JD
+├── db.create_job(jd)
+├── [If company/role missing] extract_job_keywords() → LLM   # one best-effort call
+├── db.create_application(status default "applied")          # dedupes on (job_id, resume_id)
+└── Return Application
+
+GET /api/v1/applications/{id}
+├── db.get_application() + embed job_content + applied resume
+└── Return {..., job_content, resume}    # resume: null if it was deleted
+```
+
+| Endpoint | Flow |
+|----------|------|
+| `PATCH /applications/{id}` | db.update_application() — status/position/notes/company/role/applied_at; server renumbers `position` |
+| `PATCH /applications/bulk` | db.bulk_update_status() — move many cards to one column |
+| `DELETE /applications/{id}` | db.delete_application() |
+| `POST /applications/bulk-delete` | db.bulk_delete_applications() |
+
+> **Auto-create:** `POST /resumes/improve/confirm` (and legacy `POST /resumes/improve`) create an `applied` card after persisting the tailored resume — best-effort (a tracker failure never breaks tailoring); company/role reuse the cached keyword extraction, so no extra LLM call.

--- a/docs/agent/apis/front-end-apis.md
+++ b/docs/agent/apis/front-end-apis.md
@@ -40,6 +40,22 @@ updateCoverLetter(resumeId: string, content: string) → void
 updateOutreachMessage(resumeId: string, content: string) → void
 ```
 
+## Application Tracker (`lib/api/tracker.ts`)
+
+```typescript
+// Kanban board (7 status columns: saved | applied | no_response |
+// response | interview | accepted | rejected)
+listApplications() → ApplicationListResponse        // { columns: Record<status, Application[]> }
+createApplication(payload: ManualApplicationCreate) → Application   // manual add from a pasted JD
+getApplicationDetail(id: string) → ApplicationDetail               // embedded JD + applied resume (resume null if deleted)
+updateApplication(id: string, payload: ApplicationUpdate) → Application   // status/position/notes/company/role/applied_at
+
+// Bulk
+bulkUpdateStatus(applicationIds: string[], status: ApplicationStatus) → ApplicationActionResponse
+deleteApplication(id: string) → void
+bulkDeleteApplications(applicationIds: string[]) → ApplicationActionResponse
+```
+
 ## Config Operations (`lib/api/config.ts`)
 
 ```typescript
@@ -47,6 +63,13 @@ fetchLlmConfig() → LLMConfig
 updateLlmConfig(config: LLMConfigUpdate) → LLMConfig
 testLlmConnection() → LLMHealthCheck
 fetchSystemStatus() → SystemStatus
+
+// Per-provider API keys (encrypted server-side; switching the active
+// provider no longer wipes another provider's key — responses always masked)
+fetchApiKeyStatus() → ApiKeyStatusResponse           // { providers: [{ provider, configured, masked_key }] }
+updateApiKeys(keys: ApiKeysUpdateRequest) → ApiKeysUpdateResponse
+deleteApiKey(provider: ApiKeyProvider) → void
+clearAllApiKeys() → void
 
 // Feature flags
 fetchFeatureConfig() → FeatureConfig
@@ -56,6 +79,8 @@ updateFeatureConfig(config: FeatureConfigUpdate) → FeatureConfig
 fetchLanguageConfig() → LanguageConfig
 updateLanguageConfig(language: string) → LanguageConfig
 ```
+
+> `updateLlmApiKey` (`PUT /config/llm-api-key`) no longer persists a key — keys are managed per-provider via the encrypted `/config/api-keys` endpoints above.
 
 ## Provider Info
 

--- a/docs/agent/architecture/backend-architecture.md
+++ b/docs/agent/architecture/backend-architecture.md
@@ -26,7 +26,7 @@ apps/backend/app/
 ### Health & Status
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/api/v1/health` | LLM health check |
+| GET | `/api/v1/health` | Liveness probe (no LLM call) |
 | GET | `/api/v1/status` | Full system status (LLM probe + DB stats, each isolated → 200 with degraded state on partial failure) |
 
 ### Configuration
@@ -34,7 +34,7 @@ apps/backend/app/
 |--------|----------|-------------|
 | GET/PUT | `/api/v1/config/llm-api-key` | LLM config (no longer persists a key) |
 | POST | `/api/v1/config/llm-test` | Test connection |
-| GET/PUT/DELETE | `/api/v1/config/api-keys` | Per-provider encrypted API keys |
+| GET/POST/DELETE | `/api/v1/config/api-keys` | Per-provider encrypted API keys |
 
 ### Resumes
 | Method | Endpoint | Description |
@@ -175,7 +175,7 @@ FRONTEND_BASE_URL=http://localhost:3000
 Non-secret config (provider/model/base/features) stored in `data/config.json`, takes
 precedence over env vars. **API keys are never written to `config.json`** — they live
 encrypted in the SQLite `api_keys` table (per-provider) and are injected into the config
-dict only at read time. Set them via `PUT /config/api-keys`; `PUT /config/llm-api-key` no
+dict only at read time. Set them via `POST /config/api-keys`; `PUT /config/llm-api-key` no
 longer persists a key.
 
 ## Error Handling

--- a/docs/agent/architecture/backend-architecture.md
+++ b/docs/agent/architecture/backend-architecture.md
@@ -1,19 +1,23 @@
 # Backend Architecture
 
-> FastAPI + Python 3.11+ | TinyDB | LiteLLM multi-provider
+> FastAPI + Python 3.13+ | SQLite (SQLAlchemy 2.0 async + aiosqlite) | LiteLLM multi-provider
 
 ## Directory Structure
 
 ```
 apps/backend/app/
-├── main.py              # FastAPI entry point
-├── config.py            # Pydantic settings
-├── database.py          # TinyDB wrapper
+├── main.py              # FastAPI entry point (lifespan: TinyDB→SQLite import, legacy-key fold-in)
+├── config.py            # Pydantic settings; encrypted API-key read/write
+├── crypto.py            # Fernet encrypt/decrypt for API keys at rest
+├── database.py          # Async SQLAlchemy/SQLite facade (returns plain dicts)
+├── models.py            # SQLAlchemy declarative Base + ORM models
+├── db_engine.py         # SQLite engine/session factories (async + sync) + PRAGMAs
 ├── llm.py               # LiteLLM multi-provider
 ├── pdf.py               # Playwright PDF rendering
-├── routers/             # API endpoints (health, config, resumes, jobs)
+├── routers/             # API endpoints (health, config, resumes, jobs, applications, enrichment)
 ├── services/            # parser.py, improver.py, cover_letter.py
-├── schemas/models.py    # Pydantic models
+├── schemas/             # Pydantic models (models.py, applications.py)
+├── scripts/             # migrate_tinydb_to_sqlite.py (one-time importer)
 └── prompts/templates.py # LLM prompts
 ```
 
@@ -23,13 +27,14 @@ apps/backend/app/
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/api/v1/health` | LLM health check |
-| GET | `/api/v1/status` | Full system status |
+| GET | `/api/v1/status` | Full system status (LLM probe + DB stats, each isolated → 200 with degraded state on partial failure) |
 
 ### Configuration
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET/PUT | `/api/v1/config/llm-api-key` | LLM config |
+| GET/PUT | `/api/v1/config/llm-api-key` | LLM config (no longer persists a key) |
 | POST | `/api/v1/config/llm-test` | Test connection |
+| GET/PUT/DELETE | `/api/v1/config/api-keys` | Per-provider encrypted API keys |
 
 ### Resumes
 | Method | Endpoint | Description |
@@ -48,18 +53,63 @@ apps/backend/app/
 | POST | `/jobs/upload` | Store job description |
 | GET | `/jobs/{id}` | Fetch job |
 
-## Database (`database.py`)
+### Applications (Kanban tracker)
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/applications` | All cards grouped by column (7 status keys) |
+| POST | `/applications` | Manual add (creates job + card) |
+| GET | `/applications/{id}` | Card + JD + resume (resume null if deleted) |
+| PATCH | `/applications/{id}` | Update status/position/notes/company/role |
+| PATCH | `/applications/bulk` | Move many cards to one column |
+| DELETE | `/applications/{id}` | Delete one card |
+| POST | `/applications/bulk-delete` | Delete many cards |
 
-TinyDB tables: `resumes`, `jobs`, `improvements`
+## Database (`database.py`, `models.py`, `db_engine.py`)
+
+**SQLite** via SQLAlchemy 2.0 async (`aiosqlite`). DB file: `data/resume_matcher.db`.
+`database.py` is an async `Database` facade (global `db` singleton) — same method
+names/signatures as before, but it returns **plain dicts**, never ORM rows.
+ORM models live in `models.py` (declarative `Base` + `Resume`/`Job`/`Improvement`/`Application`/`ApiKey`);
+engine/session plumbing lives in `db_engine.py`.
+
+Tables: `resumes`, `jobs`, `improvements`, `applications`, `api_keys` (encrypted).
 
 ```python
-db.create_resume(content, content_type, filename, is_master, processed_data)
-db.get_resume(resume_id) → dict | None
-db.update_resume(resume_id, updates)
-db.delete_resume(resume_id) → bool
-db.set_master_resume(resume_id)  # Only one master allowed
-db.get_stats() → {total_resumes, total_jobs, total_improvements}
+await db.create_resume(content, content_type, filename, is_master, processed_data)
+await db.get_resume(resume_id) → dict | None
+await db.update_resume(resume_id, updates) → dict
+await db.delete_resume(resume_id) → bool
+await db.set_master_resume(resume_id)            # Exactly one master allowed
+await db.create_application(...) / list_applications / update_application / bulk_*
+await db.get_stats() → {total_resumes, total_jobs, total_improvements, total_applications}
+get_api_key_ciphertexts() / replace_api_keys(...)  # sync; encrypted api_keys table
 ```
+
+**Two engines, one file (`db_engine.py`):** a module-level **async** engine serves
+the document tables + `applications`; a **sync** engine serves the encrypted
+`api_keys` table, which is read on the synchronous LLM hot path
+(`get_llm_config` → `load_config_file` → `resolve_api_key`) so async isn't threaded
+through `llm.py`. Both apply PRAGMAs `journal_mode=WAL`, `foreign_keys=ON`,
+`busy_timeout` on connect.
+
+**Single-master invariant** is preserved by an `asyncio.Lock`
+(`create_resume_atomic_master`) plus a partial unique index on `is_master`.
+**Jobs' dynamic pipeline fields** (`preview_hash`/`preview_hashes`, `job_keywords`,
+`company`/`role`) are stored in a `metadata_json` JSON column and flattened on read.
+`Application` dedupes on `(job_id, resume_id)` via a `UniqueConstraint`.
+
+### Migration & encrypted keys
+
+- **One-time importer** (`app/scripts/migrate_tinydb_to_sqlite.py`): runs on lifespan
+  startup. If a legacy `data/database.json` (TinyDB) exists and SQLite is empty, it
+  imports the rows, then renames the file `database.json.migrated` (rollback artifact).
+  Idempotent: skips if SQLite already has rows.
+- **Encrypted API keys** (`app/crypto.py`): Fernet symmetric encrypt/decrypt. The
+  secret lives at `data/.secret_key` (auto-generated, `chmod 600`, gitignored, atomic
+  write); plaintext exists only in memory. Per-provider ciphertexts live in the
+  `api_keys` table. `app/config.py` reads/writes them (atomic `replace_api_keys`);
+  `migrate_legacy_keys()` folds any legacy plaintext keys into the encrypted store on
+  startup (idempotent, non-clobbering).
 
 ## LLM Integration (`llm.py`)
 
@@ -122,7 +172,11 @@ LLM_API_KEY=sk-...
 FRONTEND_BASE_URL=http://localhost:3000
 ```
 
-Config stored in `data/config.json`, takes precedence over env vars.
+Non-secret config (provider/model/base/features) stored in `data/config.json`, takes
+precedence over env vars. **API keys are never written to `config.json`** — they live
+encrypted in the SQLite `api_keys` table (per-provider) and are injected into the config
+dict only at read time. Set them via `PUT /config/api-keys`; `PUT /config/llm-api-key` no
+longer persists a key.
 
 ## Error Handling
 

--- a/docs/agent/architecture/backend-guide.md
+++ b/docs/agent/architecture/backend-guide.md
@@ -7,36 +7,69 @@
 | Component | Technology |
 |-----------|------------|
 | Framework | FastAPI |
-| Database | TinyDB (JSON file) |
+| Database | SQLite (SQLAlchemy 2.0 async + aiosqlite) |
 | AI | LiteLLM (100+ providers) |
 | Doc Parsing | markitdown |
 | Validation | Pydantic |
+| Key encryption | Fernet (`cryptography`) |
 
 ## Directory Structure
 
 ```
 apps/backend/app/
-├── main.py         # Entry point
-├── config.py       # Settings from env/file
-├── database.py     # TinyDB wrapper
+├── main.py         # Entry point (lifespan: TinyDB→SQLite import, legacy-key fold-in)
+├── config.py       # Settings from env/file; encrypted API-key read/write
+├── crypto.py       # Fernet encrypt/decrypt for API keys at rest
+├── database.py     # Async SQLAlchemy/SQLite facade (returns plain dicts)
+├── models.py       # SQLAlchemy declarative Base + ORM models
+├── db_engine.py    # SQLite engine/session factories (async + sync) + PRAGMAs
 ├── llm.py          # Multi-provider LLM
-├── routers/        # health, config, resumes, jobs
+├── routers/        # health, config, resumes, jobs, applications, enrichment
 ├── services/       # parser, improver, cover_letter
-├── schemas/        # Pydantic models
+├── schemas/        # Pydantic models (models.py, applications.py)
+├── scripts/        # migrate_tinydb_to_sqlite.py (one-time importer)
 └── prompts/        # templates.py
 ```
 
 ## Database Operations
 
+`database.py` is an async `Database` facade (global `db` singleton). Methods keep the
+same names/signatures as the old TinyDB wrapper but return **plain dicts** (never ORM
+rows). ORM models are in `models.py`; engine plumbing is in `db_engine.py`.
+
 ```python
-db.create_resume(content, content_type, filename, is_master, processed_data)
-db.get_resume(resume_id) → dict | None
-db.list_resumes() → list[dict]
-db.update_resume(resume_id, updates)
-db.delete_resume(resume_id) → bool
-db.set_master_resume(resume_id)
-db.create_job(content, resume_id)
+await db.create_resume(content, content_type, filename, is_master, processed_data)
+await db.get_resume(resume_id) → dict | None
+await db.list_resumes() → list[dict]
+await db.update_resume(resume_id, updates)
+await db.delete_resume(resume_id) → bool
+await db.set_master_resume(resume_id)            # Exactly one master allowed
+await db.create_job(content, resume_id)
+await db.create_application(...) / list_applications / bulk_update_applications
+get_api_key_ciphertexts() / replace_api_keys(...)  # sync; encrypted api_keys table
 ```
+
+**Tables:** `resumes`, `jobs`, `improvements`, `applications`, `api_keys` (encrypted).
+DB file: `data/resume_matcher.db`.
+
+**Two engines, one file:** a module-level **async** engine serves the document tables +
+`applications`; a **sync** engine serves the encrypted `api_keys` table (read on the
+synchronous LLM hot path). Both apply PRAGMAs `journal_mode=WAL`, `foreign_keys=ON`,
+`busy_timeout`. The single-master invariant is held by an `asyncio.Lock` plus a partial
+unique index. Jobs' dynamic pipeline fields (`preview_hash(es)`, `job_keywords`,
+`company`/`role`) live in a `metadata_json` JSON column, flattened on read.
+
+### Encrypted API keys & migration
+
+- **Keys** (`crypto.py`): Fernet-encrypted, per-provider, in the `api_keys` table. Secret
+  at `data/.secret_key` (`chmod 600`, gitignored, atomic write; plaintext only in memory).
+  `config.py` injects decrypted keys at read time and strips them on save, so secrets
+  never reach `config.json`. Set via `PUT /config/api-keys`; `PUT /config/llm-api-key` no
+  longer persists a key.
+- **Migration** (`scripts/migrate_tinydb_to_sqlite.py`): runs on lifespan startup. Imports
+  a legacy `data/database.json` (TinyDB) into SQLite if present, then renames it
+  `database.json.migrated`. Idempotent. `migrate_legacy_keys()` likewise folds legacy
+  plaintext keys into the encrypted store.
 
 ## LLM Features
 
@@ -56,20 +89,24 @@ db.create_job(content, resume_id)
 ## API Endpoints Quick Ref
 
 ```
-GET  /api/v1/health          # LLM check
-GET  /api/v1/status          # Full status
-GET/PUT /api/v1/config/llm-api-key
-POST /api/v1/resumes/upload  # PDF/DOCX
-POST /api/v1/resumes/improve # Tailor (LLM)
+GET  /api/v1/health              # LLM check
+GET  /api/v1/status              # Full status (LLM + DB isolated; 200 on partial failure)
+GET/PUT /api/v1/config/llm-api-key            # no longer persists a key
+GET/PUT/DELETE /api/v1/config/api-keys        # per-provider encrypted keys
+POST /api/v1/resumes/upload      # PDF/DOCX
+POST /api/v1/resumes/improve     # Tailor (LLM)
 GET  /api/v1/resumes/{id}/pdf
 DELETE /api/v1/resumes/{id}
+GET  /api/v1/applications        # Kanban tracker: grouped list (+ POST/PATCH/DELETE/bulk)
 ```
 
 ## Data Flow
 
-**Upload:** File → markitdown → Markdown → LLM parse → JSON → TinyDB
+**Upload:** File → markitdown → Markdown → LLM parse → JSON → SQLite (via `db`)
 
-**Improve:** Resume + Job → Extract keywords (LLM) → Tailor (LLM) → Store
+**Improve:** Resume + Job → Extract keywords (LLM) → Tailor (LLM) → Store. Routers call
+services; services call `app/llm.py`; persistence goes through the async `db` facade.
+`/improve/confirm` also best-effort auto-creates an `applied` card in the tracker.
 
 ## Error Handling
 

--- a/docs/agent/architecture/backend-guide.md
+++ b/docs/agent/architecture/backend-guide.md
@@ -64,7 +64,7 @@ unique index. Jobs' dynamic pipeline fields (`preview_hash(es)`, `job_keywords`,
 - **Keys** (`crypto.py`): Fernet-encrypted, per-provider, in the `api_keys` table. Secret
   at `data/.secret_key` (`chmod 600`, gitignored, atomic write; plaintext only in memory).
   `config.py` injects decrypted keys at read time and strips them on save, so secrets
-  never reach `config.json`. Set via `PUT /config/api-keys`; `PUT /config/llm-api-key` no
+  never reach `config.json`. Set via `POST /config/api-keys`; `PUT /config/llm-api-key` no
   longer persists a key.
 - **Migration** (`scripts/migrate_tinydb_to_sqlite.py`): runs on lifespan startup. Imports
   a legacy `data/database.json` (TinyDB) into SQLite if present, then renames it
@@ -89,10 +89,10 @@ unique index. Jobs' dynamic pipeline fields (`preview_hash(es)`, `job_keywords`,
 ## API Endpoints Quick Ref
 
 ```
-GET  /api/v1/health              # LLM check
+GET  /api/v1/health              # liveness probe (no LLM call)
 GET  /api/v1/status              # Full status (LLM + DB isolated; 200 on partial failure)
 GET/PUT /api/v1/config/llm-api-key            # no longer persists a key
-GET/PUT/DELETE /api/v1/config/api-keys        # per-provider encrypted keys
+GET/POST/DELETE /api/v1/config/api-keys       # per-provider encrypted keys
 POST /api/v1/resumes/upload      # PDF/DOCX
 POST /api/v1/resumes/improve     # Tailor (LLM)
 GET  /api/v1/resumes/{id}/pdf

--- a/docs/agent/scope-and-principles.md
+++ b/docs/agent/scope-and-principles.md
@@ -8,7 +8,7 @@ Resume Matcher is an AI-powered application that helps users tailor resumes to j
 
 - **Backend**: FastAPI + Python 3.11+ with multi-provider LLM support via LiteLLM
 - **Frontend**: Next.js 15 + React 19 with Swiss International Style design
-- **Database**: TinyDB (JSON file storage)
+- **Database**: SQLite via async SQLAlchemy (`aiosqlite`)
 - **PDF Generation**: Headless Chromium via Playwright
 
 ## Non-Negotiable Rules

--- a/docs/agent/scope-and-principles.md
+++ b/docs/agent/scope-and-principles.md
@@ -6,8 +6,8 @@
 
 Resume Matcher is an AI-powered application that helps users tailor resumes to job descriptions. It consists of:
 
-- **Backend**: FastAPI + Python 3.11+ with multi-provider LLM support via LiteLLM
-- **Frontend**: Next.js 15 + React 19 with Swiss International Style design
+- **Backend**: FastAPI + Python 3.13+ with multi-provider LLM support via LiteLLM
+- **Frontend**: Next.js 16 + React 19 with Swiss International Style design
 - **Database**: SQLite via async SQLAlchemy (`aiosqlite`)
 - **PDF Generation**: Headless Chromium via Playwright
 

--- a/docs/agent/testing-strategy.md
+++ b/docs/agent/testing-strategy.md
@@ -43,7 +43,7 @@ Takeaway: a green checkmark here meant nothing, and a red one went unseen. That 
 | `llm.py` | 47% | 🟡 Pure helpers tested; **real request + `check_llm_health` + Ollama paths NOT** |
 | `routers/enrichment.py` | 38% | 🟡 Regenerate matching tested; rest mocked |
 | `config_cache.py` | 38% | 🔴 |
-| `database.py` (TinyDB) | 34% | 🔴 Real DB never exercised — every integration test mocks `db` |
+| `database.py` | 34% | 🔴 Real DB never exercised — every integration test mocks `db` |
 | `services/cover_letter.py` | 26% | 🔴 Untested |
 | `services/parser.py` | 20% | 🔴 Upload→markdown→JSON untested; even the pure date-restore is uncovered |
 | `pdf.py` (render) | 20% | 🔴 The "resume won't render" class |
@@ -51,7 +51,7 @@ Takeaway: a green checkmark here meant nothing, and a red one went unseen. That 
 
 ### 2.3 The structural truth about the integration tests
 
-Every `tests/integration/*` test patches `app.routers.<x>.db` and the LLM/parse calls. They verify **status codes, request validation, response shape, and router branch logic** (e.g. API-key masking, regenerate fallback matching). They are valuable *contract* tests. They do **not** prove TinyDB persists, Playwright renders, markitdown parses, or any provider (Ollama included) actually responds.
+Every `tests/integration/*` test patches `app.routers.<x>.db` and the LLM/parse calls. They verify **status codes, request validation, response shape, and router branch logic** (e.g. API-key masking, regenerate fallback matching). They are valuable *contract* tests. They do **not** prove the database persists, Playwright renders, markitdown parses, or any provider (Ollama included) actually responds.
 
 ---
 
@@ -115,7 +115,7 @@ Legend: ✅ done · 🚧 in progress · ⬜ planned
 - ✅ Make the suite green (fixed stale `health` tests; liveness vs readiness)
 - ✅ `llm.py` provider/Ollama pure-function regression tests (`tests/unit/test_llm_providers.py`)
 - ✅ `parser.py` pure tests (date restoration) (`tests/unit/test_parser.py`) + empty-text rejection (`tests/integration/test_upload_api.py`)
-- ✅ Real-TinyDB `database.py` CRUD tests (`tests/unit/test_database.py`)
+- ✅ Real-SQLite `database.py` CRUD tests (`tests/unit/test_database.py`)
 - ✅ Verify: **192 → 265 tests, 1 silent failure → 0, coverage 54% → 58%** (database 34→96%, parser 20→72%, llm 47→55%, health now meaningful). Anti-theater mutation check passed.
 
 **Phase 2 — Transport contract tests (LLM/Ollama) ✅ COMPLETE** (`tests/integration/test_llm_contract.py`, 8 tests)
@@ -136,8 +136,15 @@ Legend: ✅ done · 🚧 in progress · ⬜ planned
 - ✅ We **deliberately avoid a GitHub Actions PR gate** — the repo gets a high volume of external contributor PRs; PR-triggered CI would run on every one (and run untrusted code). The local hook keeps `dev`/`main` green for the maintainer's own pushes without that cost.
 - ⬜ (Optional, future) a Node-based `tsc`/`next build` check — deferred due to nvm-in-hook fragility; the pure-Python locale-parity guard already covers the known i18n break.
 
-### Result after Phases 1–5
-**192 → 320 deterministic tests** (+ 1 opt-in LLM-judge eval), **0 failures**, **coverage 54% → 69%**. Built via parallel subagents (one per phase, strict file ownership) using the `dispatching-parallel-agents` skill; integrated and re-verified together.
+**Phase 7 — SQLite persistence + tracker + encrypted-keys coverage (PRs #841 + #843 → `main`) ✅ COMPLETE**
+- ✅ The persistence layer moved from TinyDB to **SQLite (async SQLAlchemy)**; the `conftest.py::isolated_db` fixture now swaps a disposable **temp-file SQLite** DB (not TinyDB) across all router modules, and `tests/unit/test_database.py` exercises **real SQLite CRUD** (incl. `TestApplications`).
+- ✅ New tracker coverage: `tests/integration/test_applications_api.py` (CRUD, column grouping, detail tolerance for a deleted resume, bulk move/delete) and `tests/integration/test_tracker_autocreate.py` (confirming a tailoring auto-creates an `applied` card).
+- ✅ Encrypted per-provider API keys: `tests/unit/test_crypto.py` (Fernet encrypt/decrypt round-trip + masking).
+- ✅ `/status` graceful degradation (#843): `tests/integration/test_health_api.py` expanded — each check isolated, so a single failing probe yields 200 with partial/degraded state instead of 500.
+- ✅ Verify: default `uv run pytest` count is now **~444** (was ~320). `respx` still mocks the HTTP transport for `llm.py`.
+
+### Result after Phases 1–7
+**192 → ~444 deterministic tests** (+ 1 opt-in LLM-judge eval), **0 failures**. Phases 1–5 were built via parallel subagents (one per phase, strict file ownership) using the `dispatching-parallel-agents` skill; Phase 7 followed the TinyDB→SQLite migration (PRs #841 + #843).
 
 ---
 
@@ -206,5 +213,5 @@ Net: **65 → 117 frontend tests**, all green. The `pre-push` gate runs this sui
 Above the deterministic suites and the local pre-push gate sits an **agentic E2E monitor** — an opt-in, on-demand harness that drives the *real* running app (master resume → 3–4 tailored variations → PDFs), captures a durable evidence bundle (logs + every intermediate JSON + PDFs), and has a Claude Code skill judge it across three runtime jobs: **output quality**, **flow/render integrity**, and **provider reality**. It is a **report, never a gate** — it informs, never blocks a push, and is never wired into CI.
 
 - Design: `docs/superpowers/specs/2026-06-01-agentic-e2e-monitor-design.md`; plan: `docs/superpowers/plans/2026-06-01-agentic-e2e-monitor.md`; harness + how-to: `apps/backend/e2e_monitor/README.md`.
-- OSS-safe: harness deps are an optional extra (`uv sync --extra dev --extra e2e-monitor`), every move is gated behind `RM_E2E_MONITOR=1` + a configured key, and the runnable skill is gitignored (its source is the committed `e2e_monitor/AGENT_PLAYBOOK.md`). The dev's real DB is never touched (isolated `DATA_DIR`).
+- OSS-safe: harness deps are an optional extra (`uv sync --extra dev --extra e2e-monitor`), every move is gated behind `RM_E2E_MONITOR=1` + a configured key, and the runnable skill is gitignored (its source is the committed `e2e_monitor/AGENT_PLAYBOOK.md`). The dev's real SQLite DB is never touched (isolated `DATA_DIR`).
 - Run: `cd apps/backend && RM_E2E_MONITOR=1 uv run python -m e2e_monitor sweep`, then `bash e2e_monitor/install_skill.sh` and invoke the `monitor-e2e` skill for the report.

--- a/docs/agent/testing-strategy.md
+++ b/docs/agent/testing-strategy.md
@@ -43,15 +43,15 @@ Takeaway: a green checkmark here meant nothing, and a red one went unseen. That 
 | `llm.py` | 47% | 🟡 Pure helpers tested; **real request + `check_llm_health` + Ollama paths NOT** |
 | `routers/enrichment.py` | 38% | 🟡 Regenerate matching tested; rest mocked |
 | `config_cache.py` | 38% | 🔴 |
-| `database.py` | 34% | 🔴 Real DB never exercised — every integration test mocks `db` |
+| `database.py` | 34% | 🔴 Real DB not exercised *at this baseline* — integration tests mocked `db` (changed in Phases 4 & 7) |
 | `services/cover_letter.py` | 26% | 🔴 Untested |
 | `services/parser.py` | 20% | 🔴 Upload→markdown→JSON untested; even the pure date-restore is uncovered |
 | `pdf.py` (render) | 20% | 🔴 The "resume won't render" class |
 | `routers/resumes.py` | 18% | 🔴 Biggest file (1,796 LOC): tailor + PDF + CRUD — almost entirely untested |
 
-### 2.3 The structural truth about the integration tests
+### 2.3 The structural truth about the integration tests (at the 192-test baseline)
 
-Every `tests/integration/*` test patches `app.routers.<x>.db` and the LLM/parse calls. They verify **status codes, request validation, response shape, and router branch logic** (e.g. API-key masking, regenerate fallback matching). They are valuable *contract* tests. They do **not** prove the database persists, Playwright renders, markitdown parses, or any provider (Ollama included) actually responds.
+At the 192-test baseline, every `tests/integration/*` test patched `app.routers.<x>.db` and the LLM/parse calls. They verified **status codes, request validation, response shape, and router branch logic** (e.g. API-key masking, regenerate fallback matching) — valuable *contract* tests. They did **not** prove the database persists, Playwright renders, markitdown parses, or any provider (Ollama included) actually responds. *(Phases 4 & 7 below later added real-SQLite `isolated_db` persistence + pipeline/tracker integration tests.)*
 
 ---
 


### PR DESCRIPTION
## Summary
Follow-up to PRs #841/#843: the context + architecture docs still described **TinyDB** and omitted the Application Tracker and encrypted API keys. This syncs them. **Docs-only — no code changes.**

- **`.claude/CLAUDE.md`** (root) + **`apps/frontend/CLAUDE.md`** — TinyDB→SQLite; added the tracker (route, `components/tracker/`, `lib/api/tracker.ts`, i18n, local-state note) + per-provider encrypted keys; updated pytest count (~444).
- **`docs/agent/architecture/backend-guide.md` / `backend-architecture.md`** — async SQLAlchemy/SQLite facade, `models`/`db_engine`/`crypto`, the encrypted `api_keys` table + migration importer, the `/applications` router, `/status` graceful degradation.
- **`docs/agent/testing-strategy.md`** — SQLite `isolated_db` + new suites.
- **`docs/agent/apis/front-end-apis.md` / `api-flow-maps.md`** — `/applications` endpoints + per-provider encrypted `/config/api-keys` (POST) + `/status` degradation.
- **`docs/agent/scope-and-principles.md`**, **`apps/backend/e2e_monitor/README.md`** — TinyDB→SQLite wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync docs to reflect the SQLite migration, per‑provider encrypted API keys, and the new Application Tracker. Also fixes API labels, versions, and testing-baseline notes; docs-only — no code changes.

- **Refactors**
  - TinyDB → SQLite via async `SQLAlchemy`/`aiosqlite`: updated backend guides; added `models`, `db_engine`, `crypto`, one-time TinyDB→SQLite importer; encrypted `api_keys` table.
  - Application Tracker: documented `/applications` endpoints; frontend `tracker` route/components and `lib/api/tracker.ts`; i18n keys; local-state ownership note.
  - Config and status: per-provider encrypted `/config/api-keys`; `PUT /config/llm-api-key` no longer persists secrets; `/status` now degrades gracefully (200 on partial failure).
  - Testing/docs: switched to SQLite `isolated_db`; added tracker and encrypted-keys suites; default pytest count ~444; corrected `/config/api-keys` uses POST, `/health` is liveness-only, versions updated to Python 3.13+ and Next.js 16; reframed the 192-test baseline context.

<sup>Written for commit 98f24173300f9966c7bf76b699af1694cf23c1c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

