### PR TITLE
Stabilize DnD context ids to avoid hydration mismatch

### DIFF
--- a/apps/frontend/components/builder/forms/education-form.tsx
+++ b/apps/frontend/components/builder/forms/education-form.tsx
@@ -114,7 +114,12 @@ export const EducationForm: React.FC<EducationFormProps> = ({ data, onChange }) 
           </Button>
         </div>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <DndContext
+          id="education-items"
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
           <SortableContext
             items={data.map((item) => item.id)}
             strategy={verticalListSortingStrategy}

--- a/apps/frontend/components/builder/forms/experience-form.tsx
+++ b/apps/frontend/components/builder/forms/experience-form.tsx
@@ -164,7 +164,12 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
           </Button>
         </div>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <DndContext
+          id="experience-items"
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
           <SortableContext
             items={data.map((item) => item.id)}
             strategy={verticalListSortingStrategy}

--- a/apps/frontend/components/builder/resume-form.tsx
+++ b/apps/frontend/components/builder/resume-form.tsx
@@ -376,7 +376,12 @@ export const ResumeForm: React.FC<ResumeFormProps> = ({ resumeData, onUpdate }) 
   };
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+    <DndContext
+      id="resume-sections"
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
       <SortableContext
         items={sortedAllSections.map((s) => s.id)}
         strategy={verticalListSortingStrategy}


### PR DESCRIPTION
## Summary

This PR adds stable `DndContext` ids for the resume builder drag-and-drop areas to avoid server/client hydration mismatches in Next.js.

## Related Issue

Closes #880

## Changes

- Add an explicit `id` to the resume section `DndContext`.
- Add an explicit `id` to the education item `DndContext`.
- Add an explicit `id` to the experience item `DndContext`.

## Why

In development, the builder can show a hydration warning where dnd-kit generated accessibility ids differ between the server-rendered HTML and the client-rendered tree, for example:

```diff
+ aria-describedby="DndDescribedBy-0"
- aria-describedby="DndDescribedBy-3"
```

Providing stable DnD context ids makes those generated ids deterministic across server and client rendering.

## Testing

- [x] `npx eslint components/builder/resume-form.tsx components/builder/forms/education-form.tsx components/builder/forms/experience-form.tsx`

## Notes

This PR intentionally avoids manually overriding `aria-describedby`; it only provides stable `DndContext` ids so dnd-kit can continue managing its accessibility attributes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Next.js hydration warnings in the resume builder by adding stable `DndContext` ids. Ensures `dnd-kit` accessibility attributes are consistent between server and client. Closes #880.

- **Bug Fixes**
  - Set `id="resume-sections"` on the resume `DndContext`.
  - Set `id="education-items"` on the education form `DndContext`.
  - Set `id="experience-items"` on the experience form `DndContext`.

<sup>Written for commit 0772205424ac3964b1c4ffea857a04898f253b9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

