### PR TITLE
fix(llm): graceful fallback when provider rejects response_format json_object (#857)

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -742,8 +742,19 @@ def _is_response_format_unsupported(error: Exception) -> bool:
     Detecting this lets ``complete_json`` fall back to prompt-only JSON mode
     instead of failing the whole request, while genuine bad requests (e.g.
     context-length errors) still propagate.
+
+    Requires both a mention of ``response_format`` *and* a rejection/validation
+    cue, so that an unrelated 400 which merely names the parameter (e.g. a
+    context-length error) does not trigger a pointless fallback retry. The cue
+    list stays broad enough to catch varied provider wording ("must be ...",
+    "not supported", "unsupported", "not allowed", "invalid") rather than any
+    single provider's exact message.
     """
-    return "response_format" in str(error).lower()
+    msg = str(error).lower()
+    if "response_format" not in msg:
+        return False
+    rejection_cues = ("must be", "not support", "unsupported", "not allowed", "invalid")
+    return any(cue in msg for cue in rejection_cues)
 
 
 FALLBACK_MAX_TOKENS = 4096

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -731,6 +731,21 @@ def _supports_json_mode(model_name: str) -> bool:
         return False
 
 
+def _is_response_format_unsupported(error: Exception) -> bool:
+    """Return True if a 400 indicates the server rejected ``response_format``.
+
+    Some OpenAI-compatible servers (e.g. LM Studio, older llama.cpp builds) are
+    reported as supporting ``response_format`` by LiteLLM's registry but reject
+    the ``{"type": "json_object"}`` we send for JSON mode, returning a 400 such
+    as ``'response_format.type' must be 'json_schema' or 'text'`` (issue #857).
+
+    Detecting this lets ``complete_json`` fall back to prompt-only JSON mode
+    instead of failing the whole request, while genuine bad requests (e.g.
+    context-length errors) still propagate.
+    """
+    return "response_format" in str(error).lower()
+
+
 FALLBACK_MAX_TOKENS = 4096
 
 def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKENS) -> int:
@@ -1145,6 +1160,29 @@ async def complete_json(
             logging.warning(f"Content extraction failed (attempt {attempt + 1}): {e}")
             if attempt < retries:
                 continue
+            raise
+
+        except litellm.BadRequestError as e:
+            # JSON-012b: some OpenAI-compatible servers (e.g. LM Studio) report
+            # response_format support via the registry but reject
+            # {"type": "json_object"} with a 400 (issue #857). The Router does
+            # not retry bad requests, so recover here by disabling JSON mode and
+            # retrying prompt-only. Unrelated 400s (e.g. context length) still
+            # propagate.
+            if (
+                use_json_mode
+                and not json_mode_failed
+                and _is_response_format_unsupported(e)
+            ):
+                json_mode_failed = True
+                logging.warning(
+                    "Provider rejected response_format for %s; falling back to "
+                    "prompt-only JSON mode (attempt %d)",
+                    model_name,
+                    attempt + 1,
+                )
+                if attempt < retries:
+                    continue
             raise
 
         except Exception:

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -363,13 +363,60 @@ class TestCompleteJsonFallback:
     @patch("app.llm.get_router")
     @patch("app.llm.get_model_name")
     @patch("app.llm._supports_json_mode")
+    async def test_json_mode_fallback_on_varied_rejection_wording(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """The fallback must trigger across provider wording, not just LM Studio's.
+
+        Guards against narrowing the heuristic so much that a genuine
+        response_format rejection phrased as "not supported" is missed (which
+        would re-introduce issue #857 for that provider).
+        """
+        import litellm
+
+        mock_supports_json.return_value = True
+        mock_get_name.return_value = "openai/some-local-model"
+
+        rejection = litellm.BadRequestError(
+            "OpenAIException - Error code: 400 - "
+            "{'error': 'response_format json_object is not supported by this model'}",
+            model="openai/some-local-model",
+            llm_provider="openai",
+        )
+
+        good_choice = MagicMock()
+        good_choice.message.content = '{"answer": "ok"}'
+        good_response = MagicMock()
+        good_response.choices = [good_choice]
+
+        router = MagicMock()
+        router.acompletion = AsyncMock(side_effect=[rejection, good_response])
+        config = MagicMock()
+        config.provider = "openai_compatible"
+        config.reasoning_effort = None
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json(
+            prompt="Test prompt", schema_type="resume", retries=2
+        )
+
+        assert result == {"answer": "ok"}
+        assert "response_format" not in router.acompletion.call_args_list[1].kwargs
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
     async def test_unrelated_bad_request_is_not_swallowed(
         self, mock_supports_json, mock_get_name, mock_get_router
     ):
         """A 400 unrelated to response_format must still propagate, not retry.
 
-        Guards against the fix masking genuine bad requests (e.g. context length
-        exceeded) by blindly retrying without JSON mode.
+        Uses a context-length error that *also names* response_format — the
+        false-positive case raised in review (cubic/Kilo). Dropping JSON mode
+        would not help, so the fallback must NOT fire and the error must surface.
         """
         import litellm
 
@@ -377,8 +424,8 @@ class TestCompleteJsonFallback:
         mock_get_name.return_value = "openai/gpt-4o"
 
         rejection = litellm.BadRequestError(
-            "OpenAIException - Error code: 400 - "
-            "{'error': 'maximum context length exceeded'}",
+            "OpenAIException - Error code: 400 - {'error': 'maximum context "
+            "length exceeded while using response_format=json_object'}",
             model="openai/gpt-4o",
             llm_provider="openai",
         )

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -302,6 +302,102 @@ class TestCompleteJsonFallback:
         assert calls[0].kwargs.get("response_format") == {"type": "json_object"}
         assert "response_format" not in calls[1].kwargs
 
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
+    async def test_json_mode_fallback_on_response_format_rejection(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """Issue #857: an OpenAI-compatible server (e.g. LM Studio) rejects
+        ``response_format={"type": "json_object"}`` with a 400.
+
+        First call: JSON mode enabled → server raises ``BadRequestError``
+          ("'response_format.type' must be 'json_schema' or 'text'").
+        Second call: JSON mode disabled → returns valid JSON → success.
+
+        Before the fix the 400 was re-raised immediately (the existing fallback
+        only handled malformed JSON, not rejection of the parameter itself),
+        so the wizard turn failed with a 500.
+        """
+        import litellm
+
+        mock_supports_json.return_value = True
+        mock_get_name.return_value = "openai/gemma-4-e2b"
+
+        # First call raises the exact LM Studio rejection over the wire.
+        rejection = litellm.BadRequestError(
+            "OpenAIException - Error code: 400 - "
+            "{'error': \"'response_format.type' must be 'json_schema' or 'text'\"}",
+            model="openai/gemma-4-e2b",
+            llm_provider="openai",
+        )
+
+        good_choice = MagicMock()
+        good_choice.message.content = '{"answer": "ok"}'
+        good_response = MagicMock()
+        good_response.choices = [good_choice]
+
+        router = MagicMock()
+        router.acompletion = AsyncMock(side_effect=[rejection, good_response])
+        config = MagicMock()
+        config.provider = "openai_compatible"
+        config.reasoning_effort = None
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json(
+            prompt="Test prompt",
+            schema_type="resume",
+            retries=2,
+        )
+
+        assert result == {"answer": "ok"}
+        # JSON mode was sent on the first (rejected) call, dropped on the retry.
+        calls = router.acompletion.call_args_list
+        assert calls[0].kwargs.get("response_format") == {"type": "json_object"}
+        assert "response_format" not in calls[1].kwargs
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
+    async def test_unrelated_bad_request_is_not_swallowed(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """A 400 unrelated to response_format must still propagate, not retry.
+
+        Guards against the fix masking genuine bad requests (e.g. context length
+        exceeded) by blindly retrying without JSON mode.
+        """
+        import litellm
+
+        mock_supports_json.return_value = True
+        mock_get_name.return_value = "openai/gpt-4o"
+
+        rejection = litellm.BadRequestError(
+            "OpenAIException - Error code: 400 - "
+            "{'error': 'maximum context length exceeded'}",
+            model="openai/gpt-4o",
+            llm_provider="openai",
+        )
+
+        router = MagicMock()
+        router.acompletion = AsyncMock(side_effect=rejection)
+        config = MagicMock()
+        config.provider = "openai"
+        config.reasoning_effort = None
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        with pytest.raises(litellm.BadRequestError):
+            await complete_json(prompt="Test prompt", schema_type="resume", retries=2)
+
+        # No retry: an unrelated 400 fails fast (Router already handles retries).
+        assert router.acompletion.await_count == 1
+
 
 # ---------------------------------------------------------------------------
 # complete() dynamic timeout


### PR DESCRIPTION
Fixes #857

## Problem

With **LM Studio** (and similar OpenAI-compatible servers) as the provider, the resume wizard fails with a 500 on every turn:

```
litellm.BadRequestError: OpenAIException - Error code: 400 -
{'error': "'response_format.type' must be 'json_schema' or 'text'"}
```

LM Studio only accepts `response_format.type` of `json_schema` or `text`, but Resume Matcher sends `json_object`.

## Root cause

The wizard calls `complete_json` (`app/llm.py`). That function:

1. `_supports_json_mode()` returns `True` (LiteLLM's registry reports `response_format` support for the `openai/`-prefixed model), so it sends `response_format={"type": "json_object"}` (llm.py:1080).
2. LM Studio rejects it with a **400 `BadRequestError`**.
3. The existing JSON-mode fallback (`json_mode_failed`) **only triggers inside `except json.JSONDecodeError`** — i.e. when the server *accepts* the param but returns malformed JSON. A 400 that *rejects the parameter itself* is neither a `JSONDecodeError` nor a `ValueError`, so it fell through to the generic `except Exception`, which re-raises immediately. The Router's retry policy gives bad-requests 0 retries → hard 500.

In short: the code anticipated *"registry says JSON-mode works but the output is bad"* but not *"registry says JSON-mode works but the server rejects the parameter."*

## Fix

`app/llm.py`:
- New helper `_is_response_format_unsupported(error)` — detects a `response_format` rejection from the error message.
- New `except litellm.BadRequestError` handler in `complete_json` (before the generic `except Exception`): when JSON mode is active and the 400 is a `response_format` rejection, disable JSON mode and retry **prompt-only** (the system prompt already instructs "respond with valid JSON only"). Unrelated 400s (e.g. context-length) still propagate and fail fast.

This is provider-agnostic (works for any server that rejects `json_object`) and composes with the existing malformed-JSON fallback. It mirrors the existing **JSON-012** design intent for registry-vs-reality mismatches, extending it from the response *body* to the request *parameter*.

## Tests (TDD — written to fail first, then fixed)
- `test_json_mode_fallback_on_response_format_rejection` — first call raises the exact LM Studio 400, retry succeeds prompt-only; asserts `response_format` is sent on call 1 and dropped on call 2.
- `test_unrelated_bad_request_is_not_swallowed` — a context-length 400 still raises and is **not** retried (guards against masking genuine bad requests).

## Verification
- `uv run pytest` → **484 passed**, 1 deselected (eval).
- New `_is_response_format_unsupported` has full type hints.
- No schema/prompt change; the existing "JSON-mode → prompt-only fallback" behavior described in the backend docs still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gracefully falls back when providers reject `response_format: json_object`, preventing 500s in the resume wizard with LM Studio and other OpenAI-compatible servers (fixes #857).

- **Bug Fixes**
  - In `complete_json`, handle `litellm.BadRequestError` on `response_format={"type": "json_object"}` rejections by disabling JSON mode and retrying; unrelated 400s still fail fast.
  - Tightened `_is_response_format_unsupported()` to require a `response_format` mention plus a rejection cue (e.g., "must be", "not support(ed)", "unsupported", "not allowed", "invalid") to avoid false positives and catch varied provider wording.
  - Tests cover the fallback, varied rejection messages, and that context-length 400s are not retried.

<sup>Written for commit 8ef98b3eb55797d445f5f670ba3942c1b937ee03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

