### PR TITLE
Allow resume description points to render without bullet markers

### DIFF
--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -39,7 +39,8 @@ RESUME_SCHEMA_EXAMPLE = """{
       "description": [
         "Led development of microservices architecture",
         "Improved system performance by 40%"
-      ]
+      ],
+      "descriptionStyles": ["bullet", "bullet"]
     }
   ],
   "education": [
@@ -60,7 +61,8 @@ RESUME_SCHEMA_EXAMPLE = """{
       "description": [
         "Built CLI tool with 1000+ GitHub stars",
         "Used by 50+ companies worldwide"
-      ]
+      ],
+      "descriptionStyles": ["bullet", "bullet"]
     }
   ],
   "additional": {
@@ -78,7 +80,8 @@ RESUME_SCHEMA_EXAMPLE = """{
           "title": "Paper Title",
           "subtitle": "Journal Name",
           "years": "Jun 2023",
-          "description": ["Brief description of the publication"]
+          "description": ["Brief description of the publication"],
+          "descriptionStyles": ["bullet"]
         }
       ]
     },
@@ -102,7 +105,8 @@ IMPROVE_SCHEMA_EXAMPLE = """{
       "description": [
         "Led development of microservices architecture",
         "Improved system performance by 40%"
-      ]
+      ],
+      "descriptionStyles": ["bullet", "bullet"]
     }
   ],
   "education": [
@@ -123,7 +127,8 @@ IMPROVE_SCHEMA_EXAMPLE = """{
       "description": [
         "Built CLI tool with 1000+ GitHub stars",
         "Used by 50+ companies worldwide"
-      ]
+      ],
+      "descriptionStyles": ["bullet", "bullet"]
     }
   ],
   "additional": {
@@ -141,7 +146,8 @@ IMPROVE_SCHEMA_EXAMPLE = """{
           "title": "Paper Title",
           "subtitle": "Journal Name",
           "years": "Jun 2023",
-          "description": ["Brief description of the publication"]
+          "description": ["Brief description of the publication"],
+          "descriptionStyles": ["bullet"]
         }
       ]
     },
@@ -167,6 +173,7 @@ Custom section types:
 Rules:
 - Use "" for missing text fields, [] for missing arrays, null for optional fields
 - Number IDs starting from 1
+- For workExperience, personalProjects, and custom itemList items, include descriptionStyles with one value for each description row. Use "bullet" for normal bullet rows and "plain" for rows that should render without a bullet marker (for example subheadings or standalone labels).
 - Format dates preserving the original precision. Keep months when present: "Jan 2020 - Dec 2023", "May 2021 - Present". Use "YYYY - YYYY" only when the source has no months.
 - Use snake_case for custom section keys (e.g., "volunteer_work", "publications")
 - Preserve the original section name as a descriptive key
@@ -244,6 +251,7 @@ Rules:
 - Do NOT introduce new tools, technologies, or certifications not already present
 - Do NOT add new bullet points or sections
 - Preserve original bullet count and ordering within each section
+- Preserve descriptionStyles arrays and keep them aligned one-to-one with description arrays
 - Keep proper nouns (names, company names, locations) unchanged
 - For customSections: preserve exact structure, item count, titles, subtitles, and years. If an item's description is an empty array [] in the original, keep it empty []. Do NOT generate descriptions for items that had none.
 - Copy the "years" field values EXACTLY as they appear in the original resume (including any month prefixes like "Jan 2020 - Present"). Do not shorten, reformat, or drop months.
@@ -274,6 +282,7 @@ Rules:
 - You may rephrase bullet points to include keyword phrasing
 - Do NOT introduce new skills, tools, or certifications not in the resume
 - Do NOT change role, industry, or seniority level
+- Preserve descriptionStyles arrays and keep them aligned one-to-one with description arrays
 - For customSections: preserve exact structure, item count, titles, subtitles, and years. If an item's description is an empty array [] in the original, keep it empty []. Do NOT generate descriptions for items that had none.
 - Copy the "years" field values EXACTLY as they appear in the original resume (including any month prefixes like "Jan 2020 - Present"). Do not shorten, reformat, or drop months.
 - If resume is non-technical, keep language non-technical while still aligning keywords
@@ -304,6 +313,7 @@ Rules:
 - Preserve existing action verbs. Do not invent quantifiable achievements not in the original.
 - Keep proper nouns (names, company names, locations) unchanged
 - Translate job titles, descriptions, and skills to {output_language}
+- Preserve descriptionStyles arrays and keep them aligned one-to-one with description arrays
 - For customSections: preserve exact structure, item count, titles, subtitles, and years. If an item's description is an empty array [] in the original, keep it empty []. Do NOT generate descriptions for items that had none.
 - Improve custom section content the same way as standard sections
 - Copy the "years" field values EXACTLY as they appear in the original resume (including any month prefixes like "Jan 2020 - Present"). Do not shorten, reformat, or drop months.

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -140,6 +140,7 @@ class Experience(BaseModel):
     location: str | None = None
     years: str = ""
     description: list[str] = Field(default_factory=list)
+    descriptionStyles: list[Literal["bullet", "plain"]] = Field(default_factory=list)
 
     @field_validator("description", mode="before")
     @classmethod
@@ -172,6 +173,7 @@ class Project(BaseModel):
     github: str | None = None
     website: str | None = None
     description: list[str] = Field(default_factory=list)
+    descriptionStyles: list[Literal["bullet", "plain"]] = Field(default_factory=list)
 
     @field_validator("description", mode="before")
     @classmethod
@@ -221,6 +223,7 @@ class CustomSectionItem(BaseModel):
     location: str | None = None
     years: str = ""
     description: list[str] = Field(default_factory=list)
+    descriptionStyles: list[Literal["bullet", "plain"]] = Field(default_factory=list)
 
     @field_validator("description", mode="before")
     @classmethod

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -107,6 +107,25 @@ def _coerce_string_list(value: Any) -> list[str]:
     return [coerced] if coerced else []
 
 
+def _coerce_description_styles(value: Any) -> list[Literal["bullet", "plain"]]:
+    """Coerce description style values into supported row styles."""
+    if not isinstance(value, list):
+        return []
+
+    return ["plain" if entry == "plain" else "bullet" for entry in value]
+
+
+def _align_description_styles(
+    description: list[str],
+    description_styles: list[Literal["bullet", "plain"]],
+) -> list[Literal["bullet", "plain"]]:
+    """Keep descriptionStyles aligned with description rows."""
+    return [
+        description_styles[index] if index < len(description_styles) else "bullet"
+        for index, _ in enumerate(description)
+    ]
+
+
 # Section Type Enum for dynamic sections
 class SectionType(str, Enum):
     """Types of resume sections."""
@@ -147,6 +166,20 @@ class Experience(BaseModel):
     def _normalize_description(cls, value: Any) -> list[str]:
         return _coerce_string_list(value)
 
+    @field_validator("descriptionStyles", mode="before")
+    @classmethod
+    def _normalize_description_styles(
+        cls, value: Any
+    ) -> list[Literal["bullet", "plain"]]:
+        return _coerce_description_styles(value)
+
+    @model_validator(mode="after")
+    def _sync_description_styles(self) -> "Experience":
+        self.descriptionStyles = _align_description_styles(
+            self.description, self.descriptionStyles
+        )
+        return self
+
 
 class Education(BaseModel):
     """Education entry."""
@@ -179,6 +212,20 @@ class Project(BaseModel):
     @classmethod
     def _normalize_description(cls, value: Any) -> list[str]:
         return _coerce_string_list(value)
+
+    @field_validator("descriptionStyles", mode="before")
+    @classmethod
+    def _normalize_description_styles(
+        cls, value: Any
+    ) -> list[Literal["bullet", "plain"]]:
+        return _coerce_description_styles(value)
+
+    @model_validator(mode="after")
+    def _sync_description_styles(self) -> "Project":
+        self.descriptionStyles = _align_description_styles(
+            self.description, self.descriptionStyles
+        )
+        return self
 
 
 class AdditionalInfo(BaseModel):
@@ -229,6 +276,20 @@ class CustomSectionItem(BaseModel):
     @classmethod
     def _normalize_description(cls, value: Any) -> list[str]:
         return _coerce_string_list(value)
+
+    @field_validator("descriptionStyles", mode="before")
+    @classmethod
+    def _normalize_description_styles(
+        cls, value: Any
+    ) -> list[Literal["bullet", "plain"]]:
+        return _coerce_description_styles(value)
+
+    @model_validator(mode="after")
+    def _sync_description_styles(self) -> "CustomSectionItem":
+        self.descriptionStyles = _align_description_styles(
+            self.description, self.descriptionStyles
+        )
+        return self
 
 
 class CustomSection(BaseModel):

--- a/apps/backend/tests/unit/test_description_styles.py
+++ b/apps/backend/tests/unit/test_description_styles.py
@@ -1,0 +1,45 @@
+from app.schemas.models import CustomSectionItem, Experience, Project, ResumeData
+
+
+def test_experience_description_styles_are_aligned_to_descriptions() -> None:
+    experience = Experience.model_validate(
+        {
+            "description": ["Built APIs", "Led migrations", "Reduced latency"],
+            "descriptionStyles": [None, "plain"],
+        }
+    )
+
+    assert experience.descriptionStyles == ["bullet", "plain", "bullet"]
+
+
+def test_project_description_styles_are_trimmed_to_description_count() -> None:
+    project = Project.model_validate(
+        {
+            "description": ["Built CLI"],
+            "descriptionStyles": ["plain", "bullet"],
+        }
+    )
+
+    assert project.descriptionStyles == ["plain"]
+
+
+def test_resume_data_defaults_missing_custom_item_styles_to_bullets() -> None:
+    resume = ResumeData.model_validate(
+        {
+            "customSections": {
+                "publications": {
+                    "sectionType": "itemList",
+                    "items": [
+                        {
+                            "title": "Paper",
+                            "description": ["Accepted", "Presented"],
+                        }
+                    ],
+                }
+            }
+        }
+    )
+
+    item = resume.customSections["publications"].items[0]
+    assert isinstance(item, CustomSectionItem)
+    assert item.descriptionStyles == ["bullet", "bullet"]

--- a/apps/frontend/components/builder/forms/experience-form.tsx
+++ b/apps/frontend/components/builder/forms/experience-form.tsx
@@ -18,7 +18,7 @@ const RichTextEditor = dynamic(
   }
 );
 import { Experience } from '@/components/dashboard/resume-component';
-import { Plus, Trash2 } from 'lucide-react';
+import { AlignLeft, List, Plus, Trash2 } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
 import {
   DndContext,
@@ -80,6 +80,7 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
         location: '',
         years: '',
         description: [''],
+        descriptionStyles: ['bullet'],
       },
     ]);
   };
@@ -116,7 +117,24 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
     onChange(
       data.map((item) => {
         if (item.id === id) {
-          return { ...item, description: [...(item.description || []), ''] };
+          return {
+            ...item,
+            description: [...(item.description || []), ''],
+            descriptionStyles: [...(item.descriptionStyles || []), 'bullet'],
+          };
+        }
+        return item;
+      })
+    );
+  };
+
+  const handleToggleDescriptionStyle = (id: number, index: number) => {
+    onChange(
+      data.map((item) => {
+        if (item.id === id) {
+          const styles = [...(item.descriptionStyles || [])];
+          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
+          return { ...item, descriptionStyles: styles };
         }
         return item;
       })
@@ -129,7 +147,9 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          return { ...item, description: newDesc };
+          const newStyles = [...(item.descriptionStyles || [])];
+          newStyles.splice(index, 1);
+          return { ...item, description: newDesc, descriptionStyles: newStyles };
         }
         return item;
       })
@@ -256,6 +276,20 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
                               minHeight="60px"
                             />
                           </div>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleToggleDescriptionStyle(item.id, idx)}
+                            className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                            aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
+                            title={t('builder.genericItemForm.actions.togglePointStyle')}
+                          >
+                            {item.descriptionStyles?.[idx] === 'plain' ? (
+                              <AlignLeft className="w-3 h-3" />
+                            ) : (
+                              <List className="w-3 h-3" />
+                            )}
+                          </Button>
                           <Button
                             variant="ghost"
                             size="icon"

--- a/apps/frontend/components/builder/forms/experience-form.tsx
+++ b/apps/frontend/components/builder/forms/experience-form.tsx
@@ -20,6 +20,7 @@ const RichTextEditor = dynamic(
 import { Experience } from '@/components/dashboard/resume-component';
 import { AlignLeft, List, Plus, Trash2 } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
+import { alignDescriptionStyles, toggleDescriptionStyle } from '@/lib/utils/description-styles';
 import {
   DndContext,
   closestCenter,
@@ -132,9 +133,14 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
     onChange(
       data.map((item) => {
         if (item.id === id) {
-          const styles = [...(item.descriptionStyles || [])];
-          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
-          return { ...item, descriptionStyles: styles };
+          return {
+            ...item,
+            descriptionStyles: toggleDescriptionStyle(
+              item.description,
+              item.descriptionStyles,
+              index
+            ),
+          };
         }
         return item;
       })
@@ -147,7 +153,7 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          const newStyles = [...(item.descriptionStyles || [])];
+          const newStyles = alignDescriptionStyles(item.description, item.descriptionStyles);
           newStyles.splice(index, 1);
           return { ...item, description: newDesc, descriptionStyles: newStyles };
         }

--- a/apps/frontend/components/builder/forms/generic-item-form.tsx
+++ b/apps/frontend/components/builder/forms/generic-item-form.tsx
@@ -16,7 +16,7 @@ const RichTextEditor = dynamic(
     ),
   }
 );
-import { Plus, Trash2 } from 'lucide-react';
+import { AlignLeft, List, Plus, Trash2 } from 'lucide-react';
 import type { CustomSectionItem } from '@/components/dashboard/resume-component';
 import { useTranslations } from '@/lib/i18n';
 
@@ -81,6 +81,7 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
         location: '',
         years: '',
         description: [''],
+        descriptionStyles: ['bullet'],
       },
     ]);
   };
@@ -117,7 +118,24 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
     onChange(
       items.map((item) => {
         if (item.id === id) {
-          return { ...item, description: [...(item.description || []), ''] };
+          return {
+            ...item,
+            description: [...(item.description || []), ''],
+            descriptionStyles: [...(item.descriptionStyles || []), 'bullet'],
+          };
+        }
+        return item;
+      })
+    );
+  };
+
+  const handleToggleDescriptionStyle = (id: number, index: number) => {
+    onChange(
+      items.map((item) => {
+        if (item.id === id) {
+          const styles = [...(item.descriptionStyles || [])];
+          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
+          return { ...item, descriptionStyles: styles };
         }
         return item;
       })
@@ -130,7 +148,9 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          return { ...item, description: newDesc };
+          const newStyles = [...(item.descriptionStyles || [])];
+          newStyles.splice(index, 1);
+          return { ...item, description: newDesc, descriptionStyles: newStyles };
         }
         return item;
       })
@@ -241,6 +261,20 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
                       minHeight="60px"
                     />
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleToggleDescriptionStyle(item.id, idx)}
+                    className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                    aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
+                    title={t('builder.genericItemForm.actions.togglePointStyle')}
+                  >
+                    {item.descriptionStyles?.[idx] === 'plain' ? (
+                      <AlignLeft className="w-3 h-3" />
+                    ) : (
+                      <List className="w-3 h-3" />
+                    )}
+                  </Button>
                   <Button
                     variant="ghost"
                     size="icon"

--- a/apps/frontend/components/builder/forms/generic-item-form.tsx
+++ b/apps/frontend/components/builder/forms/generic-item-form.tsx
@@ -19,6 +19,7 @@ const RichTextEditor = dynamic(
 import { AlignLeft, List, Plus, Trash2 } from 'lucide-react';
 import type { CustomSectionItem } from '@/components/dashboard/resume-component';
 import { useTranslations } from '@/lib/i18n';
+import { alignDescriptionStyles, toggleDescriptionStyle } from '@/lib/utils/description-styles';
 
 interface GenericItemFormProps {
   items: CustomSectionItem[];
@@ -133,9 +134,14 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
     onChange(
       items.map((item) => {
         if (item.id === id) {
-          const styles = [...(item.descriptionStyles || [])];
-          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
-          return { ...item, descriptionStyles: styles };
+          return {
+            ...item,
+            descriptionStyles: toggleDescriptionStyle(
+              item.description,
+              item.descriptionStyles,
+              index
+            ),
+          };
         }
         return item;
       })
@@ -148,7 +154,7 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          const newStyles = [...(item.descriptionStyles || [])];
+          const newStyles = alignDescriptionStyles(item.description, item.descriptionStyles);
           newStyles.splice(index, 1);
           return { ...item, description: newDesc, descriptionStyles: newStyles };
         }

--- a/apps/frontend/components/builder/forms/projects-form.tsx
+++ b/apps/frontend/components/builder/forms/projects-form.tsx
@@ -17,7 +17,7 @@ const RichTextEditor = dynamic(
   }
 );
 import { Project } from '@/components/dashboard/resume-component';
-import { Plus, Trash2, Github, Globe } from 'lucide-react';
+import { AlignLeft, List, Plus, Trash2, Github, Globe } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
 
 interface ProjectsFormProps {
@@ -40,6 +40,7 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
         github: '',
         website: '',
         description: [''],
+        descriptionStyles: ['bullet'],
       },
     ]);
   };
@@ -76,7 +77,24 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
     onChange(
       data.map((item) => {
         if (item.id === id) {
-          return { ...item, description: [...(item.description || []), ''] };
+          return {
+            ...item,
+            description: [...(item.description || []), ''],
+            descriptionStyles: [...(item.descriptionStyles || []), 'bullet'],
+          };
+        }
+        return item;
+      })
+    );
+  };
+
+  const handleToggleDescriptionStyle = (id: number, index: number) => {
+    onChange(
+      data.map((item) => {
+        if (item.id === id) {
+          const styles = [...(item.descriptionStyles || [])];
+          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
+          return { ...item, descriptionStyles: styles };
         }
         return item;
       })
@@ -89,7 +107,9 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          return { ...item, description: newDesc };
+          const newStyles = [...(item.descriptionStyles || [])];
+          newStyles.splice(index, 1);
+          return { ...item, description: newDesc, descriptionStyles: newStyles };
         }
         return item;
       })
@@ -209,6 +229,20 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
                       minHeight="60px"
                     />
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleToggleDescriptionStyle(item.id, idx)}
+                    className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                    aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
+                    title={t('builder.genericItemForm.actions.togglePointStyle')}
+                  >
+                    {item.descriptionStyles?.[idx] === 'plain' ? (
+                      <AlignLeft className="w-3 h-3" />
+                    ) : (
+                      <List className="w-3 h-3" />
+                    )}
+                  </Button>
                   <Button
                     variant="ghost"
                     size="icon"

--- a/apps/frontend/components/builder/forms/projects-form.tsx
+++ b/apps/frontend/components/builder/forms/projects-form.tsx
@@ -19,6 +19,7 @@ const RichTextEditor = dynamic(
 import { Project } from '@/components/dashboard/resume-component';
 import { AlignLeft, List, Plus, Trash2, Github, Globe } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
+import { alignDescriptionStyles, toggleDescriptionStyle } from '@/lib/utils/description-styles';
 
 interface ProjectsFormProps {
   data: Project[];
@@ -92,9 +93,14 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
     onChange(
       data.map((item) => {
         if (item.id === id) {
-          const styles = [...(item.descriptionStyles || [])];
-          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
-          return { ...item, descriptionStyles: styles };
+          return {
+            ...item,
+            descriptionStyles: toggleDescriptionStyle(
+              item.description,
+              item.descriptionStyles,
+              index
+            ),
+          };
         }
         return item;
       })
@@ -107,7 +113,7 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          const newStyles = [...(item.descriptionStyles || [])];
+          const newStyles = alignDescriptionStyles(item.description, item.descriptionStyles);
           newStyles.splice(index, 1);
           return { ...item, description: newDesc, descriptionStyles: newStyles };
         }

--- a/apps/frontend/components/common/resume_previewer_context.tsx
+++ b/apps/frontend/components/common/resume_previewer_context.tsx
@@ -20,6 +20,7 @@ export interface ExperienceEntry {
   location?: string;
   years?: string;
   description: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 export interface EducationEntry {
@@ -36,6 +37,7 @@ export interface ProjectEntry {
   role?: string;
   years?: string;
   description: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 export interface AdditionalInfo {

--- a/apps/frontend/components/dashboard/resume-component.tsx
+++ b/apps/frontend/components/dashboard/resume-component.tsx
@@ -34,6 +34,7 @@ export interface Experience {
   location?: string;
   years?: string;
   description?: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 export interface Education {
@@ -52,6 +53,7 @@ export interface Project {
   github?: string;
   website?: string;
   description?: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 export interface AdditionalInfo {
@@ -106,6 +108,7 @@ export interface CustomSectionItem {
   location?: string;
   years?: string;
   description?: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 // Custom section data container

--- a/apps/frontend/components/resume/description-list.tsx
+++ b/apps/frontend/components/resume/description-list.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { SafeHtml } from './safe-html';
+import baseStyles from './styles/_base.module.css';
+
+export type DescriptionStyle = 'bullet' | 'plain';
+
+interface DescriptionListProps {
+  items?: string[];
+  styles?: DescriptionStyle[];
+  textClassName?: string;
+  marker?: string;
+  markerClassName?: string;
+}
+
+export const DescriptionList: React.FC<DescriptionListProps> = ({
+  items,
+  styles,
+  textClassName = baseStyles['resume-text-sm'],
+  marker = '•',
+  markerClassName = 'mr-1.5 flex-shrink-0',
+}) => {
+  if (!items || items.length === 0) return null;
+
+  return (
+    <ul className={cn(baseStyles['resume-list'], textClassName)}>
+      {items.map((desc, index) => {
+        const showMarker = styles?.[index] !== 'plain';
+
+        return (
+          <li key={index} className={cn('flex', showMarker && 'ml-4')}>
+            {showMarker && (
+              <span className={markerClassName} aria-hidden="true">
+                {marker}
+                {'\u00A0'}
+              </span>
+            )}
+            <span>
+              <SafeHtml html={desc} />
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/apps/frontend/components/resume/dynamic-resume-section.tsx
+++ b/apps/frontend/components/resume/dynamic-resume-section.tsx
@@ -6,7 +6,7 @@ import type {
   CustomSectionItem,
 } from '@/components/dashboard/resume-component';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 
 interface DynamicResumeSectionProps {
@@ -109,18 +109,7 @@ const ItemListSectionContent: React.FC<{ items: CustomSectionItem[] }> = ({ item
           )}
 
           {/* Description Points */}
-          {item.description && item.description.length > 0 && (
-            <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
-              {item.description.map((desc, index) => (
-                <li key={index} className="flex">
-                  <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                  <span>
-                    <SafeHtml html={desc} />
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
+          <DescriptionList items={item.description} styles={item.descriptionStyles} />
         </div>
       ))}
     </div>

--- a/apps/frontend/components/resume/resume-clean.tsx
+++ b/apps/frontend/components/resume/resume-clean.tsx
@@ -151,7 +151,7 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
               {workExperience.map((exp) => (
                 <div key={exp.id} className={baseStyles['resume-item']}>
                   {renderEntryHeader(exp.company, exp.title, exp.location, exp.years)}
-                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
+                  {renderBullets(exp.description, exp.descriptionStyles)}
                 </div>
               ))}
             </div>

--- a/apps/frontend/components/resume/resume-clean.tsx
+++ b/apps/frontend/components/resume/resume-clean.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 import { getSortedSections } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/clean.module.css';
 
@@ -124,21 +124,9 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
     );
   };
 
-  const renderBullets = (items?: string[]) => {
-    if (!items || items.length === 0) return null;
-    return (
-      <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
-        {items.map((desc, index) => (
-          <li key={index} className="flex">
-            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-            <span>
-              <SafeHtml html={desc} />
-            </span>
-          </li>
-        ))}
-      </ul>
-    );
-  };
+  const renderBullets = (items?: string[], styles?: ('bullet' | 'plain')[]) => (
+    <DescriptionList items={items} styles={styles} />
+  );
 
   const renderSection = (section: SectionMeta) => {
     switch (section.key) {
@@ -163,7 +151,7 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
               {workExperience.map((exp) => (
                 <div key={exp.id} className={baseStyles['resume-item']}>
                   {renderEntryHeader(exp.company, exp.title, exp.location, exp.years)}
-                  {renderBullets(exp.description)}
+                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -234,7 +222,7 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
                       <span className={styles.entryMeta}>{formatDateRange(project.years)}</span>
                     )}
                   </div>
-                  {renderBullets(project.description)}
+                  <DescriptionList items={project.description} styles={project.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -376,7 +364,7 @@ const AdditionalSection: React.FC<{
 const DynamicResumeSectionClean: React.FC<{
   sectionMeta: SectionMeta;
   resumeData: ResumeData;
-  renderBullets: (items?: string[]) => React.ReactNode;
+  renderBullets: (items?: string[], styles?: ('bullet' | 'plain')[]) => React.ReactNode;
   renderEntryHeader: (
     primary?: string,
     role?: string,
@@ -413,7 +401,7 @@ const DynamicResumeSectionClean: React.FC<{
           {customSection.items.map((item) => (
             <div key={item.id} className={baseStyles['resume-item']}>
               {renderEntryHeader(item.title, item.subtitle, item.location, item.years)}
-              {renderBullets(item.description)}
+              {renderBullets(item.description, item.descriptionStyles)}
             </div>
           ))}
         </div>

--- a/apps/frontend/components/resume/resume-latex.tsx
+++ b/apps/frontend/components/resume/resume-latex.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 import { getSortedSections } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/latex.module.css';
 
@@ -119,21 +119,9 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
     </>
   );
 
-  const renderBullets = (items?: string[]) => {
-    if (!items || items.length === 0) return null;
-    return (
-      <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
-        {items.map((desc, index) => (
-          <li key={index} className="flex">
-            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-            <span>
-              <SafeHtml html={desc} />
-            </span>
-          </li>
-        ))}
-      </ul>
-    );
-  };
+  const renderBullets = (items?: string[], styles?: ('bullet' | 'plain')[]) => (
+    <DescriptionList items={items} styles={styles} />
+  );
 
   const renderSection = (section: SectionMeta) => {
     switch (section.key) {
@@ -158,7 +146,7 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
               {workExperience.map((exp) => (
                 <div key={exp.id} className={baseStyles['resume-item']}>
                   {renderEntryHeader(exp.company, exp.years, exp.title, exp.location)}
-                  {renderBullets(exp.description)}
+                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -230,7 +218,7 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
                       <span className={styles.entrySecondary}>{project.role}</span>
                     </div>
                   )}
-                  {renderBullets(project.description)}
+                  {renderBullets(project.description, project.descriptionStyles)}
                 </div>
               ))}
             </div>
@@ -374,7 +362,7 @@ const AdditionalSection: React.FC<{
 const DynamicResumeSectionLatex: React.FC<{
   sectionMeta: SectionMeta;
   resumeData: ResumeData;
-  renderBullets: (items?: string[]) => React.ReactNode;
+  renderBullets: (items?: string[], styles?: ('bullet' | 'plain')[]) => React.ReactNode;
 }> = ({ sectionMeta, resumeData, renderBullets }) => {
   const customSection = resumeData.customSections?.[sectionMeta.key];
   if (!customSection) return null;
@@ -420,7 +408,7 @@ const DynamicResumeSectionLatex: React.FC<{
                   )}
                 </div>
               )}
-              {renderBullets(item.description)}
+              {renderBullets(item.description, item.descriptionStyles)}
             </div>
           ))}
         </div>

--- a/apps/frontend/components/resume/resume-latex.tsx
+++ b/apps/frontend/components/resume/resume-latex.tsx
@@ -146,7 +146,7 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
               {workExperience.map((exp) => (
                 <div key={exp.id} className={baseStyles['resume-item']}>
                   {renderEntryHeader(exp.company, exp.years, exp.title, exp.location)}
-                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
+                  {renderBullets(exp.description, exp.descriptionStyles)}
                 </div>
               ))}
             </div>

--- a/apps/frontend/components/resume/resume-modern-two-column.tsx
+++ b/apps/frontend/components/resume/resume-modern-two-column.tsx
@@ -8,7 +8,7 @@ import type {
 import { getSortedSections, getSectionMeta } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
 import { DynamicResumeSection } from './dynamic-resume-section';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/modern-two-column.module.css';
 
@@ -208,20 +208,11 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                       </span>
                     </div>
 
-                    {exp.description && exp.description.length > 0 && (
-                      <ul
-                        className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}
-                      >
-                        {exp.description.map((desc, index) => (
-                          <li key={index} className="flex">
-                            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                            <span>
-                              <SafeHtml html={desc} />
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
+                    <DescriptionList
+                      items={exp.description}
+                      styles={exp.descriptionStyles}
+                      textClassName={baseStyles['resume-text-xs']}
+                    />
                   </div>
                 ))}
               </div>
@@ -298,20 +289,11 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                           <span>{project.role}</span>
                         </div>
                       )}
-                      {project.description && project.description.length > 0 && (
-                        <ul
-                          className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}
-                        >
-                          {project.description.map((desc, index) => (
-                            <li key={index} className="flex">
-                              <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                              <span>
-                                <SafeHtml html={desc} />
-                              </span>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
+                      <DescriptionList
+                        items={project.description}
+                        styles={project.descriptionStyles}
+                        textClassName={baseStyles['resume-text-xs']}
+                      />
                     </div>
                   ))}
                 </div>

--- a/apps/frontend/components/resume/resume-modern.tsx
+++ b/apps/frontend/components/resume/resume-modern.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 import { getSortedSections } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/modern.module.css';
 
@@ -127,20 +127,7 @@ export const ResumeModern: React.FC<ResumeModernProps> = ({
                     <span>{exp.company}</span>
                     {exp.location && <span>{exp.location}</span>}
                   </div>
-                  {exp.description && exp.description.length > 0 && (
-                    <ul
-                      className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}
-                    >
-                      {exp.description.map((desc, index) => (
-                        <li key={index} className="flex">
-                          <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                          <span>
-                            <SafeHtml html={desc} />
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -214,20 +201,7 @@ export const ResumeModern: React.FC<ResumeModernProps> = ({
                       <span>{project.role}</span>
                     </div>
                   )}
-                  {project.description && project.description.length > 0 && (
-                    <ul
-                      className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}
-                    >
-                      {project.description.map((desc, index) => (
-                        <li key={index} className="flex">
-                          <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                          <span>
-                            <SafeHtml html={desc} />
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <DescriptionList items={project.description} styles={project.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -510,18 +484,7 @@ function renderDynamicContent(
                   {item.location && <span>{item.location}</span>}
                 </div>
               )}
-              {item.description && item.description.length > 0 && (
-                <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
-                  {item.description.map((desc, index) => (
-                    <li key={index} className="flex">
-                      <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                      <span>
-                        <SafeHtml html={desc} />
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
+              <DescriptionList items={item.description} styles={item.descriptionStyles} />
             </div>
           ))}
         </div>

--- a/apps/frontend/components/resume/resume-single-column.tsx
+++ b/apps/frontend/components/resume/resume-single-column.tsx
@@ -8,7 +8,7 @@ import type {
 import { getSortedSections } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
 import { DynamicResumeSection } from './dynamic-resume-section';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/swiss-single.module.css';
 
@@ -127,20 +127,7 @@ export const ResumeSingleColumn: React.FC<ResumeSingleColumnProps> = ({
                     <span>{exp.company}</span>
                     {exp.location && <span>{exp.location}</span>}
                   </div>
-                  {exp.description && exp.description.length > 0 && (
-                    <ul
-                      className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}
-                    >
-                      {exp.description.map((desc, index) => (
-                        <li key={index} className="flex">
-                          <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                          <span>
-                            <SafeHtml html={desc} />
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -214,20 +201,7 @@ export const ResumeSingleColumn: React.FC<ResumeSingleColumnProps> = ({
                       <span>{project.role}</span>
                     </div>
                   )}
-                  {project.description && project.description.length > 0 && (
-                    <ul
-                      className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}
-                    >
-                      {project.description.map((desc, index) => (
-                        <li key={index} className="flex">
-                          <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                          <span>
-                            <SafeHtml html={desc} />
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <DescriptionList items={project.description} styles={project.descriptionStyles} />
                 </div>
               ))}
             </div>

--- a/apps/frontend/components/resume/resume-two-column.tsx
+++ b/apps/frontend/components/resume/resume-two-column.tsx
@@ -4,7 +4,7 @@ import type { ResumeData, ResumeSectionHeadings } from '@/components/dashboard/r
 import { getSortedSections, getSectionMeta } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
 import { DynamicResumeSection } from './dynamic-resume-section';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/swiss-two-column.module.css';
 
@@ -243,20 +243,11 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
                       </span>
                     </div>
 
-                    {exp.description && exp.description.length > 0 && (
-                      <ul
-                        className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}
-                      >
-                        {exp.description.map((desc, index) => (
-                          <li key={index} className="flex">
-                            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                            <span>
-                              <SafeHtml html={desc} />
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
+                    <DescriptionList
+                      items={exp.description}
+                      styles={exp.descriptionStyles}
+                      textClassName={baseStyles['resume-text-xs']}
+                    />
                   </div>
                 ))}
               </div>
@@ -333,20 +324,11 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
                           <span>{project.role}</span>
                         </div>
                       )}
-                      {project.description && project.description.length > 0 && (
-                        <ul
-                          className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}
-                        >
-                          {project.description.map((desc, index) => (
-                            <li key={index} className="flex">
-                              <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                              <span>
-                                <SafeHtml html={desc} />
-                              </span>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
+                      <DescriptionList
+                        items={project.description}
+                        styles={project.descriptionStyles}
+                        textClassName={baseStyles['resume-text-xs']}
+                      />
                     </div>
                   ))}
                 </div>

--- a/apps/frontend/components/resume/resume-vivid.tsx
+++ b/apps/frontend/components/resume/resume-vivid.tsx
@@ -8,7 +8,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 import { getSortedSections, getSectionMeta } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/vivid.module.css';
 
@@ -134,22 +134,17 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
 
   const renderArrowBullets = (
     items?: string[],
-    textClass: string = baseStyles['resume-text-xs']
-  ) => {
-    if (!items || items.length === 0) return null;
-    return (
-      <ul className={`ml-4 ${baseStyles['resume-list']} ${textClass}`}>
-        {items.map((desc, index) => (
-          <li key={index} className="flex">
-            <span className={`mr-1.5 ${styles.arrow}`}>➜&nbsp;</span>
-            <span>
-              <SafeHtml html={desc} />
-            </span>
-          </li>
-        ))}
-      </ul>
-    );
-  };
+    textClass: string = baseStyles['resume-text-xs'],
+    itemStyles?: ('bullet' | 'plain')[]
+  ) => (
+    <DescriptionList
+      items={items}
+      styles={itemStyles}
+      textClassName={textClass}
+      marker="➜"
+      markerClassName={`mr-1.5 ${styles.arrow}`}
+    />
+  );
 
   return (
     <>
@@ -209,7 +204,11 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
                     <div className={`${baseStyles['resume-row-tight']} ${styles.entryMeta}`}>
                       {[formatDateRange(exp.years), exp.location].filter(Boolean).join(' | ')}
                     </div>
-                    {renderArrowBullets(exp.description)}
+                    {renderArrowBullets(
+                      exp.description,
+                      baseStyles['resume-text-xs'],
+                      exp.descriptionStyles
+                    )}
                   </div>
                 ))}
               </div>
@@ -284,7 +283,11 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
                           </span>
                         )}
                       </div>
-                      {renderArrowBullets(project.description)}
+                      {renderArrowBullets(
+                        project.description,
+                        baseStyles['resume-text-xs'],
+                        project.descriptionStyles
+                      )}
                     </div>
                   ))}
                 </div>
@@ -400,7 +403,11 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
 const DynamicResumeSectionVivid: React.FC<{
   sectionMeta: SectionMeta;
   resumeData: ResumeData;
-  renderArrowBullets: (items?: string[], textClass?: string) => React.ReactNode;
+  renderArrowBullets: (
+    items?: string[],
+    textClass?: string,
+    itemStyles?: ('bullet' | 'plain')[]
+  ) => React.ReactNode;
 }> = ({ sectionMeta, resumeData, renderArrowBullets }) => {
   const customSection = resumeData.customSections?.[sectionMeta.key];
   if (!customSection) return null;
@@ -448,7 +455,11 @@ const DynamicResumeSectionVivid: React.FC<{
                   </span>
                 )}
               </div>
-              {renderArrowBullets(item.description)}
+              {renderArrowBullets(
+                item.description,
+                baseStyles['resume-text-xs'],
+                item.descriptionStyles
+              )}
             </div>
           ))}
         </div>

--- a/apps/frontend/lib/api/resume.ts
+++ b/apps/frontend/lib/api/resume.ts
@@ -27,6 +27,7 @@ interface ProcessedResume {
     location?: string | null;
     years?: string;
     description?: string[];
+    descriptionStyles?: ('bullet' | 'plain')[];
   }>;
   education?: Array<{
     id: number;
@@ -43,6 +44,7 @@ interface ProcessedResume {
     github?: string | null;
     website?: string | null;
     description?: string[];
+    descriptionStyles?: ('bullet' | 'plain')[];
   }>;
   additional?: {
     technicalSkills?: string[];

--- a/apps/frontend/lib/utils/description-styles.ts
+++ b/apps/frontend/lib/utils/description-styles.ts
@@ -1,0 +1,23 @@
+export type DescriptionStyle = 'bullet' | 'plain';
+
+export function alignDescriptionStyles(
+  descriptions: string[] | undefined,
+  styles: (DescriptionStyle | null | undefined)[] | undefined
+): DescriptionStyle[] {
+  return (descriptions || []).map((_, index) => (styles?.[index] === 'plain' ? 'plain' : 'bullet'));
+}
+
+export function toggleDescriptionStyle(
+  descriptions: string[] | undefined,
+  styles: (DescriptionStyle | null | undefined)[] | undefined,
+  index: number
+): DescriptionStyle[] {
+  const alignedStyles = alignDescriptionStyles(descriptions, styles);
+
+  if (index < 0 || index >= alignedStyles.length) {
+    return alignedStyles;
+  }
+
+  alignedStyles[index] = alignedStyles[index] === 'plain' ? 'bullet' : 'plain';
+  return alignedStyles;
+}

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "Description Points"
       },
       "actions": {
-        "addPoint": "Add Point"
+        "addPoint": "Add Point",
+        "togglePointStyle": "Toggle bullet marker"
       },
       "placeholders": {
         "title": "Title",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "Puntos de descripción"
       },
       "actions": {
-        "addPoint": "Agregar punto"
+        "addPoint": "Agregar punto",
+        "togglePointStyle": "Alternar viñeta"
       },
       "placeholders": {
         "title": "Título",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -289,7 +289,8 @@
         "descriptionPoints": "Points de description"
       },
       "actions": {
-        "addPoint": "Ajouter un point"
+        "addPoint": "Ajouter un point",
+        "togglePointStyle": "Basculer la puce"
       },
       "placeholders": {
         "title": "Titre",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "説明ポイント"
       },
       "actions": {
-        "addPoint": "ポイントを追加"
+        "addPoint": "ポイントを追加",
+        "togglePointStyle": "箇条書き記号を切り替え"
       },
       "placeholders": {
         "title": "タイトル",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "Pontos de Descrição"
       },
       "actions": {
-        "addPoint": "Adicionar Ponto"
+        "addPoint": "Adicionar Ponto",
+        "togglePointStyle": "Alternar marcador"
       },
       "placeholders": {
         "title": "Título",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "描述要点"
       },
       "actions": {
-        "addPoint": "添加要点"
+        "addPoint": "添加要点",
+        "togglePointStyle": "切换项目符号"
       },
       "placeholders": {
         "title": "标题",

--- a/apps/frontend/tests/description-list.test.tsx
+++ b/apps/frontend/tests/description-list.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DescriptionList } from '@/components/resume/description-list';
+
+describe('DescriptionList', () => {
+  it('renders bullet rows with a marker and plain rows without marker indentation', () => {
+    render(
+      <DescriptionList
+        items={['Core module', 'Built reliable workflows']}
+        styles={['plain', 'bullet']}
+      />
+    );
+
+    const rows = screen.getAllByRole('listitem');
+
+    expect(rows[0]).not.toHaveClass('ml-4');
+    expect(within(rows[0]).queryByText('•')).not.toBeInTheDocument();
+    expect(rows[0]).toHaveTextContent('Core module');
+
+    expect(rows[1]).toHaveClass('ml-4');
+    expect(within(rows[1]).getByText('•')).toBeInTheDocument();
+    expect(rows[1]).toHaveTextContent('Built reliable workflows');
+  });
+});

--- a/apps/frontend/tests/description-styles.test.ts
+++ b/apps/frontend/tests/description-styles.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { alignDescriptionStyles, toggleDescriptionStyle } from '@/lib/utils/description-styles';
+
+describe('description style helpers', () => {
+  it('aligns missing and sparse description styles to bullet defaults', () => {
+    expect(alignDescriptionStyles(['A', 'B', 'C'], undefined)).toEqual([
+      'bullet',
+      'bullet',
+      'bullet',
+    ]);
+    expect(alignDescriptionStyles(['A', 'B', 'C'], [undefined, null, 'plain'])).toEqual([
+      'bullet',
+      'bullet',
+      'plain',
+    ]);
+  });
+
+  it('toggles after aligning styles so old resumes do not create sparse arrays', () => {
+    expect(toggleDescriptionStyle(['A', 'B', 'C'], undefined, 2)).toEqual([
+      'bullet',
+      'bullet',
+      'plain',
+    ]);
+    expect(toggleDescriptionStyle(['A', 'B', 'C'], ['bullet', 'plain'], 1)).toEqual([
+      'bullet',
+      'bullet',
+      'bullet',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds support for rendering individual resume description rows either as normal bullet points or as plain left-aligned text without a marker.

## Related Issue

Closes #878

## Changes

- Add optional `descriptionStyles` metadata for experience, project, and custom item-list descriptions.
- Add a reusable `DescriptionList` component for rich-text description rendering.
- Add an editor toggle for switching a description row between bullet and plain modes.
- Update resume templates to render description rows through `DescriptionList`.
- Preserve existing behavior for resumes without `descriptionStyles` by defaulting rows to bullets.
- Add a small component test for bullet/plain rendering.

## Why

Some resume items need lightweight hierarchy inside their description list, such as a plain module label followed by normal bullet points. Previously every description row rendered as a bullet, so these rows could not be aligned as plain text.

## Testing

- [x] `npx eslint components/resume/description-list.tsx components/builder/forms/experience-form.tsx components/builder/forms/generic-item-form.tsx components/builder/forms/projects-form.tsx components/resume/dynamic-resume-section.tsx components/resume/resume-clean.tsx components/resume/resume-latex.tsx components/resume/resume-modern-two-column.tsx components/resume/resume-modern.tsx components/resume/resume-single-column.tsx components/resume/resume-two-column.tsx components/resume/resume-vivid.tsx tests/description-list.test.tsx`
- [x] `npm test -- description-list.test.tsx resume-latex.test.tsx resume-clean.test.tsx resume-vivid.test.tsx`

## Notes

This does not introduce full heading semantics inside a description list. It only allows a description row to render without a marker and without bullet indentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let resume description rows render as bullets or plain, left-aligned lines with a per‑row toggle. Adds a shared renderer and keeps style arrays aligned across backend, API, and forms.

- **New Features**
  - Per-row style: 'bullet' or 'plain' with an editor toggle; defaults to bullets when missing.
  - `DescriptionList` replaces inline list rendering across all templates (Vivid keeps its arrow marker).

- **Bug Fixes**
  - Backend enforces 1:1 alignment of `descriptionStyles` with `description` and defaults missing entries to 'bullet'.
  - Forms keep styles in sync when adding/removing points; prompts updated to include/preserve `descriptionStyles`; tests added.

<sup>Written for commit 436f86ffffd12139ed6c2db334c843393b28c25f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

