### PR TITLE
fix: restore duplicate year ranges in order

### DIFF
--- a/apps/backend/app/services/parser.py
+++ b/apps/backend/app/services/parser.py
@@ -51,19 +51,17 @@ def restore_dates_from_markdown(
     if not md_dates:
         return parsed_data
 
-    # Build a lookup: "2020 - 2021" → "Jun 2020 - Aug 2021"
-    year_to_full: dict[str, str] = {}
+    # Build a lookup: "2020 - 2021" → ["Jun 2020 - Aug 2021", ...].
+    # Keep all matches so repeated year-only entries can be restored in order.
+    year_to_full: dict[str, list[str]] = {}
     year_only_re = re.compile(r"\d{4}")
     for md_date in md_dates:
         years_in_date = year_only_re.findall(md_date)
         if years_in_date:
             # Create year-only key like "2020 - 2021" or "2023"
             year_key = " - ".join(years_in_date)
-            # Keep the first (most specific) match
-            if year_key not in year_to_full:
-                # Normalize separators
-                normalized = re.sub(r"\s*[-–—]\s*", " - ", md_date.strip())
-                year_to_full[year_key] = normalized
+            normalized = re.sub(r"\s*[-–—]\s*", " - ", md_date.strip())
+            year_to_full.setdefault(year_key, []).append(normalized)
 
     if not year_to_full:
         return parsed_data
@@ -84,8 +82,8 @@ def restore_dates_from_markdown(
             ):
                 continue
             # Try to find a matching month-inclusive date
-            if years in year_to_full:
-                entry["years"] = year_to_full[years]
+            if years in year_to_full and year_to_full[years]:
+                entry["years"] = year_to_full[years].pop(0)
                 patched += 1
 
     # Custom sections
@@ -106,8 +104,8 @@ def restore_dates_from_markdown(
                     re.IGNORECASE,
                 ):
                     continue
-                if years in year_to_full:
-                    item["years"] = year_to_full[years]
+                if years in year_to_full and year_to_full[years]:
+                    item["years"] = year_to_full[years].pop(0)
                     patched += 1
 
     if patched:

--- a/apps/backend/tests/unit/test_parser.py
+++ b/apps/backend/tests/unit/test_parser.py
@@ -37,6 +37,25 @@ class TestRestoreDatesFromMarkdown:
         result = restore_dates_from_markdown(parsed, markdown)
         assert result["education"][0]["years"] == "Jun 2023"
 
+    def test_restores_repeated_year_ranges_in_markdown_order(self):
+        parsed = {
+            "workExperience": [
+                {"title": "First", "years": "2020 - 2021"},
+                {"title": "Second", "years": "2020 - 2021"},
+            ]
+        }
+        markdown = "\n".join(
+            [
+                "First role, Jan 2020 - Mar 2021",
+                "Second role, Jun 2020 - Aug 2021",
+            ]
+        )
+
+        result = restore_dates_from_markdown(parsed, markdown)
+
+        assert result["workExperience"][0]["years"] == "Jan 2020 - Mar 2021"
+        assert result["workExperience"][1]["years"] == "Jun 2020 - Aug 2021"
+
     def test_leaves_entries_that_already_have_months(self):
         parsed = {"workExperience": [{"years": "Jan 2020 - Mar 2021"}]}
         markdown = "Jun 2020 - Aug 2021"  # same years, different months


### PR DESCRIPTION
## Summary\n- preserve multiple month-inclusive date matches for the same year range\n- restore repeated year-only entries in markdown order\n- add regression coverage for duplicate year ranges\n\n## Testing\n- uv run --with pytest python -m pytest tests/unit/test_parser.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes date restoration when multiple entries share the same year range. We now keep all month-inclusive matches and apply them in markdown order so repeated year-only entries get the correct months.

- **Bug Fixes**
  - Map each year range to a list of matches and assign them FIFO across work experience and custom sections.
  - Add regression test for duplicate year ranges; entries with existing month data remain unchanged.

<sup>Written for commit 8ecdf7470fbd72c32b23d59e1bf9c6df0e146827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

