### PR TITLE
fix(i18n): add missing interviewPrep keys to fr.json (unblocks Docker publish)

### DIFF
--- a/apps/frontend/components/tailor/ats-score-card.tsx
+++ b/apps/frontend/components/tailor/ats-score-card.tsx
@@ -75,11 +75,7 @@ export function ATSScoreCard({ atsScore }: ATSScoreCardProps) {
       {/* Sub-score breakdown */}
       <div className="space-y-3">
         {Object.entries(sub_scores).map(([key, value]) => (
-          <SubScoreRow
-            key={key}
-            label={SUB_SCORE_LABELS[key] ?? key}
-            value={value}
-          />
+          <SubScoreRow key={key} label={SUB_SCORE_LABELS[key] ?? key} value={value} />
         ))}
       </div>
 

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -176,7 +176,8 @@
       "resume": "CV",
       "coverLetter": "LETTRE DE MOTIVATION",
       "outreach": "MESSAGE DE CONTACT",
-      "jdMatch": "CORRESPONDANCE FP"
+      "jdMatch": "CORRESPONDANCE FP",
+      "interviewPrep": "PRÉPARATION ENTRETIEN"
     },
     "footer": {
       "moduleLabel": "Module Créateur de CV",
@@ -195,7 +196,9 @@
       "outreachDescription": "Générez un message de prise de contact concis pour LinkedIn ou e-mail basé sur votre CV et la fiche de poste.",
       "generateButton": "Générer {title}",
       "coverLetterFooter": "Conseil : personnalisez d'abord pour de meilleurs résultats.",
-      "outreachFooter": "Conseil : restez bref et personnalisé."
+      "outreachFooter": "Conseil : restez bref et personnalisé.",
+      "interviewPrepDescription": "Générez une préparation à l'entretien spécifique au poste, basée sur votre CV personnalisé et la fiche de poste.",
+      "interviewPrepFooter": "Conseil : utilisez cette fonction après la personnalisation pour préparer des réponses sincères et fondées sur votre CV."
     },
     "regenerateDialog": {
       "title": "Régénérer {title} ?",
@@ -444,7 +447,8 @@
       "editorPanel": "Panneau d'édition",
       "coverLetterEditor": "Éditeur de lettre de motivation",
       "outreachEditor": "Éditeur de message de contact",
-      "jdMatchAnalysis": "Analyse de correspondance FP"
+      "jdMatchAnalysis": "Analyse de correspondance FP",
+      "interviewPrep": "Préparation à l'entretien"
     },
     "alerts": {
       "saveNotAvailable": "L'enregistrement n'est disponible que lors de la modification d'un CV existant.",
@@ -461,7 +465,8 @@
       "coverLetterDownloadFailed": "Impossible de télécharger la lettre de motivation : {error}",
       "outreachSaveFailed": "Impossible d'enregistrer le message de contact. Veuillez réessayer.",
       "coverLetterGenerateFailed": "Impossible de générer la lettre de motivation : {error}",
-      "outreachGenerateFailed": "Impossible de générer le message de contact : {error}"
+      "outreachGenerateFailed": "Impossible de générer le message de contact : {error}",
+      "interviewPrepGenerateFailed": "Impossible de générer la préparation à l'entretien : {error}"
     }
   },
   "enrichment": {
@@ -705,7 +710,11 @@
       "customPromptLabel": "Invite personnalisée (optionnelle)",
       "customPromptHelp": "Doit inclure ces espaces réservés (chacun entre accolades) : job_description, resume_data, output_language. Laissez vide pour utiliser l'invite par défaut.",
       "customPromptResetButton": "Rétablir la valeur par défaut",
-      "customPromptErrorMissing": "Espaces réservés manquants : {missing}"
+      "customPromptErrorMissing": "Espaces réservés manquants : {missing}",
+      "interviewPrep": {
+        "label": "Préparation à l'entretien",
+        "description": "Générez automatiquement une préparation à l'entretien en même temps que les CV personnalisés enregistrés"
+      }
     },
     "promptSettings": {
       "title": "Paramètres d'invite",
@@ -1005,6 +1014,25 @@
       "loadFailed": "Impossible de charger les candidatures.",
       "moveFailed": "Impossible de déplacer la candidature.",
       "deleteFailed": "Impossible de supprimer la ou les candidatures."
+    }
+  },
+  "interviewPrep": {
+    "title": "Préparation à l'entretien",
+    "regenerate": "Régénérer",
+    "unavailableTitle": "Préparation à l'entretien non disponible",
+    "loadingContextDescription": "Vérification du contexte du poste pour ce CV personnalisé avant la génération.",
+    "missingContextDescription": "Ce CV personnalisé ne dispose pas du contexte de poste enregistré nécessaire pour générer la préparation à l'entretien. Personnalisez à nouveau le CV avec une fiche de poste pour utiliser ce flux.",
+    "saveRequiredDescription": "Enregistrez ce CV personnalisé avant de générer la préparation à l'entretien.",
+    "focusArea": "Point d'attention",
+    "suggestedAnswerPoints": "Éléments de réponse suggérés",
+    "whyItMatters": "Pourquoi c'est important",
+    "preparationSuggestion": "Suggestion de préparation",
+    "sections": {
+      "roleFit": "Analyse d'adéquation au poste",
+      "resumeQuestions": "Questions basées sur le CV",
+      "projectFollowUps": "Questions de suivi sur les projets",
+      "skillGaps": "Écarts de compétences",
+      "talkingPoints": "Arguments clés"
     }
   }
 }


### PR DESCRIPTION
## Why

`Publish Docker Image` has failed on **every push to `main` since 2026-07-06** ([run 28813449466](https://github.com/srbhr/Resume-Matcher/actions/runs/28813449466)). No `latest` image has shipped since then.

The failure is a **semantic merge conflict** between two PRs that were each green on their own branch:

| PR | Merged | What it did |
|----|--------|-------------|
| #869 French language support | 17:42 | Added `messages/fr.json`, branched 2026-06-27 — before interview prep existed |
| #873 Interview prep workflow | 18:18 | Added `interviewPrep` keys to `en/es/ja/pt-BR/zh`, branched 2026-07-02 — before French existed |

Neither branch contained the other's changes, so neither build saw the gap. Merging #873 on top of #869 produced a `main` where `fr.json` is missing every `interviewPrep` key.

`lib/i18n/messages.ts` types every locale as `typeof en`, so the gap is a hard type error:

```
lib/i18n/messages.ts(18,3): error TS2741: Property '"interviewPrep"' is missing in type
'{ common: {...}; ... 16 more ...; tracker: {...} }' but required in type
'{ common: {...}; ... 17 more ...; interviewPrep: {...} }'.
```

`next build` runs `tsc`, the Dockerfile runs `npm run build`, so buildx fails:

```
#24 ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1
ERROR: failed to build: failed to solve: ...
##[error]buildx failed with: ERROR: failed to build: ...
```

## What

Adds the **25 missing keys** to `fr.json`. `tsc` only reported the top-level `interviewPrep`; `scripts/check_locale_parity.py` surfaced the full set, which also includes nested entries that would have failed next:

- `interviewPrep.*` — top-level tree (title, regenerate, focusArea, sections.*, …)
- `builder.previewTabs.interviewPrep`
- `builder.leftPanel.interviewPrep`
- `builder.generatePrompt.interviewPrepDescription` / `.interviewPrepFooter`
- `builder.alerts.interviewPrepGenerateFailed`
- `settings.contentGeneration.interviewPrep.label` / `.description`

Translations follow the terminology already established in `fr.json`: `CV`, `fiche de poste`, `Régénérer`, `Conseil :`. Keys are inserted in the same order as `en.json`.

Second commit is an unrelated one-line Prettier fix in `components/tailor/ats-score-card.tsx` — a pre-existing violation from #813 that made `npm run lint` red on `main`. Pure formatting.

## Verification

```
python3 scripts/check_locale_parity.py    ok — all locale files match en.json
npx tsc --noEmit                          exit 0
npm run build                             ✓ Compiled successfully, TypeScript finished
npm run lint                              clean
npm run test                              27 files, 190 tests passed
```

Before the fix, parity reported 25 missing keys and `tsc` failed with the error above.

## Note on prevention

The guard for exactly this break already exists — `scripts/check_locale_parity.py` and `tests/i18n-locale-parity.test.ts` — but it only runs in the local `pre-push` hook, which can't see a merge performed through the GitHub UI. Two independently-green PRs can still land a red `main`. Worth considering a locale-parity check on `main` pushes, but that touches `.github/workflows/` so I've left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing `interviewPrep` translations to the French locale to restore parity with `en.json` and fix the TypeScript error blocking the Docker publish workflow. Also applies a small Prettier fix so lint passes.

- **Bug Fixes**
  - Added 25 `interviewPrep` keys to `apps/frontend/messages/fr.json` (top-level and related `builder.*` and `settings.contentGeneration.interviewPrep` entries).
  - Resolves `lib/i18n/messages.ts` parity error so `tsc`/`next build` succeed, unblocking the `Publish Docker Image` workflow.
  - Prettier-only change in `apps/frontend/components/tailor/ats-score-card.tsx` to clear lint.

<sup>Written for commit 3e88090e3f40cbffd47666d9bf5c54af53a25a62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

