### PR TITLE
fix(resumes): make "Delete & Start Over" work when a resume fails processing

### DIFF
--- a/apps/frontend/app/(default)/resumes/[id]/page.tsx
+++ b/apps/frontend/app/(default)/resumes/[id]/page.tsx
@@ -213,10 +213,11 @@ export default function ResumeViewerPage() {
     setShowDownloadSuccessDialog(false);
   };
 
-  // Delete-related dialogs are rendered in every return branch (including the
-  // loading/error early returns) so the "Delete & Start Over" recovery action
-  // works when a resume fails processing — otherwise the confirm dialog would
-  // never mount and the delete request would never be sent.
+  // Delete-related dialogs, shared by the failed-processing error branch and the
+  // main viewer branch so the "Delete & Start Over" recovery action works in the
+  // error state. Previously these lived only in the main branch, so on the error
+  // path the confirm dialog never mounted and the delete request was never sent.
+  // (The loading branch omits them — it has no delete affordance.)
   const deleteDialogs = (
     <>
       <ConfirmDialog

--- a/apps/frontend/app/(default)/resumes/[id]/page.tsx
+++ b/apps/frontend/app/(default)/resumes/[id]/page.tsx
@@ -213,6 +213,59 @@ export default function ResumeViewerPage() {
     setShowDownloadSuccessDialog(false);
   };
 
+  // Delete-related dialogs are rendered in every return branch (including the
+  // loading/error early returns) so the "Delete & Start Over" recovery action
+  // works when a resume fails processing — otherwise the confirm dialog would
+  // never mount and the delete request would never be sent.
+  const deleteDialogs = (
+    <>
+      <ConfirmDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        title={
+          isMasterResume ? t('confirmations.deleteMasterResumeTitle') : t('dashboard.deleteResume')
+        }
+        description={
+          isMasterResume
+            ? t('confirmations.deleteMasterResumeDescription')
+            : t('confirmations.deleteResumeFromSystemDescription')
+        }
+        confirmLabel={t('confirmations.deleteResumeConfirmLabel')}
+        cancelLabel={t('confirmations.keepResumeCancelLabel')}
+        onConfirm={handleDeleteResume}
+        variant="danger"
+      />
+
+      <ConfirmDialog
+        open={showDeleteSuccessDialog}
+        onOpenChange={setShowDeleteSuccessDialog}
+        title={t('resumeViewer.deletedTitle')}
+        description={
+          isMasterResume
+            ? t('resumeViewer.deletedDescriptionMaster')
+            : t('resumeViewer.deletedDescriptionRegular')
+        }
+        confirmLabel={t('resumeViewer.returnToDashboard')}
+        onConfirm={handleDeleteSuccessConfirm}
+        variant="success"
+        showCancelButton={false}
+      />
+
+      {deleteError && (
+        <ConfirmDialog
+          open={!!deleteError}
+          onOpenChange={() => setDeleteError(null)}
+          title={t('resumeViewer.deleteFailedTitle')}
+          description={deleteError}
+          confirmLabel={t('common.ok')}
+          onConfirm={() => setDeleteError(null)}
+          variant="danger"
+          showCancelButton={false}
+        />
+      )}
+    </>
+  );
+
   if (loading) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center bg-background">
@@ -229,56 +282,59 @@ export default function ResumeViewerPage() {
     const isFailed = processingStatus === 'failed';
 
     return (
-      <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4">
-        <div
-          className={`border p-6 text-center max-w-md shadow-sw-default ${
-            isProcessing
-              ? 'bg-blue-50 border-blue-200'
-              : isFailed
-                ? 'bg-orange-50 border-orange-200'
-                : 'bg-red-50 border-red-200'
-          }`}
-        >
-          <div className="flex justify-center mb-4">
-            {isProcessing ? (
-              <Loader2 className="w-8 h-8 animate-spin text-blue-700" />
-            ) : isFailed ? (
-              <AlertCircle className="w-8 h-8 text-orange-600" />
-            ) : (
-              <AlertCircle className="w-8 h-8 text-red-600" />
-            )}
-          </div>
-          <p
-            className={`font-bold mb-4 ${
-              isProcessing ? 'text-blue-700' : isFailed ? 'text-orange-700' : 'text-red-700'
+      <>
+        <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4">
+          <div
+            className={`border p-6 text-center max-w-md shadow-sw-default ${
+              isProcessing
+                ? 'bg-blue-50 border-blue-200'
+                : isFailed
+                  ? 'bg-orange-50 border-orange-200'
+                  : 'bg-red-50 border-red-200'
             }`}
           >
-            {error || t('resumeViewer.resumeNotFound')}
-          </p>
-          <div className="flex flex-col gap-2">
-            {isFailed && (
-              <>
-                <Button onClick={handleRetryProcessing} disabled={isRetrying}>
-                  {isRetrying ? (
-                    <>
-                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                      {t('common.processing')}
-                    </>
-                  ) : (
-                    t('resumeViewer.retryProcessing')
-                  )}
-                </Button>
-                <Button variant="destructive" onClick={() => setShowDeleteDialog(true)}>
-                  {t('resumeViewer.deleteAndStartOver')}
-                </Button>
-              </>
-            )}
-            <Button variant="outline" onClick={() => router.push('/dashboard')}>
-              {t('resumeViewer.returnToDashboard')}
-            </Button>
+            <div className="flex justify-center mb-4">
+              {isProcessing ? (
+                <Loader2 className="w-8 h-8 animate-spin text-blue-700" />
+              ) : isFailed ? (
+                <AlertCircle className="w-8 h-8 text-orange-600" />
+              ) : (
+                <AlertCircle className="w-8 h-8 text-red-600" />
+              )}
+            </div>
+            <p
+              className={`font-bold mb-4 ${
+                isProcessing ? 'text-blue-700' : isFailed ? 'text-orange-700' : 'text-red-700'
+              }`}
+            >
+              {error || t('resumeViewer.resumeNotFound')}
+            </p>
+            <div className="flex flex-col gap-2">
+              {isFailed && (
+                <>
+                  <Button onClick={handleRetryProcessing} disabled={isRetrying}>
+                    {isRetrying ? (
+                      <>
+                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        {t('common.processing')}
+                      </>
+                    ) : (
+                      t('resumeViewer.retryProcessing')
+                    )}
+                  </Button>
+                  <Button variant="destructive" onClick={() => setShowDeleteDialog(true)}>
+                    {t('resumeViewer.deleteAndStartOver')}
+                  </Button>
+                </>
+              )}
+              <Button variant="outline" onClick={() => router.push('/dashboard')}>
+                {t('resumeViewer.returnToDashboard')}
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
+        {deleteDialogs}
+      </>
     );
   }
 
@@ -382,37 +438,7 @@ export default function ResumeViewerPage() {
         </div>
       </div>
 
-      <ConfirmDialog
-        open={showDeleteDialog}
-        onOpenChange={setShowDeleteDialog}
-        title={
-          isMasterResume ? t('confirmations.deleteMasterResumeTitle') : t('dashboard.deleteResume')
-        }
-        description={
-          isMasterResume
-            ? t('confirmations.deleteMasterResumeDescription')
-            : t('confirmations.deleteResumeFromSystemDescription')
-        }
-        confirmLabel={t('confirmations.deleteResumeConfirmLabel')}
-        cancelLabel={t('confirmations.keepResumeCancelLabel')}
-        onConfirm={handleDeleteResume}
-        variant="danger"
-      />
-
-      <ConfirmDialog
-        open={showDeleteSuccessDialog}
-        onOpenChange={setShowDeleteSuccessDialog}
-        title={t('resumeViewer.deletedTitle')}
-        description={
-          isMasterResume
-            ? t('resumeViewer.deletedDescriptionMaster')
-            : t('resumeViewer.deletedDescriptionRegular')
-        }
-        confirmLabel={t('resumeViewer.returnToDashboard')}
-        onConfirm={handleDeleteSuccessConfirm}
-        variant="success"
-        showCancelButton={false}
-      />
+      {deleteDialogs}
 
       <ConfirmDialog
         open={showDownloadSuccessDialog}
@@ -424,19 +450,6 @@ export default function ResumeViewerPage() {
         variant="success"
         showCancelButton={false}
       />
-
-      {deleteError && (
-        <ConfirmDialog
-          open={!!deleteError}
-          onOpenChange={() => setDeleteError(null)}
-          title={t('resumeViewer.deleteFailedTitle')}
-          description={deleteError}
-          confirmLabel={t('common.ok')}
-          onConfirm={() => setDeleteError(null)}
-          variant="danger"
-          showCancelButton={false}
-        />
-      )}
 
       {/* Enrichment Modal - Only for master resume */}
       {isMasterResume && (

--- a/apps/frontend/tests/resume-viewer-delete.test.tsx
+++ b/apps/frontend/tests/resume-viewer-delete.test.tsx
@@ -43,8 +43,8 @@ describe('ResumeViewerPage — delete from the processing-failed error state', (
     mockedFetchResume.mockResolvedValue({
       title: 'Broken Resume',
       raw_resume: { processing_status: 'failed' },
-    } as never);
-    mockedDeleteResume.mockResolvedValue({ message: 'deleted' } as never);
+    } as Awaited<ReturnType<typeof fetchResume>>);
+    mockedDeleteResume.mockResolvedValue(undefined);
 
     render(<ResumeViewerPage />);
 

--- a/apps/frontend/tests/resume-viewer-delete.test.tsx
+++ b/apps/frontend/tests/resume-viewer-delete.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import ResumeViewerPage from '@/app/(default)/resumes/[id]/page';
+import { fetchResume, deleteResume } from '@/lib/api/resume';
+
+const push = vi.fn();
+const decrementResumes = vi.fn();
+const setHasMasterResume = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+  useParams: () => ({ id: 'resume-123' }),
+}));
+vi.mock('@/lib/i18n', () => ({ useTranslations: () => ({ t: (key: string) => key }) }));
+vi.mock('@/lib/context/status-cache', () => ({
+  useStatusCache: () => ({ decrementResumes, setHasMasterResume }),
+}));
+vi.mock('@/lib/context/language-context', () => ({
+  useLanguage: () => ({ uiLanguage: 'en' }),
+}));
+vi.mock('@/components/enrichment/enrichment-modal', () => ({ EnrichmentModal: () => null }));
+vi.mock('@/components/dashboard/resume-component', () => ({ default: () => null }));
+vi.mock('@/lib/api/resume', () => ({
+  fetchResume: vi.fn(),
+  deleteResume: vi.fn(),
+  retryProcessing: vi.fn(),
+  renameResume: vi.fn(),
+  downloadResumePdf: vi.fn(),
+  getResumePdfUrl: vi.fn(),
+}));
+
+const mockedFetchResume = vi.mocked(fetchResume);
+const mockedDeleteResume = vi.mocked(deleteResume);
+
+describe('ResumeViewerPage — delete from the processing-failed error state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('opens the confirm dialog and deletes the resume when processing has failed', async () => {
+    // A resume whose processing failed: no processed_resume, status "failed".
+    mockedFetchResume.mockResolvedValue({
+      title: 'Broken Resume',
+      raw_resume: { processing_status: 'failed' },
+    } as never);
+    mockedDeleteResume.mockResolvedValue({ message: 'deleted' } as never);
+
+    render(<ResumeViewerPage />);
+
+    // The error card for a failed resume renders with the recovery actions.
+    expect(await screen.findByText('resumeViewer.errors.processingFailed')).toBeInTheDocument();
+
+    // Click "Delete & Start Over".
+    fireEvent.click(screen.getByRole('button', { name: 'resumeViewer.deleteAndStartOver' }));
+
+    // The confirmation dialog must actually mount in the error state (regression).
+    const confirmButton = await screen.findByRole('button', {
+      name: 'confirmations.deleteResumeConfirmLabel',
+    });
+    fireEvent.click(confirmButton);
+
+    // The DELETE request is dispatched to the backend and the cache is updated.
+    await waitFor(() => {
+      expect(mockedDeleteResume).toHaveBeenCalledWith('resume-123');
+      expect(decrementResumes).toHaveBeenCalledTimes(1);
+    });
+
+    // The success dialog appears and routes back to the dashboard. Scope to the
+    // dialog because the error card also carries a "return to dashboard" button.
+    await screen.findByText('resumeViewer.deletedTitle');
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'resumeViewer.returnToDashboard' }));
+    expect(push).toHaveBeenCalledWith('/dashboard');
+  });
+});


### PR DESCRIPTION
## Problem

When a resume fails processing, the resume viewer (`/resumes/[id]`) shows an error card with **Retry Processing** / **Delete & Start Over** / **Return to Dashboard**. Clicking **Delete & Start Over** does nothing — the resume is never deleted.

The user's evidence made this obvious: the backend logs during the repro showed **only `GET` requests, never a `DELETE`**. The delete request was never being sent.

## Root cause

`ResumeViewerPage` takes an **early return** for the error state (`if (error || !resumeData)`), which renders the error card. But the `<ConfirmDialog>` bound to `showDeleteDialog` — whose `onConfirm={handleDeleteResume}` is what actually calls `deleteResume()` / `DELETE /{resume_id}` — was rendered **only in the main (success) render branch**, which is unreachable once the error card returns early.

So the chain broke:
1. Click "Delete & Start Over" → `setShowDeleteDialog(true)` ✅
2. Re-render → still the error early return, which contained **no** `ConfirmDialog` ❌
3. Dialog never mounts → `handleDeleteResume` never runs → **no `DELETE` reaches the backend**

Retry / Return to Dashboard worked in that same card because they call their handlers directly (no dialog).

## Fix (option A)

Extract the three delete-related dialogs (confirm, success, failure) into a shared `deleteDialogs` fragment and render it in **both** the error branch and the main branch, so the recovery action — including the "are you sure" confirmation and the success/failure follow-ups — works in every state.

## Testing

- New component test `tests/resume-viewer-delete.test.tsx`: reproduces the failed-processing state, clicks "Delete & Start Over", and asserts the confirm dialog mounts, `deleteResume` is dispatched with the resume id, the cache counter decrements, and the success dialog routes back to the dashboard. Verified it fails on the pre-fix code and passes after.
- Full frontend suite green: **180 passed (25 files)**.
- `tsc --noEmit` clean; `eslint` clean; touched files pass `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Delete & Start Over" action on failed resume processing so it actually deletes the resume and routes back to the dashboard. The delete confirm/success/error dialogs now render in both the error and main branches.

- **Bug Fixes**
  - Render a shared `deleteDialogs` fragment in the error and main branches so the confirm dialog mounts and the `DELETE` request is sent from the error state; the loading branch intentionally omits them.
  - Added a component test that reproduces the failed state, verifies the confirm dialog, dispatches `deleteResume`, updates the cache, and navigates to `/dashboard`; aligned test mocks with real API types.

<sup>Written for commit 55e19f9cf5ef7ce2a8172b21675bd37687ca3759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

