### PR TITLE
fix(builder): persist Compact Mode and Contact Icons toggles across sessions

### DIFF
--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -125,6 +125,7 @@ const ResumeBuilderContent = () => {
   const [isDownloading, setIsDownloading] = useState(false);
   const [, setLoadingState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
   const [templateSettings, setTemplateSettings] = useState<TemplateSettings>(() => {
+    if (typeof window === 'undefined') return DEFAULT_TEMPLATE_SETTINGS;
     try {
       const saved = localStorage.getItem(SETTINGS_STORAGE_KEY);
       if (saved) {

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -124,8 +124,24 @@ const ResumeBuilderContent = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [, setLoadingState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
-  const [templateSettings, setTemplateSettings] =
-    useState<TemplateSettings>(DEFAULT_TEMPLATE_SETTINGS);
+  const [templateSettings, setTemplateSettings] = useState<TemplateSettings>(() => {
+    try {
+      const saved = localStorage.getItem(SETTINGS_STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        return {
+          ...DEFAULT_TEMPLATE_SETTINGS,
+          ...parsed,
+          margins: { ...DEFAULT_TEMPLATE_SETTINGS.margins, ...parsed.margins },
+          spacing: { ...DEFAULT_TEMPLATE_SETTINGS.spacing, ...parsed.spacing },
+          fontSize: { ...DEFAULT_TEMPLATE_SETTINGS.fontSize, ...parsed.fontSize },
+        };
+      }
+    } catch {
+      // fall through to defaults
+    }
+    return DEFAULT_TEMPLATE_SETTINGS;
+  });
   const { improvedData } = useResumePreview();
   const improvedPreview = improvedData?.data?.resume_preview;
   const improvedCoverLetter = improvedData?.data?.cover_letter;
@@ -262,25 +278,6 @@ const ResumeBuilderContent = () => {
     () => withLocalizedDefaultSections(resumeData, t),
     [resumeData, t]
   );
-
-  // Load template settings from localStorage on mount
-  useEffect(() => {
-    const savedSettings = localStorage.getItem(SETTINGS_STORAGE_KEY);
-    if (savedSettings) {
-      try {
-        const parsed = JSON.parse(savedSettings);
-        setTemplateSettings({
-          ...DEFAULT_TEMPLATE_SETTINGS,
-          ...parsed,
-          margins: { ...DEFAULT_TEMPLATE_SETTINGS.margins, ...parsed.margins },
-          spacing: { ...DEFAULT_TEMPLATE_SETTINGS.spacing, ...parsed.spacing },
-          fontSize: { ...DEFAULT_TEMPLATE_SETTINGS.fontSize, ...parsed.fontSize },
-        });
-      } catch {
-        // Use defaults
-      }
-    }
-  }, []);
 
   // Save template settings to localStorage when they change
   useEffect(() => {


### PR DESCRIPTION
## Summary

Closes #850

**Root cause:** `templateSettings` was initialised with `DEFAULT_TEMPLATE_SETTINGS` synchronously, and a `useEffect` was used to load the saved value from `localStorage` on mount. React runs effects _after_ the render, so the sequence on every component mount was:

1. Render with `DEFAULT_TEMPLATE_SETTINGS` (`compactMode: false`, `showContactIcons: false`)
2. Load effect reads saved settings from `localStorage` → schedules `setTemplateSettings(saved)`
3. Save effect fires (from render 1) → **writes `DEFAULT_TEMPLATE_SETTINGS` back to `localStorage`**, clobbering the user's saved preferences
4. Re-render with the correct saved values (from step 2)
5. Save effect fires again → restores correct values to `localStorage`

In React Strict Mode (used in development) and under specific navigation timing, step 3 can overwrite the user's stored preferences before step 5 restores them, causing the toggles to reset to their defaults on re-entry to edit mode.

**Fix:** Replace the load `useEffect` with a `useState` lazy initialiser. The initialiser runs synchronously before the first render, so `templateSettings` is already correct on render 1 — no race condition, no clobber. The save effect is left unchanged.

```tsx
// Before
const [templateSettings, setTemplateSettings] = useState<TemplateSettings>(DEFAULT_TEMPLATE_SETTINGS);
// + useEffect that reads localStorage and calls setTemplateSettings

// After
const [templateSettings, setTemplateSettings] = useState<TemplateSettings>(() => {
  try {
    const saved = localStorage.getItem(SETTINGS_STORAGE_KEY);
    if (saved) {
      const parsed = JSON.parse(saved);
      return { ...DEFAULT_TEMPLATE_SETTINGS, ...parsed, margins: {...}, spacing: {...}, fontSize: {...} };
    }
  } catch {}
  return DEFAULT_TEMPLATE_SETTINGS;
});
```

## Test plan

- [ ] Open a resume in the builder
- [ ] Toggle **Compact Mode** ON
- [ ] Toggle **Contact Icons** ON
- [ ] Click Save
- [ ] Navigate away (e.g. back to dashboard)
- [ ] Re-enter edit mode for the same resume — both toggles should still be ON
- [ ] Reload the page — toggles should persist across full page reloads
- [ ] Verify other formatting controls (template, page size, margins, spacing, fonts) still persist correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Compact Mode and Contact Icons across sessions by initializing `templateSettings` from `localStorage` before first render. Fixes a race condition that reset user preferences in React Strict Mode. Addresses Linear issue #850.

- **Bug Fixes**
  - Replaced `useEffect` loader with a `useState` lazy initializer to read `localStorage` synchronously.
  - Added an SSR guard in the initializer to return defaults when `window` is undefined.
  - Prevented defaults from overwriting saved values; kept the save effect unchanged.
  - Merged saved values with `DEFAULT_TEMPLATE_SETTINGS` for margins, spacing, and fontSize to preserve existing formatting.

<sup>Written for commit 9f673efc0394d295f3746a2d0ff64b356c9d46ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

