### PR TITLE
Add Azure AI Foundry provider support

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -206,6 +206,7 @@ Resume Matcher supports multiple AI providers. You can configure your provider t
 | Provider | Configuration | Get API Key |
 |----------|--------------|-------------|
 | **OpenAI** | `LLM_PROVIDER=openai`<br>`LLM_MODEL=gpt-5-nano-2025-08-07` | [platform.openai.com](https://platform.openai.com/api-keys) |
+| **Azure AI Foundry** | `LLM_PROVIDER=azure_foundry`<br>`LLM_MODEL=mistral-large-latest`<br>`LLM_API_BASE=https://<resource>.services.ai.azure.com/models`<br>For Foundry-hosted Azure OpenAI GPT deployments, use the service root or the full `/openai/v1/responses` endpoint from Foundry. | Azure AI Foundry endpoint/key |
 | **Anthropic** | `LLM_PROVIDER=anthropic`<br>`LLM_MODEL=claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com/) |
 | **Google Gemini** | `LLM_PROVIDER=gemini`<br>`LLM_MODEL=gemini/gemini-3-flash-preview` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | **OpenRouter** | `LLM_PROVIDER=openrouter`<br>`LLM_MODEL=deepseek/deepseek-chat` | [openrouter.ai](https://openrouter.ai/keys) |

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,7 +2,7 @@
 # LLM Provider Configuration
 # ===========================================
 # Supported providers:
-#   openai, openai_compatible, anthropic, openrouter, gemini, deepseek, ollama
+#   openai, openai_compatible, azure_foundry, anthropic, openrouter, gemini, deepseek, groq, ollama
 # openai_compatible = llama.cpp, vLLM, LM Studio, and any self-hosted server
 # that exposes the OpenAI Chat Completions API. API key is optional for this
 # provider (backend passes a sentinel when blank).
@@ -30,6 +30,18 @@ LLM_API_KEY=sk-your-api-key-here
 # LLM_PROVIDER=openrouter
 # LLM_MODEL=deepseek/deepseek-chat
 # LLM_API_KEY=sk-or-v1-your-key
+
+# For Azure AI Foundry / Azure AI Inference model endpoints
+# LLM_PROVIDER=azure_foundry
+# LLM_MODEL=mistral-large-latest
+# LLM_API_BASE=https://<resource>.services.ai.azure.com/models
+# LLM_API_KEY=your-azure-ai-foundry-key
+#
+# For Azure OpenAI GPT deployments in Azure AI Foundry, you can use the
+# service root or paste the full v1 endpoint from Foundry; the backend will
+# normalize it for LiteLLM:
+# LLM_MODEL=gpt-5.4-mini
+# LLM_API_BASE=https://<resource>.services.ai.azure.com/openai/v1/responses
 
 # For Anthropic
 # LLM_PROVIDER=anthropic

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -154,6 +154,7 @@ def migrate_legacy_keys() -> None:
 _LEGACY_PROVIDER_KEY_MAP: dict[str, str] = {
     "openai": "openai",
     "openai_compatible": "openai_compatible",
+    "azure_foundry": "azure_foundry",
     "anthropic": "anthropic",
     "gemini": "google",
     "openrouter": "openrouter",
@@ -182,6 +183,7 @@ def _get_llm_api_key_with_fallback() -> str:
     # Map provider to config key
     provider_map = {
         "openai": "openai",
+        "azure_foundry": "azure_foundry",
         "anthropic": "anthropic",
         "gemini": "google",
         "openrouter": "openrouter",
@@ -207,6 +209,7 @@ class Settings(BaseSettings):
     llm_provider: Literal[
         "openai",
         "openai_compatible",
+        "azure_foundry",
         "anthropic",
         "openrouter",
         "gemini",

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -5,6 +5,7 @@ import logging
 import re
 import threading
 from typing import Any, Literal
+from urllib.parse import urlsplit
 
 import litellm
 from litellm import Router
@@ -58,7 +59,40 @@ class LLMConfig(BaseModel):
     model: str
     api_key: str
     api_base: str | None = None
+    api_version: str | None = None
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
+
+
+def _is_azure_openai_foundry_endpoint(api_base: str | None) -> bool:
+    """Return True for Azure AI Foundry endpoints exposing Azure OpenAI APIs."""
+    if not api_base:
+        return False
+    parsed = urlsplit(api_base.strip())
+    host = parsed.hostname or ""
+    return host.endswith(".services.ai.azure.com") and "/openai" in parsed.path
+
+
+def _is_azure_foundry_gpt5_model(model: str) -> bool:
+    """Return True when a deployment/model name should use LiteLLM GPT-5 routing."""
+    normalized = model.lower()
+    return "gpt-5" in normalized or "gpt5_series/" in normalized
+
+
+def _azure_foundry_api_version(config: LLMConfig) -> str | None:
+    """Resolve API version for Azure Foundry calls.
+
+    Azure's v1 Foundry/OpenAI URLs look like
+    `https://<resource>.services.ai.azure.com/openai/v1/responses`. LiteLLM
+    expects the service root plus `api_version='v1'` for that API family.
+    """
+    if config.api_version:
+        return config.api_version
+    if config.provider != "azure_foundry" or not config.api_base:
+        return None
+    parsed = urlsplit(config.api_base.strip())
+    if "/openai/v1" in parsed.path:
+        return "v1"
+    return None
 
 
 def _normalize_api_base(provider: str, api_base: str | None) -> str | None:
@@ -82,6 +116,13 @@ def _normalize_api_base(provider: str, api_base: str | None) -> str | None:
         return None
 
     base = base.rstrip("/")
+
+    # Azure AI Foundry can expose Azure OpenAI APIs under paths like
+    # /openai/v1/responses. LiteLLM's Azure v1 client expects the service root
+    # and appends /openai/v1/ itself, so strip endpoint-specific suffixes.
+    if provider == "azure_foundry" and _is_azure_openai_foundry_endpoint(base):
+        parsed = urlsplit(base)
+        return f"{parsed.scheme}://{parsed.netloc}"
 
     # OpenAI / OpenAI-compatible: preserve the URL as-is. The OpenAI client
     # resolves paths correctly whether the base includes /v1 or not.
@@ -302,6 +343,7 @@ def _scrub_secrets(text: str) -> str:
 _PROVIDER_KEY_MAP: dict[str, str] = {
     "openai": "openai",
     "openai_compatible": "openai_compatible",
+    "azure_foundry": "azure_foundry",
     "anthropic": "anthropic",
     "gemini": "google",
     "openrouter": "openrouter",
@@ -396,6 +438,7 @@ def get_llm_config() -> LLMConfig:
         model=model,
         api_key=api_key,
         api_base=stored.get("api_base", settings.llm_api_base),
+        api_version=stored.get("api_version"),
         reasoning_effort=reasoning_effort,
     )
 
@@ -413,6 +456,7 @@ def get_model_name(config: LLMConfig) -> str:
         # client handles the request; works for llama.cpp, vLLM, LM Studio,
         # and any server exposing the OpenAI Chat Completions API shape.
         "openai_compatible": "openai/",
+        "azure_foundry": "azure_ai/",
         "anthropic": "anthropic/",
         "openrouter": "openrouter/",
         "gemini": "gemini/",
@@ -422,6 +466,15 @@ def get_model_name(config: LLMConfig) -> str:
     }
 
     prefix = provider_prefixes.get(config.provider, "")
+
+    if config.provider == "azure_foundry" and _is_azure_openai_foundry_endpoint(
+        config.api_base
+    ):
+        if config.model.startswith("azure/"):
+            return config.model
+        if _is_azure_foundry_gpt5_model(config.model):
+            return f"azure/gpt5_series/{config.model}"
+        return f"azure/{config.model}"
 
     # OpenRouter is special: always add openrouter/ prefix unless already present
     # OpenRouter models use nested format: openrouter/anthropic/claude-3.5-sonnet
@@ -437,6 +490,8 @@ def get_model_name(config: LLMConfig) -> str:
         "gemini/",
         "deepseek/",
         "groq/",
+        "azure/",
+        "azure_ai/",
         "ollama/",
         "ollama_chat/",
         "openai/",
@@ -466,7 +521,7 @@ def _config_fingerprint(config: LLMConfig) -> str:
     The raw key is never stored in the fingerprint string.
     """
     key_hash = hash(config.api_key) if config.api_key else 0
-    return f"{config.provider}|{config.model}|{key_hash}|{config.api_base}"
+    return f"{config.provider}|{config.model}|{key_hash}|{config.api_base}|{config.api_version}"
 
 
 def _build_router(config: LLMConfig) -> Router:
@@ -480,6 +535,9 @@ def _build_router(config: LLMConfig) -> Router:
     api_base = _normalize_api_base(config.provider, config.api_base)
     if api_base:
         litellm_params["api_base"] = api_base
+    api_version = _azure_foundry_api_version(config)
+    if api_version:
+        litellm_params["api_version"] = api_version
 
     return Router(
         model_list=[
@@ -563,6 +621,9 @@ async def check_llm_health(
             "api_base": _normalize_api_base(config.provider, config.api_base),
             "timeout": LLM_TIMEOUT_HEALTH_CHECK,
         }
+        api_version = _azure_foundry_api_version(config)
+        if api_version:
+            kwargs["api_version"] = api_version
         if config.reasoning_effort:
             kwargs["reasoning_effort"] = config.reasoning_effort
 
@@ -959,6 +1020,7 @@ def _calculate_timeout(
     provider_factors = {
         "openai": 1.0,
         "anthropic": 1.2,
+        "azure_foundry": 1.2,
         "openrouter": 1.5,  # More variable latency
         "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -63,13 +63,20 @@ class LLMConfig(BaseModel):
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
 
 
-def _is_azure_openai_foundry_endpoint(api_base: str | None) -> bool:
+def _is_azure_openai_foundry_endpoint(api_base: str | None, model: str | None = None) -> bool:
     """Return True for Azure AI Foundry endpoints exposing Azure OpenAI APIs."""
     if not api_base:
         return False
     parsed = urlsplit(api_base.strip())
     host = parsed.hostname or ""
-    return host.endswith(".services.ai.azure.com") and "/openai" in parsed.path
+    path = parsed.path.rstrip("/")
+    if not host.endswith(".services.ai.azure.com"):
+        return False
+    if path == "/models" or path.startswith("/models/"):
+        return False
+    if not path:
+        return model is not None and _is_azure_foundry_gpt5_model(model)
+    return path == "/openai" or path.startswith("/openai/")
 
 
 def _is_azure_foundry_gpt5_model(model: str) -> bool:
@@ -90,7 +97,8 @@ def _azure_foundry_api_version(config: LLMConfig) -> str | None:
     if config.provider != "azure_foundry" or not config.api_base:
         return None
     parsed = urlsplit(config.api_base.strip())
-    if "/openai/v1" in parsed.path:
+    path = parsed.path.rstrip("/")
+    if "/openai/v1" in path or (not path and _is_azure_foundry_gpt5_model(config.model)):
         return "v1"
     return None
 
@@ -468,7 +476,7 @@ def get_model_name(config: LLMConfig) -> str:
     prefix = provider_prefixes.get(config.provider, "")
 
     if config.provider == "azure_foundry" and _is_azure_openai_foundry_endpoint(
-        config.api_base
+        config.api_base, config.model
     ):
         if config.model.startswith(("azure/", "azure_ai/")):
             return config.model

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -1184,8 +1184,11 @@ async def complete_json(
             retry_temp = _get_retry_temperature(model_name, attempt)
             if retry_temp is not None:
                 kwargs["temperature"] = retry_temp
-            if config.reasoning_effort:
-                kwargs["reasoning_effort"] = config.reasoning_effort
+            reasoning_effort = config.reasoning_effort
+            if attempt > 0 and reasoning_effort in ("low", "medium", "high"):
+                reasoning_effort = "minimal"
+            if reasoning_effort:
+                kwargs["reasoning_effort"] = reasoning_effort
 
             # JSON-012: Fallback to prompt-only JSON mode after JSON-mode failure.
             # LiteLLM registry may report support for models that the upstream

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -470,7 +470,7 @@ def get_model_name(config: LLMConfig) -> str:
     if config.provider == "azure_foundry" and _is_azure_openai_foundry_endpoint(
         config.api_base
     ):
-        if config.model.startswith("azure/"):
+        if config.model.startswith(("azure/", "azure_ai/")):
             return config.model
         if _is_azure_foundry_gpt5_model(config.model):
             return f"azure/gpt5_series/{config.model}"

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -434,6 +434,7 @@ async def update_feature_prompts(
 # their env-fallback skip in resolve_api_key.
 SUPPORTED_PROVIDERS = [
     "openai",
+    "azure_foundry",
     "anthropic",
     "google",
     "openrouter",
@@ -493,6 +494,13 @@ async def update_api_keys(request: ApiKeysUpdateRequest) -> ApiKeysUpdateRespons
         elif "openai" in stored_keys:
             del stored_keys["openai"]
         updated.append("openai")
+
+    if request.azure_foundry is not None:
+        if request.azure_foundry:
+            stored_keys["azure_foundry"] = request.azure_foundry
+        elif "azure_foundry" in stored_keys:
+            del stored_keys["azure_foundry"]
+        updated.append("azure_foundry")
 
     if request.anthropic is not None:
         if request.anthropic:

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -752,6 +752,7 @@ class ApiKeysUpdateRequest(BaseModel):
     """Request to update API keys."""
 
     openai: str | None = None
+    azure_foundry: str | None = None
     anthropic: str | None = None
     google: str | None = None
     openrouter: str | None = None

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -7,6 +7,7 @@ import pytest
 from app.llm import (
     LLMConfig,
     _appears_truncated,
+    _azure_foundry_api_version,
     _get_retry_temperature,
     _normalize_api_base,
     _supports_temperature,
@@ -54,6 +55,29 @@ class TestProviderConfiguration:
         )
 
         assert get_model_name(config) == "azure_ai/command-r-plus"
+
+    def test_azure_foundry_service_root_routes_gpt5_via_azure(self):
+        """Foundry service-root GPT deployments use Azure GPT-5 routing."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="gpt-5.4-mini",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com",
+        )
+
+        assert get_model_name(config) == "azure/gpt5_series/gpt-5.4-mini"
+        assert _azure_foundry_api_version(config) == "v1"
+
+    def test_azure_foundry_service_root_keeps_non_gpt_on_azure_ai(self):
+        """Non-GPT Foundry service-root models keep Azure AI Inference routing."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="mistral-large-latest",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com",
+        )
+
+        assert get_model_name(config) == "azure_ai/mistral-large-latest"
 
     def test_azure_foundry_openai_endpoint_routes_gpt5_via_azure(self):
         """Foundry Azure OpenAI endpoints use Azure GPT-5 routing."""

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -44,6 +44,17 @@ class TestProviderConfiguration:
 
         assert get_model_name(config) == "azure_ai/command-r-plus"
 
+    def test_azure_foundry_openai_endpoint_preserves_azure_ai_prefix(self):
+        """Azure OpenAI-style Foundry endpoints do not rewrite azure_ai models."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="azure_ai/command-r-plus",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com/openai/v1/responses",
+        )
+
+        assert get_model_name(config) == "azure_ai/command-r-plus"
+
     def test_azure_foundry_openai_endpoint_routes_gpt5_via_azure(self):
         """Foundry Azure OpenAI endpoints use Azure GPT-5 routing."""
         config = LLMConfig(

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -4,7 +4,72 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.llm import _appears_truncated, _get_retry_temperature, _supports_temperature
+from app.llm import (
+    LLMConfig,
+    _appears_truncated,
+    _get_retry_temperature,
+    _normalize_api_base,
+    _supports_temperature,
+    get_model_name,
+    resolve_api_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Provider configuration helpers
+# ---------------------------------------------------------------------------
+
+
+class TestProviderConfiguration:
+    """Tests for provider-specific model and key mapping."""
+
+    def test_azure_foundry_model_uses_litellm_azure_ai_prefix(self):
+        """Azure AI Foundry routes through LiteLLM's azure_ai provider."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="mistral-large-latest",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com/models",
+        )
+
+        assert get_model_name(config) == "azure_ai/mistral-large-latest"
+
+    def test_azure_foundry_model_preserves_existing_prefix(self):
+        """Already-prefixed Azure AI models are not double-prefixed."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="azure_ai/command-r-plus",
+            api_key="foundry-key",
+        )
+
+        assert get_model_name(config) == "azure_ai/command-r-plus"
+
+    def test_azure_foundry_openai_endpoint_routes_gpt5_via_azure(self):
+        """Foundry Azure OpenAI endpoints use Azure GPT-5 routing."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="gpt-5.4-mini",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com/openai/v1/responses",
+        )
+
+        assert get_model_name(config) == "azure/gpt5_series/gpt-5.4-mini"
+
+    def test_azure_foundry_openai_endpoint_normalizes_to_resource_root(self):
+        """LiteLLM appends /openai/v1 itself for Azure v1 API calls."""
+        assert (
+            _normalize_api_base(
+                "azure_foundry",
+                "https://example.services.ai.azure.com/openai/v1/responses",
+            )
+            == "https://example.services.ai.azure.com"
+        )
+
+    def test_azure_foundry_key_resolves_from_provider_store(self):
+        """Azure AI Foundry uses its own encrypted key-store slot."""
+        stored = {"api_keys": {"azure_foundry": "foundry-key"}}
+
+        assert resolve_api_key(stored, "azure_foundry") == "foundry-key"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -406,6 +406,47 @@ class TestCompleteJsonFallback:
     @patch("app.llm.get_router")
     @patch("app.llm.get_model_name")
     @patch("app.llm._supports_json_mode")
+    async def test_empty_json_retry_lowers_reasoning_effort(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """Reasoning-heavy JSON attempts can return no visible content.
+
+        Retrying with minimal effort gives GPT-5-family models enough budget to
+        produce the requested JSON instead of repeating an empty response.
+        """
+        mock_supports_json.return_value = False
+        mock_get_name.return_value = "azure/gpt5_series/gpt-5.4-mini"
+
+        empty_choice = MagicMock()
+        empty_choice.message.content = ""
+        empty_response = MagicMock()
+        empty_response.choices = [empty_choice]
+
+        good_choice = MagicMock()
+        good_choice.message.content = '{"required_skills": [], "preferred_skills": [], "keywords": []}'
+        good_response = MagicMock()
+        good_response.choices = [good_choice]
+
+        router = MagicMock()
+        router.acompletion = AsyncMock(side_effect=[empty_response, good_response])
+        config = MagicMock()
+        config.provider = "azure_foundry"
+        config.reasoning_effort = "high"
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json(prompt="Extract keywords", schema_type="keywords", retries=2)
+
+        assert result == {"required_skills": [], "preferred_skills": [], "keywords": []}
+        calls = router.acompletion.call_args_list
+        assert calls[0].kwargs["reasoning_effort"] == "high"
+        assert calls[1].kwargs["reasoning_effort"] == "minimal"
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
     async def test_json_mode_fallback_on_response_format_rejection(
         self, mock_supports_json, mock_get_name, mock_get_router
     ):

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -70,6 +70,7 @@ type Status = 'idle' | 'loading' | 'saving' | 'saved' | 'error' | 'testing';
 const PROVIDERS: LLMProvider[] = [
   'openai',
   'openai_compatible',
+  'azure_foundry',
   'anthropic',
   'openrouter',
   'gemini',
@@ -411,6 +412,11 @@ export default function SettingsPage() {
         setStatus('error');
         return;
       }
+      if (requiresApiBase && !apiBase.trim()) {
+        setError(`${providerInfo.name} requires a Base URL.`);
+        setStatus('error');
+        return;
+      }
 
       const trimmedKey = apiKey.trim();
 
@@ -457,6 +463,17 @@ export default function SettingsPage() {
     setHealthCheck(null);
 
     try {
+      if (requiresApiBase && !apiBase.trim()) {
+        setHealthCheck({
+          healthy: false,
+          provider,
+          model,
+          error: `${providerInfo.name} requires a Base URL.`,
+        });
+        setStatus('idle');
+        return;
+      }
+
       // Build config from current form values
       const testConfig: LLMConfigUpdate = {
         provider,
@@ -630,6 +647,12 @@ export default function SettingsPage() {
   };
 
   const requiresApiKey = providerInfo.requiresKey ?? true;
+  const requiresApiBase = providerInfo.requiresBaseUrl ?? false;
+  const baseUrlLabel = providerInfo.baseUrlLabel ?? t('settings.llmConfiguration.baseUrlLabel');
+  const baseUrlPlaceholder =
+    providerInfo.baseUrlPlaceholder ?? t('settings.llmConfiguration.baseUrlPlaceholder');
+  const baseUrlDescription =
+    providerInfo.baseUrlDescription ?? t('settings.llmConfiguration.baseUrlDescription');
 
   return (
     <div className="flex flex-col items-center justify-start p-6 md:p-12 min-h-screen overflow-y-auto">
@@ -964,17 +987,17 @@ export default function SettingsPage() {
 
               {/* API Base URL (optional, for proxies/aggregators/custom endpoints) */}
               <div className="space-y-2">
-                <Label htmlFor="apiBase">{t('settings.llmConfiguration.baseUrlLabel')}</Label>
+                <Label htmlFor="apiBase">
+                  {baseUrlLabel} {requiresApiBase && <span className="text-destructive">*</span>}
+                </Label>
                 <Input
                   id="apiBase"
                   value={apiBase}
                   onChange={(e) => setApiBase(e.target.value)}
-                  placeholder={t('settings.llmConfiguration.baseUrlPlaceholder')}
+                  placeholder={baseUrlPlaceholder}
                   className="font-mono"
                 />
-                <p className="text-xs text-steel-grey font-mono">
-                  {t('settings.llmConfiguration.baseUrlDescription')}
-                </p>
+                <p className="text-xs text-steel-grey font-mono">{baseUrlDescription}</p>
               </div>
 
               {/* Reasoning Effort (optional, only applies to reasoning-capable models) */}

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -385,7 +385,9 @@ export default function SettingsPage() {
     setProvider(newProvider);
     setModel(PROVIDER_INFO[newProvider].defaultModel);
 
-    if (newProvider === 'ollama' && !apiBase.trim()) {
+    if (newProvider === 'azure_foundry' && provider !== 'azure_foundry') {
+      setApiBase('');
+    } else if (newProvider === 'ollama' && !apiBase.trim()) {
       setApiBase('http://localhost:11434');
     }
     if (newProvider === 'openai_compatible' && !apiBase.trim()) {
@@ -413,7 +415,7 @@ export default function SettingsPage() {
         return;
       }
       if (requiresApiBase && !apiBase.trim()) {
-        setError(`${providerInfo.name} requires a Base URL.`);
+        setError(t('settings.errors.baseUrlRequired', { provider: providerInfo.name }));
         setStatus('error');
         return;
       }
@@ -468,7 +470,7 @@ export default function SettingsPage() {
           healthy: false,
           provider,
           model,
-          error: `${providerInfo.name} requires a Base URL.`,
+          error: t('settings.errors.baseUrlRequired', { provider: providerInfo.name }),
         });
         setStatus('idle');
         return;

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -4,6 +4,7 @@ import { apiFetch } from './client';
 export type LLMProvider =
   | 'openai'
   | 'openai_compatible'
+  | 'azure_foundry'
   | 'anthropic'
   | 'openrouter'
   | 'gemini'
@@ -138,7 +139,15 @@ export async function fetchSystemStatus(): Promise<SystemStatus> {
 // Provider display names and default models
 export const PROVIDER_INFO: Record<
   LLMProvider,
-  { name: string; defaultModel: string; requiresKey: boolean }
+  {
+    name: string;
+    defaultModel: string;
+    requiresKey: boolean;
+    requiresBaseUrl?: boolean;
+    baseUrlLabel?: string;
+    baseUrlPlaceholder?: string;
+    baseUrlDescription?: string;
+  }
 > = {
   openai: { name: 'OpenAI', defaultModel: 'gpt-5-nano-2025-08-07', requiresKey: true },
   // OpenAI-compatible: llama.cpp, vLLM, LM Studio, and other servers that expose
@@ -148,6 +157,16 @@ export const PROVIDER_INFO: Record<
     name: 'OpenAI-Compatible (Local)',
     defaultModel: 'custom-model',
     requiresKey: false,
+  },
+  azure_foundry: {
+    name: 'Azure AI Foundry',
+    defaultModel: 'mistral-large-latest',
+    requiresKey: true,
+    requiresBaseUrl: true,
+    baseUrlLabel: 'Azure AI Foundry endpoint',
+    baseUrlPlaceholder: 'https://<resource>.services.ai.azure.com/openai/v1/responses',
+    baseUrlDescription:
+      'Paste the endpoint from Foundry. GPT deployments can use the service root or /openai/v1/responses; Azure AI Inference models can use the /models endpoint.',
   },
   anthropic: { name: 'Anthropic', defaultModel: 'claude-haiku-4-5-20251001', requiresKey: true },
   openrouter: {
@@ -373,6 +392,7 @@ export async function updateFeaturePrompts(update: FeaturePromptsUpdate): Promis
 // API Key Management types
 export type ApiKeyProvider =
   | 'openai'
+  | 'azure_foundry'
   | 'anthropic'
   | 'google'
   | 'openrouter'
@@ -401,6 +421,7 @@ export interface ApiKeyStatusResponse {
 
 export interface ApiKeysUpdateRequest {
   openai?: string;
+  azure_foundry?: string;
   anthropic?: string;
   google?: string;
   openrouter?: string;
@@ -419,6 +440,7 @@ export interface ApiKeysUpdateResponse {
 export const API_KEY_PROVIDER_INFO: Record<ApiKeyProvider, { name: string; description: string }> =
   {
     openai: { name: 'OpenAI', description: 'GPT-4, GPT-4o, etc.' },
+    azure_foundry: { name: 'Azure AI Foundry', description: 'Azure AI Inference models' },
     anthropic: { name: 'Anthropic', description: 'Claude 3.5, Claude 4, etc.' },
     google: { name: 'Google', description: 'Gemini 1.5, Gemini 2, etc.' },
     openrouter: { name: 'OpenRouter', description: 'Access multiple providers' },

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "Can't reach the server. Make sure it's running.",
       "apiKeyRequired": "API key is required for the selected provider.",
+      "baseUrlRequired": "{provider} requires a Base URL.",
       "unknownProvider": "Unknown provider returned from backend: {provider}",
       "unableToSaveConfiguration": "Unable to save configuration",
       "failedToClearApiKeys": "Failed to clear API keys. Please try again.",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "No se puede acceder al servidor. Asegúrate de que esté en ejecución.",
       "apiKeyRequired": "Se requiere una clave API para el proveedor seleccionado.",
+      "baseUrlRequired": "{provider} requiere una URL base.",
       "unknownProvider": "Proveedor desconocido devuelto por el backend: {provider}",
       "unableToSaveConfiguration": "No se pudo guardar la configuración",
       "failedToClearApiKeys": "No se pudieron borrar las claves API. Inténtalo de nuevo.",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "Impossible d'atteindre le serveur. Assurez-vous qu'il est en cours d'exécution.",
       "apiKeyRequired": "La clé API est requise pour le fournisseur sélectionné.",
+      "baseUrlRequired": "{provider} nécessite une URL de base.",
       "unknownProvider": "Fournisseur inconnu retourné par le backend : {provider}",
       "unableToSaveConfiguration": "Impossible d'enregistrer la configuration",
       "failedToClearApiKeys": "Impossible d'effacer les clés API. Veuillez réessayer.",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -176,7 +176,8 @@
       "resume": "CV",
       "coverLetter": "LETTRE DE MOTIVATION",
       "outreach": "MESSAGE DE CONTACT",
-      "jdMatch": "CORRESPONDANCE FP"
+      "jdMatch": "CORRESPONDANCE FP",
+      "interviewPrep": "PRÉPARATION ENTRETIEN"
     },
     "footer": {
       "moduleLabel": "Module Créateur de CV",
@@ -195,7 +196,9 @@
       "outreachDescription": "Générez un message de prise de contact concis pour LinkedIn ou e-mail basé sur votre CV et la fiche de poste.",
       "generateButton": "Générer {title}",
       "coverLetterFooter": "Conseil : personnalisez d'abord pour de meilleurs résultats.",
-      "outreachFooter": "Conseil : restez bref et personnalisé."
+      "outreachFooter": "Conseil : restez bref et personnalisé.",
+      "interviewPrepDescription": "Générez une préparation à l'entretien adaptée au poste à partir de votre CV personnalisé et de la fiche de poste.",
+      "interviewPrepFooter": "Conseil : utilisez-la après la personnalisation pour préparer des réponses fiables et ancrées dans votre CV."
     },
     "regenerateDialog": {
       "title": "Régénérer {title} ?",
@@ -444,7 +447,8 @@
       "editorPanel": "Panneau d'édition",
       "coverLetterEditor": "Éditeur de lettre de motivation",
       "outreachEditor": "Éditeur de message de contact",
-      "jdMatchAnalysis": "Analyse de correspondance FP"
+      "jdMatchAnalysis": "Analyse de correspondance FP",
+      "interviewPrep": "Préparation à l'entretien"
     },
     "alerts": {
       "saveNotAvailable": "L'enregistrement n'est disponible que lors de la modification d'un CV existant.",
@@ -461,7 +465,8 @@
       "coverLetterDownloadFailed": "Impossible de télécharger la lettre de motivation : {error}",
       "outreachSaveFailed": "Impossible d'enregistrer le message de contact. Veuillez réessayer.",
       "coverLetterGenerateFailed": "Impossible de générer la lettre de motivation : {error}",
-      "outreachGenerateFailed": "Impossible de générer le message de contact : {error}"
+      "outreachGenerateFailed": "Impossible de générer le message de contact : {error}",
+      "interviewPrepGenerateFailed": "Impossible de générer la préparation à l'entretien : {error}"
     }
   },
   "enrichment": {
@@ -705,7 +710,11 @@
       "customPromptLabel": "Invite personnalisée (optionnelle)",
       "customPromptHelp": "Doit inclure ces espaces réservés (chacun entre accolades) : job_description, resume_data, output_language. Laissez vide pour utiliser l'invite par défaut.",
       "customPromptResetButton": "Rétablir la valeur par défaut",
-      "customPromptErrorMissing": "Espaces réservés manquants : {missing}"
+      "customPromptErrorMissing": "Espaces réservés manquants : {missing}",
+      "interviewPrep": {
+        "label": "Préparation à l'entretien",
+        "description": "Générez automatiquement une préparation à l'entretien avec les CV personnalisés enregistrés"
+      }
     },
     "promptSettings": {
       "title": "Paramètres d'invite",
@@ -1005,6 +1014,25 @@
       "loadFailed": "Impossible de charger les candidatures.",
       "moveFailed": "Impossible de déplacer la candidature.",
       "deleteFailed": "Impossible de supprimer la ou les candidatures."
+    }
+  },
+  "interviewPrep": {
+    "title": "Préparation à l'entretien",
+    "regenerate": "Régénérer",
+    "unavailableTitle": "Préparation à l'entretien indisponible",
+    "loadingContextDescription": "Vérification du contexte du poste pour ce CV personnalisé avant la génération.",
+    "missingContextDescription": "Ce CV personnalisé ne contient pas le contexte de poste enregistré nécessaire pour générer la préparation à l'entretien. Personnalisez à nouveau le CV avec une fiche de poste pour utiliser ce flux.",
+    "saveRequiredDescription": "Enregistrez ce CV personnalisé avant de générer la préparation à l'entretien.",
+    "focusArea": "Point d'attention",
+    "suggestedAnswerPoints": "Points de réponse suggérés",
+    "whyItMatters": "Pourquoi c'est important",
+    "preparationSuggestion": "Suggestion de préparation",
+    "sections": {
+      "roleFit": "Analyse d'adéquation au poste",
+      "resumeQuestions": "Questions basées sur le CV",
+      "projectFollowUps": "Questions de suivi sur les projets",
+      "skillGaps": "Écarts de compétences",
+      "talkingPoints": "Points à aborder"
     }
   }
 }

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "サーバーに接続できません。サーバーが起動していることを確認してください。",
       "apiKeyRequired": "選択したプロバイダーには API キーが必要です。",
+      "baseUrlRequired": "{provider} にはベース URL が必要です。",
       "unknownProvider": "バックエンドから未知のプロバイダーが返されました: {provider}",
       "unableToSaveConfiguration": "設定を保存できません",
       "failedToClearApiKeys": "API キーの消去に失敗しました。もう一度お試しください。",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "Não foi possível alcançar o servidor. Verifique se ele está rodando.",
       "apiKeyRequired": "Chave de API é necessária para o provedor selecionado.",
+      "baseUrlRequired": "{provider} requer uma URL base.",
       "unknownProvider": "Provedor desconhecido retornado do backend: {provider}",
       "unableToSaveConfiguration": "Não foi possível salvar a configuração",
       "failedToClearApiKeys": "Falha ao limpar chaves de API. Por favor, tente novamente.",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "无法连接到服务器。请确认服务器正在运行。",
       "apiKeyRequired": "所选提供商需要 API 密钥。",
+      "baseUrlRequired": "{provider} 需要基础 URL。",
       "unknownProvider": "后端返回未知提供商：{provider}",
       "unableToSaveConfiguration": "无法保存配置",
       "failedToClearApiKeys": "清除 API 密钥失败，请重试。",

--- a/docs/agent/llm-integration.md
+++ b/docs/agent/llm-integration.md
@@ -10,6 +10,7 @@ Backend uses LiteLLM to support multiple providers through a unified API:
 |----------|------|-------|
 | **Ollama** | Local | Free, runs on your machine |
 | **OpenAI** | Cloud | GPT-5 Nano, GPT-4o |
+| **Azure AI Foundry** | Cloud | Azure AI Inference / Foundry model endpoints |
 | **Anthropic** | Cloud | Claude Haiku 4.5 |
 | **Google Gemini** | Cloud | Gemini 3 Flash |
 | **OpenRouter** | Cloud | Access to multiple models |
@@ -95,6 +96,8 @@ Users configure their preferred AI provider via:
 
 - Settings page: `/settings`
 - API: `PUT /api/v1/config/llm-api-key`
+
+Azure AI Foundry uses LiteLLM's `azure_ai/` route for generic Azure AI Inference endpoints. Foundry-hosted Azure OpenAI endpoints such as `https://<resource>.services.ai.azure.com/openai/v1/responses` are normalized to the service root and routed through LiteLLM's `azure/` provider automatically. Set `LLM_PROVIDER=azure_foundry`, `LLM_MODEL` to the Foundry model or deployment name, `LLM_API_BASE` to the Azure AI endpoint, and store the Foundry API key in the `azure_foundry` key slot.
 
 ## Health Checks
 


### PR DESCRIPTION
## Summary

Adds Azure AI Foundry as a first-class LLM provider in Resume Matcher.

This covers two Foundry endpoint shapes:

- generic Azure AI Inference endpoints, routed through LiteLLM's `azure_ai/` provider
- Foundry-hosted Azure OpenAI endpoints such as `/openai/v1/responses`, normalized to the service root and routed through LiteLLM's Azure provider

The Settings page also now gives Azure Foundry-specific Base URL copy and requires the endpoint when that provider is selected.

## Why

When using a Foundry Azure OpenAI endpoint like:

```text
https://your-resource.services.ai.azure.com/openai/v1/responses
```

LiteLLM needs the service root plus `api_version="v1"`. Passing the full endpoint as `api_base` caused Azure to return `Resource not found` during the health check.

## Changes

- Add `azure_foundry` provider/key-store support in backend config and API key routes
- Route generic Foundry models through `azure_ai/`
- Detect Foundry Azure OpenAI endpoints and route GPT-5 deployments through `azure/gpt5_series/`
- Normalize `/openai/v1/...` Foundry URLs to the service root before calling LiteLLM
- Add Azure Foundry provider option and provider-specific Base URL guidance in Settings
- Add regression tests for Foundry model routing and URL normalization
- Fill missing French locale keys needed by the current frontend message schema
- Update setup and LLM integration docs

## Tested

```text
uv run --extra dev pytest tests/unit/test_llm.py -q
npx tsc --noEmit
npx eslint "lib/api/config.ts" "app/(default)/settings/page.tsx"
docker build -t resume-matcher:azure-foundry .
```

Also smoke-tested locally with `azure_foundry` + a GPT-5 deployment through `/api/v1/config/llm-test`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Azure AI Foundry as a first-class LLM provider with correct routing for Azure AI Inference and Foundry‑hosted Azure OpenAI deployments. Also improves JSON-mode reliability by lowering reasoning effort on retries.

- **New Features**
  - Backend: new `azure_foundry` provider with its own key slot; default routes via `azure_ai/`; Foundry Azure OpenAI endpoints are normalized to the service root, set `api_version="v1"`, and route via `azure/` (GPT‑5 via `azure/gpt5_series/`); preserve already‑prefixed `azure/` or `azure_ai/` models; health checks pass `api_version`; timeout factor added; API keys API and supported providers updated; JSON retries now lower `reasoning_effort` to `minimal` after a failed attempt to reduce empty responses.
  - Frontend: Settings adds Azure Foundry with required Base URL, provider‑specific label/placeholder, and Save/LLM Test validation; added “base URL required” translations across locales.
  - Tests & docs: unit tests for routing, normalization, `api_version`, prefix preservation, key resolution, and reasoning‑effort retry; updates to `SETUP.md`, `.env.example`, and LLM integration docs.

- **Migration**
  - Set `LLM_PROVIDER=azure_foundry`, pick a model, and store the Foundry API key in the `azure_foundry` slot (Settings or `PUT /api/v1/config/llm-api-key`).
  - Azure AI Inference models: `LLM_MODEL=mistral-large-latest`, `LLM_API_BASE=https://<resource>.services.ai.azure.com/models`.
  - Foundry Azure OpenAI deployments: set `LLM_MODEL=<deployment>` and `LLM_API_BASE` to the service root or full `/openai/v1/responses`; the backend normalizes and sets `api_version="v1"` automatically.

<sup>Written for commit 51d004d61333768cc7c3aee5717e6d2f7c422b0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

