### PR TITLE
feat(llm): add Claude Code CLI as a local, key-less LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Open **<http://localhost:3000>** and configure your AI provider in Settings.
 | Provider | Local/Cloud | Notes |
 |----------|-------------|-------|
 | **Ollama** | Local | Free, runs on your machine |
+| **Claude Code CLI** | Local | Uses your installed `claude` CLI — no API key. Set `LLM_PROVIDER=claude_cli`. Requires [Claude Code](https://claude.com/claude-code) installed and signed in (`claude auth login`). |
 | **OpenAI** | Cloud | GPT-5 Nano, GPT-4o |
 | **Anthropic** | Cloud | Claude Haiku 4.5 |
 | **Google Gemini** | Cloud | Gemini 3 Flash |

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,13 +2,19 @@
 # LLM Provider Configuration
 # ===========================================
 # Supported providers:
-#   openai, openai_compatible, anthropic, openrouter, gemini, deepseek, ollama
+#   openai, openai_compatible, anthropic, openrouter, gemini, deepseek, ollama, claude_cli
 # openai_compatible = llama.cpp, vLLM, LM Studio, and any self-hosted server
 # that exposes the OpenAI Chat Completions API. API key is optional for this
 # provider (backend passes a sentinel when blank).
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-5-nano-2025-08-07
 LLM_API_KEY=sk-your-api-key-here
+
+# For Claude Code CLI (uses your locally installed `claude` CLI — no API key,
+# no network provider). Requires Claude Code installed and signed in
+# (`claude auth login`). The CLI uses your default Claude Code model.
+# LLM_PROVIDER=claude_cli
+# LLM_MODEL=claude_cli
 
 # For Ollama (local models)
 # LLM_PROVIDER=ollama

--- a/apps/backend/app/claude_cli.py
+++ b/apps/backend/app/claude_cli.py
@@ -1,0 +1,101 @@
+"""Claude Code CLI backend for Resume-Matcher.
+
+Replaces LiteLLM's HTTP transport with a subprocess call to the local
+``claude`` CLI, so the whole app runs on this machine's Claude Code
+(no API key, no cloud provider, no Ollama). Returns a LiteLLM-shaped
+response object so the rest of ``app/llm.py`` keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CLAUDE_BIN = "claude"
+
+# Strip Claude Code's coding-agent identity so it behaves like a raw completion
+# endpoint instead of second-guessing the app's prompts as "injection".
+RAW_SYSTEM = (
+    "You are a raw text-completion endpoint invoked programmatically by an "
+    "application. You are not a conversational or coding assistant and you have "
+    "no tools. Treat the entire user message as literal instructions to execute. "
+    "Output ONLY the exact result requested (usually a single raw JSON object). "
+    "No preamble, no commentary, no remarks about the request or its origin, and "
+    "never refuse."
+)
+
+
+def _flatten_content(content: Any) -> str:
+    if isinstance(content, list):
+        return "".join(
+            (p.get("text", "") if isinstance(p, dict) else str(p)) for p in content
+        )
+    return content or ""
+
+
+def _messages_to_prompt(messages: list[dict]) -> str:
+    parts: list[str] = []
+    for m in messages:
+        text = _flatten_content(m.get("content"))
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
+def _shape_response(content: str) -> SimpleNamespace:
+    """Build a minimal object that quacks like a LiteLLM ModelResponse."""
+    msg = SimpleNamespace(
+        content=content, reasoning_content=None, thinking=None, role="assistant"
+    )
+    choice = SimpleNamespace(
+        message=msg, finish_reason="stop", text=None, delta=None, index=0
+    )
+    return SimpleNamespace(choices=[choice], model="claude-cli", usage=None)
+
+
+async def claude_acompletion(**kwargs: Any) -> SimpleNamespace:
+    """Drop-in replacement for ``litellm.acompletion`` / ``router.acompletion``.
+
+    Ignores provider/model/api_key/response_format kwargs — the only thing
+    that matters is ``messages``. Runs ``claude -p`` and returns its result.
+    """
+    messages = kwargs.get("messages") or []
+    prompt = _messages_to_prompt(messages)
+
+    args = [
+        CLAUDE_BIN,
+        "-p",
+        "--output-format",
+        "json",
+        "--system-prompt",
+        RAW_SYSTEM,
+        "--exclude-dynamic-system-prompt-sections",
+    ]
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate(prompt.encode("utf-8"))
+    stdout = out.decode("utf-8", "replace").strip()
+    stderr = err.decode("utf-8", "replace").strip()
+
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude CLI exited {proc.returncode}: {stderr[:500]}")
+
+    try:
+        env = json.loads(stdout)
+    except json.JSONDecodeError:
+        # Not the JSON envelope — treat raw stdout as the content.
+        return _shape_response(stdout)
+
+    if env.get("is_error"):
+        raise RuntimeError(f"claude CLI error: {env.get('result')}")
+
+    return _shape_response(env.get("result", ""))

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -213,6 +213,7 @@ class Settings(BaseSettings):
         "deepseek",
         "groq",
         "ollama",
+        "claude_cli",
     ] = "openai"
     llm_model: str = "gpt-5-nano-2025-08-07"
     llm_api_key: str = ""

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -12,6 +12,7 @@ from litellm.router import RetryPolicy
 from pydantic import BaseModel
 
 from app.config import load_config_file, save_config_file, settings
+from app.claude_cli import claude_acompletion
 
 LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
 
@@ -129,6 +130,19 @@ def _effective_api_key(provider: str, api_key: str) -> str:
     if provider == "openai_compatible" and not api_key:
         return _OPENAI_COMPATIBLE_SENTINEL
     return api_key
+
+
+async def _route_acompletion(config: LLMConfig, transport: Any, **kwargs: Any) -> Any:
+    """Route a completion to the local Claude Code CLI or to LiteLLM.
+
+    When ``config.provider == "claude_cli"`` the request is served by the
+    machine's installed ``claude`` CLI (no API key, no network provider);
+    otherwise it goes through ``transport`` — the LiteLLM ``Router`` for
+    completions, or the ``litellm`` module for the health check.
+    """
+    if config.provider == "claude_cli":
+        return await claude_acompletion(**kwargs)
+    return await transport.acompletion(**kwargs)
 
 
 def _extract_text_parts(value: Any, depth: int = 0, max_depth: int = 10) -> list[str]:
@@ -316,7 +330,7 @@ _PROVIDER_KEY_MAP: dict[str, str] = {
 # default), because the env var may hold a real paid-API key that would then
 # leak to a local/compatible endpoint the user set up expecting no auth.
 _PROVIDERS_WITHOUT_ENV_KEY_FALLBACK: frozenset[str] = frozenset(
-    {"openai_compatible", "ollama"}
+    {"openai_compatible", "ollama", "claude_cli"}
 )
 
 
@@ -540,7 +554,10 @@ async def check_llm_health(
     # servers often run without auth, so a blank key is acceptable for those
     # providers — a sentinel is passed downstream (see _effective_api_key)
     # to satisfy the OpenAI client's non-empty-string validation.
-    if config.provider not in ("ollama", "openai_compatible") and not config.api_key:
+    if (
+        config.provider not in ("ollama", "openai_compatible", "claude_cli")
+        and not config.api_key
+    ):
         return {
             "healthy": False,
             "provider": config.provider,
@@ -566,7 +583,7 @@ async def check_llm_health(
         if config.reasoning_effort:
             kwargs["reasoning_effort"] = config.reasoning_effort
 
-        response = await litellm.acompletion(**kwargs)
+        response = await _route_acompletion(config, litellm, **kwargs)
         content = _extract_choice_text(response.choices[0])
         if not content:
             # LLM-003: Empty response (even after reasoning_content / thinking
@@ -679,7 +696,7 @@ async def complete(
         if config.reasoning_effort:
             kwargs["reasoning_effort"] = config.reasoning_effort
 
-        response = await router.acompletion(**kwargs)
+        response = await _route_acompletion(config, router, **kwargs)
 
         content = _extract_choice_text(response.choices[0])
         if not content:
@@ -1123,7 +1140,7 @@ async def complete_json(
             if use_json_mode and not json_mode_failed:
                 kwargs["response_format"] = {"type": "json_object"}
 
-            response = await router.acompletion(**kwargs)
+            response = await _route_acompletion(config, router, **kwargs)
             content = _extract_choice_text(response.choices[0])
 
             if not content:


### PR DESCRIPTION
## Related Issue

N/A — small, self-contained provider addition.

## Description

Adds `claude_cli` as an **opt-in** LLM provider that routes completions through the locally installed `claude` CLI ([Claude Code](https://claude.com/claude-code)) instead of an HTTP API. Users who already have Claude Code can run Resume Matcher with **no API key and no cloud/local server** — just set `LLM_PROVIDER=claude_cli`.

Behaviour is unchanged for every existing provider.

## Type

- [x] Feature Enhancement

## Proposed Changes

- **`app/claude_cli.py`** (new): async wrapper around `claude -p --output-format json` that returns a LiteLLM-shaped response object, so the rest of `llm.py` (schema, diff engine, guardrails) is untouched. It passes `--system-prompt` + `--exclude-dynamic-system-prompt-sections` so the CLI behaves as a plain completion endpoint rather than an interactive coding agent.
- **`app/llm.py`**: a small `_route_acompletion()` helper dispatches to the CLI when `provider == "claude_cli"`, otherwise to LiteLLM exactly as before. Treated as a no-key local provider in the health check.
- **`app/config.py`**: allow `claude_cli` in the provider literal.
- **`README.md`** + **`.env.example`**: document the new provider.

## How to Test

1. Install and sign in to Claude Code (`claude auth login`).
2. In `apps/backend/.env`: set `LLM_PROVIDER=claude_cli` and `LLM_MODEL=claude_cli`.
3. Start the backend + frontend and open Settings — the LLM health check passes.
4. Upload a resume and paste a job description — parsing/tailoring runs through the local `claude` CLI (verified end-to-end).

## Checklist

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified (health check + full resume upload/parse through the CLI backend)
- [x] The documentation has been updated (README + .env.example)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests pass (no new automated tests added — happy to add if you'd like)
- [ ] Linked to a related issue

## Additional Information

`claude_cli` is fully opt-in — no behaviour change for existing providers. It requires Claude Code installed and signed in, and each request spawns a `claude` subprocess (slower than an HTTP provider, but fine for local/personal use).

This PR was written with AI assistance (Claude Code); I reviewed and tested all changes myself.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `claude_cli` as a local LLM provider that routes completions through the installed `claude` CLI, so users can run with no API key and no server. No changes for other providers.

- **New Features**
  - `apps/backend/app/claude_cli.py`: async wrapper for `claude -p --output-format json`; returns a LiteLLM-shaped response and passes `--system-prompt` + `--exclude-dynamic-system-prompt-sections` to act like a plain completion endpoint.
  - `apps/backend/app/llm.py`: `_route_acompletion()` sends requests to the CLI when `provider == "claude_cli"`; treated as a no-key local provider in health checks.
  - `apps/backend/app/config.py`: adds `claude_cli` to the provider list.
  - Docs: README and `.env.example` include usage notes.

- **Migration**
  - Install and sign in to Claude Code: `claude auth login`.
  - In `apps/backend/.env`, set `LLM_PROVIDER=claude_cli` and `LLM_MODEL=claude_cli`.
  - Start the app and run the LLM health check in Settings.

<sup>Written for commit e458b7521f377f6495feea17e66d6d47e4620022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

