### PR TITLE
docs: fix sponsorship guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We are grateful to our sponsors who help keep this project going. If you find Re
 
 ![donate](assets/supporting_resume_matcher.png)
 
-Please read our [Sponsorship Guide]([docs/agent/80-sponsorship/sponsorship-guide.md](https://resumematcher.fyi/docs/sponsoring)) for details on how your sponsorship helps the project. You will receive a special thank you in the ReadME and on our website.
+Please read our [Sponsorship Guide](https://resumematcher.fyi/docs/sponsoring) for details on how your sponsorship helps the project. You will receive a special thank you in the README and on our website.
 
 | Platform  | Link                                   |
 |-----------|----------------------------------------|


### PR DESCRIPTION
## Summary\n- fix the malformed Sponsorship Guide Markdown link\n- standardize README capitalization\n\n## Testing\n- Not run; documentation-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken Sponsorship Guide link in the README and standardize capitalization. Replaces the malformed nested Markdown link with https://resumematcher.fyi/docs/sponsoring and updates ReadME to README.

<sup>Written for commit 7718fbaf8e372efbacfd3b98c8e4a6c8290ef36c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

