### PR TITLE
fix(resume): render skills/languages/certs/awards as individual tags, not a continuous string

### DIFF
--- a/apps/frontend/components/resume/resume-modern.tsx
+++ b/apps/frontend/components/resume/resume-modern.tsx
@@ -409,27 +409,43 @@ const AdditionalSection: React.FC<{
       <h3 className={styles['section-title-accent']}>{displayName}</h3>
       <div className={`${baseStyles['resume-stack']} ${baseStyles['resume-text-sm']}`}>
         {technicalSkills.length > 0 && (
-          <div className="flex">
+          <div className="flex items-start">
             <span className="font-bold w-32 shrink-0">{mergedLabels.technicalSkills}</span>
-            <span>{technicalSkills.join(', ')}</span>
+            <div className="flex flex-wrap gap-1">
+              {technicalSkills.map((skill, index) => (
+                <span key={index} className={baseStyles['resume-skill-pill']}>{skill}</span>
+              ))}
+            </div>
           </div>
         )}
         {languages.length > 0 && (
-          <div className="flex">
+          <div className="flex items-start">
             <span className="font-bold w-32 shrink-0">{mergedLabels.languages}</span>
-            <span>{languages.join(', ')}</span>
+            <div className="flex flex-wrap gap-1">
+              {languages.map((lang, index) => (
+                <span key={index} className={baseStyles['resume-skill-pill']}>{lang}</span>
+              ))}
+            </div>
           </div>
         )}
         {certificationsTraining.length > 0 && (
-          <div className="flex">
+          <div className="flex items-start">
             <span className="font-bold w-32 shrink-0">{mergedLabels.certifications}</span>
-            <span>{certificationsTraining.join(', ')}</span>
+            <div className="flex flex-wrap gap-1">
+              {certificationsTraining.map((cert, index) => (
+                <span key={index} className={baseStyles['resume-skill-pill']}>{cert}</span>
+              ))}
+            </div>
           </div>
         )}
         {awards.length > 0 && (
-          <div className="flex">
+          <div className="flex items-start">
             <span className="font-bold w-32 shrink-0">{mergedLabels.awards}</span>
-            <span>{awards.join(', ')}</span>
+            <div className="flex flex-wrap gap-1">
+              {awards.map((award, index) => (
+                <span key={index} className={baseStyles['resume-skill-pill']}>{award}</span>
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/apps/frontend/components/resume/resume-single-column.tsx
+++ b/apps/frontend/components/resume/resume-single-column.tsx
@@ -407,27 +407,43 @@ const AdditionalSection: React.FC<{
       <h3 className={baseStyles['resume-section-title']}>{displayName}</h3>
       <div className={`${baseStyles['resume-stack']} ${baseStyles['resume-text-sm']}`}>
         {technicalSkills.length > 0 && (
-          <div className="flex">
+          <div className="flex items-start">
             <span className="font-bold w-32 shrink-0">{mergedLabels.technicalSkills}</span>
-            <span>{technicalSkills.join(', ')}</span>
+            <div className="flex flex-wrap gap-1">
+              {technicalSkills.map((skill, index) => (
+                <span key={index} className={baseStyles['resume-skill-pill']}>{skill}</span>
+              ))}
+            </div>
           </div>
         )}
         {languages.length > 0 && (
-          <div className="flex">
+          <div className="flex items-start">
             <span className="font-bold w-32 shrink-0">{mergedLabels.languages}</span>
-            <span>{languages.join(', ')}</span>
+            <div className="flex flex-wrap gap-1">
+              {languages.map((lang, index) => (
+                <span key={index} className={baseStyles['resume-skill-pill']}>{lang}</span>
+              ))}
+            </div>
           </div>
         )}
         {certificationsTraining.length > 0 && (
-          <div className="flex">
+          <div className="flex items-start">
             <span className="font-bold w-32 shrink-0">{mergedLabels.certifications}</span>
-            <span>{certificationsTraining.join(', ')}</span>
+            <div className="flex flex-wrap gap-1">
+              {certificationsTraining.map((cert, index) => (
+                <span key={index} className={baseStyles['resume-skill-pill']}>{cert}</span>
+              ))}
+            </div>
           </div>
         )}
         {awards.length > 0 && (
-          <div className="flex">
+          <div className="flex items-start">
             <span className="font-bold w-32 shrink-0">{mergedLabels.awards}</span>
-            <span>{awards.join(', ')}</span>
+            <div className="flex flex-wrap gap-1">
+              {awards.map((award, index) => (
+                <span key={index} className={baseStyles['resume-skill-pill']}>{award}</span>
+              ))}
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Closes #851

**Root cause:** In the `AdditionalSection` of `resume-single-column` and `resume-modern` templates, all items in the Technical Skills, Languages, Certifications, and Awards fields were joined into a single inline string with `Array.join(', ')`. When items were stored correctly as separate array entries (e.g. `['JavaScript', 'Python', 'React']`) the result was `JavaScript, Python, React` — readable, but visually flat. When items were stored as a single string (which happened before the #763 textarea fix), the result was `JavaScript Python React` with no visual separation at all.

**Fix:** Replace `join(', ')` with individual `<span>` elements using the existing `resume-skill-pill` CSS class and a wrapping flex container. This:
- Renders each item as a distinct visual tag, matching the approach used in the Swiss Two-Column and Modern Two-Column templates
- Makes it immediately clear that each entry is a separate item regardless of how many there are
- Uses the existing `resume-skill-pill` class — no new CSS introduced
- Applies consistently to all four additional info fields (skills, languages, certifications, awards)

**Before:** `JavaScript Python React` (or at best `JavaScript, Python, React` as one run of text)

**After:** `[JavaScript] [Python] [React]` (pill tags, wrapping when needed)

## Test plan

- [ ] Open a resume in the builder with skills/languages/certifications/awards filled in
- [ ] Switch to **Swiss Single Column** template — verify each item appears as a separate pill tag
- [ ] Switch to **Modern** template — verify same pill rendering
- [ ] Verify pills wrap correctly when there are many skills (e.g. 10+)
- [ ] Verify empty lines from the textarea (blank entries in array) are NOT rendered as pills
- [ ] Compare rendering against the Swiss Two-Column and Modern Two-Column templates for visual consistency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render skills, languages, certifications, and awards as individual pill tags in the Modern and Swiss Single Column resume templates. This improves readability and matches the two-column templates.

- **Bug Fixes**
  - Replaced comma-joined strings with per-item span tags styled with `resume-skill-pill` in a flex wrap container.
  - Applied to AdditionalSection in resume-modern and resume-single-column, covering all four fields.

<sup>Written for commit 611993639fce82a5fedc6a7f63d07c4254b8d4c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

