### PR TITLE
fix: contain long dialog descriptions

### DIFF
--- a/apps/frontend/components/ui/confirm-dialog.tsx
+++ b/apps/frontend/components/ui/confirm-dialog.tsx
@@ -113,7 +113,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         <DialogHeader className="p-6 pb-4">
           <div className="flex items-start gap-4">
             {icon}
-            <div className="flex-1">
+            <div className="min-w-0 flex-1">
               <DialogTitle className="font-serif text-xl font-bold uppercase tracking-tight">
                 {title}
               </DialogTitle>

--- a/apps/frontend/tests/confirm-dialog.test.tsx
+++ b/apps/frontend/tests/confirm-dialog.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+
+vi.mock('@/lib/i18n', () => ({
+  useTranslations: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('ConfirmDialog', () => {
+  it('contains long descriptions within a scrollable flex column', () => {
+    const description = `Download failed: ${'unbroken-error-token-'.repeat(30)}`;
+
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Download failed"
+        description={description}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    const descriptionElement = screen.getByText(description);
+    expect(descriptionElement).toHaveClass(
+      'max-h-60',
+      'overflow-y-auto',
+      'whitespace-pre-wrap',
+      '[overflow-wrap:anywhere]'
+    );
+    expect(descriptionElement.parentElement).toHaveClass('min-w-0', 'flex-1');
+  });
+});


### PR DESCRIPTION
## Summary

- allow the confirm-dialog text column to shrink within its flex container
- retain the existing scroll and arbitrary-wrap behavior for long error messages
- add a component regression test for long unbroken download errors

## Validation

- `npm run test -- tests/confirm-dialog.test.tsx`
- `npx eslint components/ui/confirm-dialog.tsx tests/confirm-dialog.test.tsx`
- `npx prettier --write components/ui/confirm-dialog.tsx tests/confirm-dialog.test.tsx`
- `npm run build` compiles successfully, then hits the existing locale-parity error because `messages/fr.json` is missing `interviewPrep`; this PR does not touch translations

Closes #811

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Contain long confirm dialog descriptions by letting the text column shrink within its flex container (`min-w-0`) to prevent overflow. Keeps existing scroll/wrap behavior and adds a regression test for long unbroken error messages. Closes #811.

<sup>Written for commit d01dc7356bbf58530794744421e6446f09490435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

