### PR TITLE
Add Chinese font fallback for resume templates

### DIFF
--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -16,9 +16,9 @@ const geist = Geist({
 
 const notoSansSC = Noto_Sans_SC({
   variable: '--font-noto-sans-sc',
-  subsets: ['latin'],
-  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
+  weight: ['400', '500', '600', '700'],
   display: 'swap',
+  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -18,7 +18,6 @@ const notoSansSC = Noto_Sans_SC({
   variable: '--font-noto-sans-sc',
   weight: ['400', '500', '600', '700'],
   display: 'swap',
-  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -16,6 +16,7 @@ const geist = Geist({
 
 const notoSansSC = Noto_Sans_SC({
   variable: '--font-noto-sans-sc',
+  subsets: ['latin'],
   weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
   display: 'swap',
 });

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Geist, Space_Grotesk } from 'next/font/google';
+import { Geist, Noto_Sans_SC, Space_Grotesk } from 'next/font/google';
 import './(default)/css/globals.css';
 
 const spaceGrotesk = Space_Grotesk({
@@ -14,6 +14,12 @@ const geist = Geist({
   display: 'swap',
 });
 
+const notoSansSC = Noto_Sans_SC({
+  variable: '--font-noto-sans-sc',
+  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
+  display: 'swap',
+});
+
 export const metadata: Metadata = {
   title: 'Resume Matcher',
   description: 'Build your resume with Resume Matcher',
@@ -25,7 +31,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en-US" className="h-full" suppressHydrationWarning>
       <body
-        className={`${geist.variable} ${spaceGrotesk.variable} antialiased bg-background text-ink-soft min-h-full`}
+        className={`${geist.variable} ${spaceGrotesk.variable} ${notoSansSC.variable} antialiased bg-background text-ink-soft min-h-full`}
       >
         {children}
       </body>

--- a/apps/frontend/lib/types/template-settings.ts
+++ b/apps/frontend/lib/types/template-settings.ts
@@ -130,16 +130,16 @@ export const SECTION_HEADER_SCALE_MAP: Record<SpacingLevel, number> = {
 
 // Header font family mapping
 export const HEADER_FONT_MAP: Record<HeaderFontFamily, string> = {
-  serif: 'Georgia, var(--font-noto-sans-sc), ui-serif, Cambria, "Times New Roman", Times, serif',
+  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", var(--font-noto-sans-sc), Times, serif',
   'sans-serif':
-    'var(--font-noto-sans-sc), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
+    'ui-sans-serif, system-ui, var(--font-noto-sans-sc), sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 
 export const BODY_FONT_MAP: Record<BodyFontFamily, string> = {
-  serif: 'Georgia, var(--font-noto-sans-sc), ui-serif, Cambria, "Times New Roman", Times, serif',
+  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", var(--font-noto-sans-sc), Times, serif',
   'sans-serif':
-    'var(--font-noto-sans-sc), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
+    'ui-sans-serif, system-ui, var(--font-noto-sans-sc), sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 

--- a/apps/frontend/lib/types/template-settings.ts
+++ b/apps/frontend/lib/types/template-settings.ts
@@ -130,14 +130,16 @@ export const SECTION_HEADER_SCALE_MAP: Record<SpacingLevel, number> = {
 
 // Header font family mapping
 export const HEADER_FONT_MAP: Record<HeaderFontFamily, string> = {
-  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
-  'sans-serif': 'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
+  serif: 'Georgia, var(--font-noto-sans-sc), ui-serif, Cambria, "Times New Roman", Times, serif',
+  'sans-serif':
+    'var(--font-noto-sans-sc), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 
 export const BODY_FONT_MAP: Record<BodyFontFamily, string> = {
-  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
-  'sans-serif': 'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
+  serif: 'Georgia, var(--font-noto-sans-sc), ui-serif, Cambria, "Times New Roman", Times, serif',
+  'sans-serif':
+    'var(--font-noto-sans-sc), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 


### PR DESCRIPTION
## Summary
- load `Noto Sans SC` with `next/font/google` at the app root
- include the generated CSS variable in the resume template serif and sans font stacks
- keep the existing Latin serif/sans choices while making Chinese glyph fallback deterministic across preview and generated output

## Why
Chinese resume text can fall back to different local fonts depending on the browser, OS, or rendering environment. That makes preview and downloaded output visually inconsistent even when the same template settings are selected.

This PR scopes the fix to CJK font fallback consistency. It does not change pagination logic or force screen media for PDF export.

Closes #879

## Tests
- `npx eslint app/layout.tsx lib/types/template-settings.ts`
- `npm test -- template-registration.test.ts`
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a deterministic Chinese font fallback for resume templates using `Noto_Sans_SC` so CJK text renders consistently in preview and exported PDFs. Latin fonts keep priority for Latin text, and we now use default CJK preload behavior.

- **New Features**
  - Load `Noto_Sans_SC` via `next/font/google` at the app root and expose `--font-noto-sans-sc` in header/body serif and sans stacks.

- **Bug Fixes**
  - Keep Latin families first in the stacks and let `next/font/google` manage CJK preload by default to avoid the latin-only subset issue.

<sup>Written for commit 729bf8c9c5da1c840df18bc71c93ff1e3babb2d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

