### PR TITLE
fix: avoid reserved Windows download filenames

### DIFF
--- a/apps/frontend/lib/utils/download.ts
+++ b/apps/frontend/lib/utils/download.ts
@@ -57,6 +57,11 @@ export function sanitizeFilename(
     sanitized = chars.slice(0, 100).join('').trim();
   }
 
+  const reservedWindowsNames = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+  if (reservedWindowsNames.test(sanitized)) {
+    sanitized = `${sanitized}_`;
+  }
+
   // Add .pdf extension
   return `${sanitized}.pdf`;
 }

--- a/apps/frontend/tests/download-utils.test.ts
+++ b/apps/frontend/tests/download-utils.test.ts
@@ -192,6 +192,12 @@ describe('sanitizeFilename', () => {
   });
 
   describe('Edge cases', () => {
+    it('should avoid Windows reserved filenames', () => {
+      expect(sanitizeFilename('CON', 'test-id')).toBe('CON_.pdf');
+      expect(sanitizeFilename('aux', 'test-id')).toBe('aux_.pdf');
+      expect(sanitizeFilename('LPT1', 'test-id')).toBe('LPT1_.pdf');
+    });
+
     it('should handle title with only invalid characters', () => {
       const result = sanitizeFilename('/<>:*?"|\\', 'test-id');
       expect(result).toBe('---------.pdf');


### PR DESCRIPTION
## Summary\n- prevent sanitized PDF names from resolving to reserved Windows device names\n- add filename sanitization coverage for CON, AUX, and LPT1\n\n## Testing\n- npm test -- --run tests/download-utils.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sanitized PDF download names from resolving to Windows reserved device names by appending an underscore, so files save correctly on Windows.

- **Bug Fixes**
  - Detect `CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9` and append `_` before `.pdf`.
  - Added tests for `CON`, `aux`, and `LPT1`.

<sup>Written for commit 36b3907766a477f551f8666e7aa1cd09a5d2a911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

