### PR TITLE
Release: Korean support, Azure AI Foundry, plain description points, CJK PDF fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 \
     libatspi2.0-0 \
     libgtk-3-0 \
+    # CJK fonts for Chinese/Japanese/Korean PDF rendering via Playwright
+    fonts-noto-cjk \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/SETUP.md
+++ b/SETUP.md
@@ -206,6 +206,7 @@ Resume Matcher supports multiple AI providers. You can configure your provider t
 | Provider | Configuration | Get API Key |
 |----------|--------------|-------------|
 | **OpenAI** | `LLM_PROVIDER=openai`<br>`LLM_MODEL=gpt-5-nano-2025-08-07` | [platform.openai.com](https://platform.openai.com/api-keys) |
+| **Azure AI Foundry** | `LLM_PROVIDER=azure_foundry`<br>`LLM_MODEL=mistral-large-latest`<br>`LLM_API_BASE=https://<resource>.services.ai.azure.com/models`<br>For Foundry-hosted Azure OpenAI GPT deployments, use the service root or the full `/openai/v1/responses` endpoint from Foundry. | Azure AI Foundry endpoint/key |
 | **Anthropic** | `LLM_PROVIDER=anthropic`<br>`LLM_MODEL=claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com/) |
 | **Google Gemini** | `LLM_PROVIDER=gemini`<br>`LLM_MODEL=gemini/gemini-3-flash-preview` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | **OpenRouter** | `LLM_PROVIDER=openrouter`<br>`LLM_MODEL=deepseek/deepseek-chat` | [openrouter.ai](https://openrouter.ai/keys) |

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,7 +2,7 @@
 # LLM Provider Configuration
 # ===========================================
 # Supported providers:
-#   openai, openai_compatible, anthropic, openrouter, gemini, deepseek, ollama
+#   openai, openai_compatible, azure_foundry, anthropic, openrouter, gemini, deepseek, groq, ollama
 # openai_compatible = llama.cpp, vLLM, LM Studio, and any self-hosted server
 # that exposes the OpenAI Chat Completions API. API key is optional for this
 # provider (backend passes a sentinel when blank).
@@ -30,6 +30,18 @@ LLM_API_KEY=sk-your-api-key-here
 # LLM_PROVIDER=openrouter
 # LLM_MODEL=deepseek/deepseek-chat
 # LLM_API_KEY=sk-or-v1-your-key
+
+# For Azure AI Foundry / Azure AI Inference model endpoints
+# LLM_PROVIDER=azure_foundry
+# LLM_MODEL=mistral-large-latest
+# LLM_API_BASE=https://<resource>.services.ai.azure.com/models
+# LLM_API_KEY=your-azure-ai-foundry-key
+#
+# For Azure OpenAI GPT deployments in Azure AI Foundry, you can use the
+# service root or paste the full v1 endpoint from Foundry; the backend will
+# normalize it for LiteLLM:
+# LLM_MODEL=gpt-5.4-mini
+# LLM_API_BASE=https://<resource>.services.ai.azure.com/openai/v1/responses
 
 # For Anthropic
 # LLM_PROVIDER=anthropic

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -154,6 +154,7 @@ def migrate_legacy_keys() -> None:
 _LEGACY_PROVIDER_KEY_MAP: dict[str, str] = {
     "openai": "openai",
     "openai_compatible": "openai_compatible",
+    "azure_foundry": "azure_foundry",
     "anthropic": "anthropic",
     "gemini": "google",
     "openrouter": "openrouter",
@@ -182,6 +183,7 @@ def _get_llm_api_key_with_fallback() -> str:
     # Map provider to config key
     provider_map = {
         "openai": "openai",
+        "azure_foundry": "azure_foundry",
         "anthropic": "anthropic",
         "gemini": "google",
         "openrouter": "openrouter",
@@ -207,6 +209,7 @@ class Settings(BaseSettings):
     llm_provider: Literal[
         "openai",
         "openai_compatible",
+        "azure_foundry",
         "anthropic",
         "openrouter",
         "gemini",

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -5,6 +5,7 @@ import logging
 import re
 import threading
 from typing import Any, Literal
+from urllib.parse import urlsplit
 
 import litellm
 from litellm import Router
@@ -58,7 +59,40 @@ class LLMConfig(BaseModel):
     model: str
     api_key: str
     api_base: str | None = None
+    api_version: str | None = None
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
+
+
+def _is_azure_openai_foundry_endpoint(api_base: str | None) -> bool:
+    """Return True for Azure AI Foundry endpoints exposing Azure OpenAI APIs."""
+    if not api_base:
+        return False
+    parsed = urlsplit(api_base.strip())
+    host = parsed.hostname or ""
+    return host.endswith(".services.ai.azure.com") and "/openai" in parsed.path
+
+
+def _is_azure_foundry_gpt5_model(model: str) -> bool:
+    """Return True when a deployment/model name should use LiteLLM GPT-5 routing."""
+    normalized = model.lower()
+    return "gpt-5" in normalized or "gpt5_series/" in normalized
+
+
+def _azure_foundry_api_version(config: LLMConfig) -> str | None:
+    """Resolve API version for Azure Foundry calls.
+
+    Azure's v1 Foundry/OpenAI URLs look like
+    `https://<resource>.services.ai.azure.com/openai/v1/responses`. LiteLLM
+    expects the service root plus `api_version='v1'` for that API family.
+    """
+    if config.api_version:
+        return config.api_version
+    if config.provider != "azure_foundry" or not config.api_base:
+        return None
+    parsed = urlsplit(config.api_base.strip())
+    if "/openai/v1" in parsed.path:
+        return "v1"
+    return None
 
 
 def _normalize_api_base(provider: str, api_base: str | None) -> str | None:
@@ -82,6 +116,13 @@ def _normalize_api_base(provider: str, api_base: str | None) -> str | None:
         return None
 
     base = base.rstrip("/")
+
+    # Azure AI Foundry can expose Azure OpenAI APIs under paths like
+    # /openai/v1/responses. LiteLLM's Azure v1 client expects the service root
+    # and appends /openai/v1/ itself, so strip endpoint-specific suffixes.
+    if provider == "azure_foundry" and _is_azure_openai_foundry_endpoint(base):
+        parsed = urlsplit(base)
+        return f"{parsed.scheme}://{parsed.netloc}"
 
     # OpenAI / OpenAI-compatible: preserve the URL as-is. The OpenAI client
     # resolves paths correctly whether the base includes /v1 or not.
@@ -302,6 +343,7 @@ def _scrub_secrets(text: str) -> str:
 _PROVIDER_KEY_MAP: dict[str, str] = {
     "openai": "openai",
     "openai_compatible": "openai_compatible",
+    "azure_foundry": "azure_foundry",
     "anthropic": "anthropic",
     "gemini": "google",
     "openrouter": "openrouter",
@@ -396,6 +438,7 @@ def get_llm_config() -> LLMConfig:
         model=model,
         api_key=api_key,
         api_base=stored.get("api_base", settings.llm_api_base),
+        api_version=stored.get("api_version"),
         reasoning_effort=reasoning_effort,
     )
 
@@ -413,6 +456,7 @@ def get_model_name(config: LLMConfig) -> str:
         # client handles the request; works for llama.cpp, vLLM, LM Studio,
         # and any server exposing the OpenAI Chat Completions API shape.
         "openai_compatible": "openai/",
+        "azure_foundry": "azure_ai/",
         "anthropic": "anthropic/",
         "openrouter": "openrouter/",
         "gemini": "gemini/",
@@ -422,6 +466,15 @@ def get_model_name(config: LLMConfig) -> str:
     }
 
     prefix = provider_prefixes.get(config.provider, "")
+
+    if config.provider == "azure_foundry" and _is_azure_openai_foundry_endpoint(
+        config.api_base
+    ):
+        if config.model.startswith("azure/"):
+            return config.model
+        if _is_azure_foundry_gpt5_model(config.model):
+            return f"azure/gpt5_series/{config.model}"
+        return f"azure/{config.model}"
 
     # OpenRouter is special: always add openrouter/ prefix unless already present
     # OpenRouter models use nested format: openrouter/anthropic/claude-3.5-sonnet
@@ -437,6 +490,8 @@ def get_model_name(config: LLMConfig) -> str:
         "gemini/",
         "deepseek/",
         "groq/",
+        "azure/",
+        "azure_ai/",
         "ollama/",
         "ollama_chat/",
         "openai/",
@@ -466,7 +521,7 @@ def _config_fingerprint(config: LLMConfig) -> str:
     The raw key is never stored in the fingerprint string.
     """
     key_hash = hash(config.api_key) if config.api_key else 0
-    return f"{config.provider}|{config.model}|{key_hash}|{config.api_base}"
+    return f"{config.provider}|{config.model}|{key_hash}|{config.api_base}|{config.api_version}"
 
 
 def _build_router(config: LLMConfig) -> Router:
@@ -480,6 +535,9 @@ def _build_router(config: LLMConfig) -> Router:
     api_base = _normalize_api_base(config.provider, config.api_base)
     if api_base:
         litellm_params["api_base"] = api_base
+    api_version = _azure_foundry_api_version(config)
+    if api_version:
+        litellm_params["api_version"] = api_version
 
     return Router(
         model_list=[
@@ -563,6 +621,9 @@ async def check_llm_health(
             "api_base": _normalize_api_base(config.provider, config.api_base),
             "timeout": LLM_TIMEOUT_HEALTH_CHECK,
         }
+        api_version = _azure_foundry_api_version(config)
+        if api_version:
+            kwargs["api_version"] = api_version
         if config.reasoning_effort:
             kwargs["reasoning_effort"] = config.reasoning_effort
 
@@ -959,6 +1020,7 @@ def _calculate_timeout(
     provider_factors = {
         "openai": 1.0,
         "anthropic": 1.2,
+        "azure_foundry": 1.2,
         "openrouter": 1.5,  # More variable latency
         "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -1185,7 +1185,15 @@ async def complete_json(
             if retry_temp is not None:
                 kwargs["temperature"] = retry_temp
             reasoning_effort = config.reasoning_effort
-            if attempt > 0 and reasoning_effort in ("low", "medium", "high"):
+            # Azure Foundry GPT-5 deployments can burn their whole budget on
+            # reasoning and return no visible content. Dropping to minimal
+            # effort on retry leaves room for the JSON itself. Scoped to this
+            # provider so other providers keep their configured effort.
+            if (
+                attempt > 0
+                and config.provider == "azure_foundry"
+                and reasoning_effort in ("low", "medium", "high")
+            ):
                 reasoning_effort = "minimal"
             if reasoning_effort:
                 kwargs["reasoning_effort"] = reasoning_effort

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -63,13 +63,20 @@ class LLMConfig(BaseModel):
     reasoning_effort: Literal["minimal", "low", "medium", "high"] | None = None
 
 
-def _is_azure_openai_foundry_endpoint(api_base: str | None) -> bool:
+def _is_azure_openai_foundry_endpoint(api_base: str | None, model: str | None = None) -> bool:
     """Return True for Azure AI Foundry endpoints exposing Azure OpenAI APIs."""
     if not api_base:
         return False
     parsed = urlsplit(api_base.strip())
     host = parsed.hostname or ""
-    return host.endswith(".services.ai.azure.com") and "/openai" in parsed.path
+    path = parsed.path.rstrip("/")
+    if not host.endswith(".services.ai.azure.com"):
+        return False
+    if path == "/models" or path.startswith("/models/"):
+        return False
+    if not path:
+        return model is not None and _is_azure_foundry_gpt5_model(model)
+    return path == "/openai" or path.startswith("/openai/")
 
 
 def _is_azure_foundry_gpt5_model(model: str) -> bool:
@@ -90,7 +97,8 @@ def _azure_foundry_api_version(config: LLMConfig) -> str | None:
     if config.provider != "azure_foundry" or not config.api_base:
         return None
     parsed = urlsplit(config.api_base.strip())
-    if "/openai/v1" in parsed.path:
+    path = parsed.path.rstrip("/")
+    if "/openai/v1" in path or (not path and _is_azure_foundry_gpt5_model(config.model)):
         return "v1"
     return None
 
@@ -468,7 +476,7 @@ def get_model_name(config: LLMConfig) -> str:
     prefix = provider_prefixes.get(config.provider, "")
 
     if config.provider == "azure_foundry" and _is_azure_openai_foundry_endpoint(
-        config.api_base
+        config.api_base, config.model
     ):
         if config.model.startswith(("azure/", "azure_ai/")):
             return config.model

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -1184,8 +1184,11 @@ async def complete_json(
             retry_temp = _get_retry_temperature(model_name, attempt)
             if retry_temp is not None:
                 kwargs["temperature"] = retry_temp
-            if config.reasoning_effort:
-                kwargs["reasoning_effort"] = config.reasoning_effort
+            reasoning_effort = config.reasoning_effort
+            if attempt > 0 and reasoning_effort in ("low", "medium", "high"):
+                reasoning_effort = "minimal"
+            if reasoning_effort:
+                kwargs["reasoning_effort"] = reasoning_effort
 
             # JSON-012: Fallback to prompt-only JSON mode after JSON-mode failure.
             # LiteLLM registry may report support for models that the upstream

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -470,7 +470,7 @@ def get_model_name(config: LLMConfig) -> str:
     if config.provider == "azure_foundry" and _is_azure_openai_foundry_endpoint(
         config.api_base
     ):
-        if config.model.startswith("azure/"):
+        if config.model.startswith(("azure/", "azure_ai/")):
             return config.model
         if _is_azure_foundry_gpt5_model(config.model):
             return f"azure/gpt5_series/{config.model}"

--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -8,6 +8,7 @@ LANGUAGE_NAMES = {
     "ja": "Japanese",
     "pt": "Brazilian Portuguese",
     "fr": "French",
+    "ko": "Korean",
 }
 
 

--- a/apps/backend/app/prompts/templates.py
+++ b/apps/backend/app/prompts/templates.py
@@ -39,7 +39,8 @@ RESUME_SCHEMA_EXAMPLE = """{
       "description": [
         "Led development of microservices architecture",
         "Improved system performance by 40%"
-      ]
+      ],
+      "descriptionStyles": ["bullet", "bullet"]
     }
   ],
   "education": [
@@ -60,7 +61,8 @@ RESUME_SCHEMA_EXAMPLE = """{
       "description": [
         "Built CLI tool with 1000+ GitHub stars",
         "Used by 50+ companies worldwide"
-      ]
+      ],
+      "descriptionStyles": ["bullet", "bullet"]
     }
   ],
   "additional": {
@@ -78,7 +80,8 @@ RESUME_SCHEMA_EXAMPLE = """{
           "title": "Paper Title",
           "subtitle": "Journal Name",
           "years": "Jun 2023",
-          "description": ["Brief description of the publication"]
+          "description": ["Brief description of the publication"],
+          "descriptionStyles": ["bullet"]
         }
       ]
     },
@@ -102,7 +105,8 @@ IMPROVE_SCHEMA_EXAMPLE = """{
       "description": [
         "Led development of microservices architecture",
         "Improved system performance by 40%"
-      ]
+      ],
+      "descriptionStyles": ["bullet", "bullet"]
     }
   ],
   "education": [
@@ -123,7 +127,8 @@ IMPROVE_SCHEMA_EXAMPLE = """{
       "description": [
         "Built CLI tool with 1000+ GitHub stars",
         "Used by 50+ companies worldwide"
-      ]
+      ],
+      "descriptionStyles": ["bullet", "bullet"]
     }
   ],
   "additional": {
@@ -141,7 +146,8 @@ IMPROVE_SCHEMA_EXAMPLE = """{
           "title": "Paper Title",
           "subtitle": "Journal Name",
           "years": "Jun 2023",
-          "description": ["Brief description of the publication"]
+          "description": ["Brief description of the publication"],
+          "descriptionStyles": ["bullet"]
         }
       ]
     },
@@ -167,6 +173,7 @@ Custom section types:
 Rules:
 - Use "" for missing text fields, [] for missing arrays, null for optional fields
 - Number IDs starting from 1
+- For workExperience, personalProjects, and custom itemList items, include descriptionStyles with one value for each description row. Use "bullet" for normal bullet rows and "plain" for rows that should render without a bullet marker (for example subheadings or standalone labels).
 - Format dates preserving the original precision. Keep months when present: "Jan 2020 - Dec 2023", "May 2021 - Present". Use "YYYY - YYYY" only when the source has no months.
 - Use snake_case for custom section keys (e.g., "volunteer_work", "publications")
 - Preserve the original section name as a descriptive key
@@ -244,6 +251,7 @@ Rules:
 - Do NOT introduce new tools, technologies, or certifications not already present
 - Do NOT add new bullet points or sections
 - Preserve original bullet count and ordering within each section
+- Preserve descriptionStyles arrays and keep them aligned one-to-one with description arrays
 - Keep proper nouns (names, company names, locations) unchanged
 - For customSections: preserve exact structure, item count, titles, subtitles, and years. If an item's description is an empty array [] in the original, keep it empty []. Do NOT generate descriptions for items that had none.
 - Copy the "years" field values EXACTLY as they appear in the original resume (including any month prefixes like "Jan 2020 - Present"). Do not shorten, reformat, or drop months.
@@ -274,6 +282,7 @@ Rules:
 - You may rephrase bullet points to include keyword phrasing
 - Do NOT introduce new skills, tools, or certifications not in the resume
 - Do NOT change role, industry, or seniority level
+- Preserve descriptionStyles arrays and keep them aligned one-to-one with description arrays
 - For customSections: preserve exact structure, item count, titles, subtitles, and years. If an item's description is an empty array [] in the original, keep it empty []. Do NOT generate descriptions for items that had none.
 - Copy the "years" field values EXACTLY as they appear in the original resume (including any month prefixes like "Jan 2020 - Present"). Do not shorten, reformat, or drop months.
 - If resume is non-technical, keep language non-technical while still aligning keywords
@@ -304,6 +313,7 @@ Rules:
 - Preserve existing action verbs. Do not invent quantifiable achievements not in the original.
 - Keep proper nouns (names, company names, locations) unchanged
 - Translate job titles, descriptions, and skills to {output_language}
+- Preserve descriptionStyles arrays and keep them aligned one-to-one with description arrays
 - For customSections: preserve exact structure, item count, titles, subtitles, and years. If an item's description is an empty array [] in the original, keep it empty []. Do NOT generate descriptions for items that had none.
 - Improve custom section content the same way as standard sections
 - Copy the "years" field values EXACTLY as they appear in the original resume (including any month prefixes like "Jan 2020 - Present"). Do not shorten, reformat, or drop months.

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -434,6 +434,7 @@ async def update_feature_prompts(
 # their env-fallback skip in resolve_api_key.
 SUPPORTED_PROVIDERS = [
     "openai",
+    "azure_foundry",
     "anthropic",
     "google",
     "openrouter",
@@ -493,6 +494,13 @@ async def update_api_keys(request: ApiKeysUpdateRequest) -> ApiKeysUpdateRespons
         elif "openai" in stored_keys:
             del stored_keys["openai"]
         updated.append("openai")
+
+    if request.azure_foundry is not None:
+        if request.azure_foundry:
+            stored_keys["azure_foundry"] = request.azure_foundry
+        elif "azure_foundry" in stored_keys:
+            del stored_keys["azure_foundry"]
+        updated.append("azure_foundry")
 
     if request.anthropic is not None:
         if request.anthropic:

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -253,7 +253,7 @@ async def update_feature_config(request: FeatureConfigRequest) -> FeatureConfigR
 
 
 # Supported languages for i18n
-SUPPORTED_LANGUAGES = ["en", "es", "zh", "ja", "pt", "fr"]
+SUPPORTED_LANGUAGES = ["en", "es", "zh", "ja", "pt", "fr", "ko"]
 
 
 @router.get("/language", response_model=LanguageConfigResponse)

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -140,6 +140,7 @@ class Experience(BaseModel):
     location: str | None = None
     years: str = ""
     description: list[str] = Field(default_factory=list)
+    descriptionStyles: list[Literal["bullet", "plain"]] = Field(default_factory=list)
 
     @field_validator("description", mode="before")
     @classmethod
@@ -172,6 +173,7 @@ class Project(BaseModel):
     github: str | None = None
     website: str | None = None
     description: list[str] = Field(default_factory=list)
+    descriptionStyles: list[Literal["bullet", "plain"]] = Field(default_factory=list)
 
     @field_validator("description", mode="before")
     @classmethod
@@ -221,6 +223,7 @@ class CustomSectionItem(BaseModel):
     location: str | None = None
     years: str = ""
     description: list[str] = Field(default_factory=list)
+    descriptionStyles: list[Literal["bullet", "plain"]] = Field(default_factory=list)
 
     @field_validator("description", mode="before")
     @classmethod

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -752,6 +752,7 @@ class ApiKeysUpdateRequest(BaseModel):
     """Request to update API keys."""
 
     openai: str | None = None
+    azure_foundry: str | None = None
     anthropic: str | None = None
     google: str | None = None
     openrouter: str | None = None

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -107,6 +107,25 @@ def _coerce_string_list(value: Any) -> list[str]:
     return [coerced] if coerced else []
 
 
+def _coerce_description_styles(value: Any) -> list[Literal["bullet", "plain"]]:
+    """Coerce description style values into supported row styles."""
+    if not isinstance(value, list):
+        return []
+
+    return ["plain" if entry == "plain" else "bullet" for entry in value]
+
+
+def _align_description_styles(
+    description: list[str],
+    description_styles: list[Literal["bullet", "plain"]],
+) -> list[Literal["bullet", "plain"]]:
+    """Keep descriptionStyles aligned with description rows."""
+    return [
+        description_styles[index] if index < len(description_styles) else "bullet"
+        for index, _ in enumerate(description)
+    ]
+
+
 # Section Type Enum for dynamic sections
 class SectionType(str, Enum):
     """Types of resume sections."""
@@ -147,6 +166,20 @@ class Experience(BaseModel):
     def _normalize_description(cls, value: Any) -> list[str]:
         return _coerce_string_list(value)
 
+    @field_validator("descriptionStyles", mode="before")
+    @classmethod
+    def _normalize_description_styles(
+        cls, value: Any
+    ) -> list[Literal["bullet", "plain"]]:
+        return _coerce_description_styles(value)
+
+    @model_validator(mode="after")
+    def _sync_description_styles(self) -> "Experience":
+        self.descriptionStyles = _align_description_styles(
+            self.description, self.descriptionStyles
+        )
+        return self
+
 
 class Education(BaseModel):
     """Education entry."""
@@ -179,6 +212,20 @@ class Project(BaseModel):
     @classmethod
     def _normalize_description(cls, value: Any) -> list[str]:
         return _coerce_string_list(value)
+
+    @field_validator("descriptionStyles", mode="before")
+    @classmethod
+    def _normalize_description_styles(
+        cls, value: Any
+    ) -> list[Literal["bullet", "plain"]]:
+        return _coerce_description_styles(value)
+
+    @model_validator(mode="after")
+    def _sync_description_styles(self) -> "Project":
+        self.descriptionStyles = _align_description_styles(
+            self.description, self.descriptionStyles
+        )
+        return self
 
 
 class AdditionalInfo(BaseModel):
@@ -229,6 +276,20 @@ class CustomSectionItem(BaseModel):
     @classmethod
     def _normalize_description(cls, value: Any) -> list[str]:
         return _coerce_string_list(value)
+
+    @field_validator("descriptionStyles", mode="before")
+    @classmethod
+    def _normalize_description_styles(
+        cls, value: Any
+    ) -> list[Literal["bullet", "plain"]]:
+        return _coerce_description_styles(value)
+
+    @model_validator(mode="after")
+    def _sync_description_styles(self) -> "CustomSectionItem":
+        self.descriptionStyles = _align_description_styles(
+            self.description, self.descriptionStyles
+        )
+        return self
 
 
 class CustomSection(BaseModel):

--- a/apps/backend/tests/unit/test_description_styles.py
+++ b/apps/backend/tests/unit/test_description_styles.py
@@ -1,0 +1,45 @@
+from app.schemas.models import CustomSectionItem, Experience, Project, ResumeData
+
+
+def test_experience_description_styles_are_aligned_to_descriptions() -> None:
+    experience = Experience.model_validate(
+        {
+            "description": ["Built APIs", "Led migrations", "Reduced latency"],
+            "descriptionStyles": [None, "plain"],
+        }
+    )
+
+    assert experience.descriptionStyles == ["bullet", "plain", "bullet"]
+
+
+def test_project_description_styles_are_trimmed_to_description_count() -> None:
+    project = Project.model_validate(
+        {
+            "description": ["Built CLI"],
+            "descriptionStyles": ["plain", "bullet"],
+        }
+    )
+
+    assert project.descriptionStyles == ["plain"]
+
+
+def test_resume_data_defaults_missing_custom_item_styles_to_bullets() -> None:
+    resume = ResumeData.model_validate(
+        {
+            "customSections": {
+                "publications": {
+                    "sectionType": "itemList",
+                    "items": [
+                        {
+                            "title": "Paper",
+                            "description": ["Accepted", "Presented"],
+                        }
+                    ],
+                }
+            }
+        }
+    )
+
+    item = resume.customSections["publications"].items[0]
+    assert isinstance(item, CustomSectionItem)
+    assert item.descriptionStyles == ["bullet", "bullet"]

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -7,6 +7,7 @@ import pytest
 from app.llm import (
     LLMConfig,
     _appears_truncated,
+    _azure_foundry_api_version,
     _get_retry_temperature,
     _normalize_api_base,
     _supports_temperature,
@@ -54,6 +55,29 @@ class TestProviderConfiguration:
         )
 
         assert get_model_name(config) == "azure_ai/command-r-plus"
+
+    def test_azure_foundry_service_root_routes_gpt5_via_azure(self):
+        """Foundry service-root GPT deployments use Azure GPT-5 routing."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="gpt-5.4-mini",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com",
+        )
+
+        assert get_model_name(config) == "azure/gpt5_series/gpt-5.4-mini"
+        assert _azure_foundry_api_version(config) == "v1"
+
+    def test_azure_foundry_service_root_keeps_non_gpt_on_azure_ai(self):
+        """Non-GPT Foundry service-root models keep Azure AI Inference routing."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="mistral-large-latest",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com",
+        )
+
+        assert get_model_name(config) == "azure_ai/mistral-large-latest"
 
     def test_azure_foundry_openai_endpoint_routes_gpt5_via_azure(self):
         """Foundry Azure OpenAI endpoints use Azure GPT-5 routing."""

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -44,6 +44,17 @@ class TestProviderConfiguration:
 
         assert get_model_name(config) == "azure_ai/command-r-plus"
 
+    def test_azure_foundry_openai_endpoint_preserves_azure_ai_prefix(self):
+        """Azure OpenAI-style Foundry endpoints do not rewrite azure_ai models."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="azure_ai/command-r-plus",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com/openai/v1/responses",
+        )
+
+        assert get_model_name(config) == "azure_ai/command-r-plus"
+
     def test_azure_foundry_openai_endpoint_routes_gpt5_via_azure(self):
         """Foundry Azure OpenAI endpoints use Azure GPT-5 routing."""
         config = LLMConfig(

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -447,6 +447,52 @@ class TestCompleteJsonFallback:
     @patch("app.llm.get_router")
     @patch("app.llm.get_model_name")
     @patch("app.llm._supports_json_mode")
+    async def test_retry_keeps_reasoning_effort_for_non_azure_providers(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """The minimal-effort retry downgrade is Azure Foundry specific.
+
+        Other providers keep the effort the user configured on every attempt;
+        silently lowering it would change output quality for OpenAI GPT-5,
+        Anthropic and DeepSeek reasoning models.
+        """
+        mock_supports_json.return_value = False
+        mock_get_name.return_value = "gpt-5-nano-2025-08-07"
+
+        empty_choice = MagicMock()
+        empty_choice.message.content = ""
+        empty_response = MagicMock()
+        empty_response.choices = [empty_choice]
+
+        good_choice = MagicMock()
+        good_choice.message.content = (
+            '{"required_skills": [], "preferred_skills": [], "keywords": []}'
+        )
+        good_response = MagicMock()
+        good_response.choices = [good_choice]
+
+        router = MagicMock()
+        router.acompletion = AsyncMock(side_effect=[empty_response, good_response])
+        config = MagicMock()
+        config.provider = "openai"
+        config.reasoning_effort = "high"
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json(
+            prompt="Extract keywords", schema_type="keywords", retries=2
+        )
+
+        assert result == {"required_skills": [], "preferred_skills": [], "keywords": []}
+        calls = router.acompletion.call_args_list
+        assert calls[0].kwargs["reasoning_effort"] == "high"
+        assert calls[1].kwargs["reasoning_effort"] == "high"
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
     async def test_json_mode_fallback_on_response_format_rejection(
         self, mock_supports_json, mock_get_name, mock_get_router
     ):

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -4,7 +4,72 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.llm import _appears_truncated, _get_retry_temperature, _supports_temperature
+from app.llm import (
+    LLMConfig,
+    _appears_truncated,
+    _get_retry_temperature,
+    _normalize_api_base,
+    _supports_temperature,
+    get_model_name,
+    resolve_api_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Provider configuration helpers
+# ---------------------------------------------------------------------------
+
+
+class TestProviderConfiguration:
+    """Tests for provider-specific model and key mapping."""
+
+    def test_azure_foundry_model_uses_litellm_azure_ai_prefix(self):
+        """Azure AI Foundry routes through LiteLLM's azure_ai provider."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="mistral-large-latest",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com/models",
+        )
+
+        assert get_model_name(config) == "azure_ai/mistral-large-latest"
+
+    def test_azure_foundry_model_preserves_existing_prefix(self):
+        """Already-prefixed Azure AI models are not double-prefixed."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="azure_ai/command-r-plus",
+            api_key="foundry-key",
+        )
+
+        assert get_model_name(config) == "azure_ai/command-r-plus"
+
+    def test_azure_foundry_openai_endpoint_routes_gpt5_via_azure(self):
+        """Foundry Azure OpenAI endpoints use Azure GPT-5 routing."""
+        config = LLMConfig(
+            provider="azure_foundry",
+            model="gpt-5.4-mini",
+            api_key="foundry-key",
+            api_base="https://example.services.ai.azure.com/openai/v1/responses",
+        )
+
+        assert get_model_name(config) == "azure/gpt5_series/gpt-5.4-mini"
+
+    def test_azure_foundry_openai_endpoint_normalizes_to_resource_root(self):
+        """LiteLLM appends /openai/v1 itself for Azure v1 API calls."""
+        assert (
+            _normalize_api_base(
+                "azure_foundry",
+                "https://example.services.ai.azure.com/openai/v1/responses",
+            )
+            == "https://example.services.ai.azure.com"
+        )
+
+    def test_azure_foundry_key_resolves_from_provider_store(self):
+        """Azure AI Foundry uses its own encrypted key-store slot."""
+        stored = {"api_keys": {"azure_foundry": "foundry-key"}}
+
+        assert resolve_api_key(stored, "azure_foundry") == "foundry-key"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -406,6 +406,47 @@ class TestCompleteJsonFallback:
     @patch("app.llm.get_router")
     @patch("app.llm.get_model_name")
     @patch("app.llm._supports_json_mode")
+    async def test_empty_json_retry_lowers_reasoning_effort(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """Reasoning-heavy JSON attempts can return no visible content.
+
+        Retrying with minimal effort gives GPT-5-family models enough budget to
+        produce the requested JSON instead of repeating an empty response.
+        """
+        mock_supports_json.return_value = False
+        mock_get_name.return_value = "azure/gpt5_series/gpt-5.4-mini"
+
+        empty_choice = MagicMock()
+        empty_choice.message.content = ""
+        empty_response = MagicMock()
+        empty_response.choices = [empty_choice]
+
+        good_choice = MagicMock()
+        good_choice.message.content = '{"required_skills": [], "preferred_skills": [], "keywords": []}'
+        good_response = MagicMock()
+        good_response.choices = [good_choice]
+
+        router = MagicMock()
+        router.acompletion = AsyncMock(side_effect=[empty_response, good_response])
+        config = MagicMock()
+        config.provider = "azure_foundry"
+        config.reasoning_effort = "high"
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json(prompt="Extract keywords", schema_type="keywords", retries=2)
+
+        assert result == {"required_skills": [], "preferred_skills": [], "keywords": []}
+        calls = router.acompletion.call_args_list
+        assert calls[0].kwargs["reasoning_effort"] == "high"
+        assert calls[1].kwargs["reasoning_effort"] == "minimal"
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
     async def test_json_mode_fallback_on_response_format_rejection(
         self, mock_supports_json, mock_get_name, mock_get_router
     ):

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -70,6 +70,7 @@ type Status = 'idle' | 'loading' | 'saving' | 'saved' | 'error' | 'testing';
 const PROVIDERS: LLMProvider[] = [
   'openai',
   'openai_compatible',
+  'azure_foundry',
   'anthropic',
   'openrouter',
   'gemini',
@@ -411,6 +412,11 @@ export default function SettingsPage() {
         setStatus('error');
         return;
       }
+      if (requiresApiBase && !apiBase.trim()) {
+        setError(`${providerInfo.name} requires a Base URL.`);
+        setStatus('error');
+        return;
+      }
 
       const trimmedKey = apiKey.trim();
 
@@ -457,6 +463,17 @@ export default function SettingsPage() {
     setHealthCheck(null);
 
     try {
+      if (requiresApiBase && !apiBase.trim()) {
+        setHealthCheck({
+          healthy: false,
+          provider,
+          model,
+          error: `${providerInfo.name} requires a Base URL.`,
+        });
+        setStatus('idle');
+        return;
+      }
+
       // Build config from current form values
       const testConfig: LLMConfigUpdate = {
         provider,
@@ -630,6 +647,12 @@ export default function SettingsPage() {
   };
 
   const requiresApiKey = providerInfo.requiresKey ?? true;
+  const requiresApiBase = providerInfo.requiresBaseUrl ?? false;
+  const baseUrlLabel = providerInfo.baseUrlLabel ?? t('settings.llmConfiguration.baseUrlLabel');
+  const baseUrlPlaceholder =
+    providerInfo.baseUrlPlaceholder ?? t('settings.llmConfiguration.baseUrlPlaceholder');
+  const baseUrlDescription =
+    providerInfo.baseUrlDescription ?? t('settings.llmConfiguration.baseUrlDescription');
 
   return (
     <div className="flex flex-col items-center justify-start p-6 md:p-12 min-h-screen overflow-y-auto">
@@ -964,17 +987,17 @@ export default function SettingsPage() {
 
               {/* API Base URL (optional, for proxies/aggregators/custom endpoints) */}
               <div className="space-y-2">
-                <Label htmlFor="apiBase">{t('settings.llmConfiguration.baseUrlLabel')}</Label>
+                <Label htmlFor="apiBase">
+                  {baseUrlLabel} {requiresApiBase && <span className="text-destructive">*</span>}
+                </Label>
                 <Input
                   id="apiBase"
                   value={apiBase}
                   onChange={(e) => setApiBase(e.target.value)}
-                  placeholder={t('settings.llmConfiguration.baseUrlPlaceholder')}
+                  placeholder={baseUrlPlaceholder}
                   className="font-mono"
                 />
-                <p className="text-xs text-steel-grey font-mono">
-                  {t('settings.llmConfiguration.baseUrlDescription')}
-                </p>
+                <p className="text-xs text-steel-grey font-mono">{baseUrlDescription}</p>
               </div>
 
               {/* Reasoning Effort (optional, only applies to reasoning-capable models) */}

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -385,7 +385,9 @@ export default function SettingsPage() {
     setProvider(newProvider);
     setModel(PROVIDER_INFO[newProvider].defaultModel);
 
-    if (newProvider === 'ollama' && !apiBase.trim()) {
+    if (newProvider === 'azure_foundry' && provider !== 'azure_foundry') {
+      setApiBase('');
+    } else if (newProvider === 'ollama' && !apiBase.trim()) {
       setApiBase('http://localhost:11434');
     }
     if (newProvider === 'openai_compatible' && !apiBase.trim()) {
@@ -413,7 +415,7 @@ export default function SettingsPage() {
         return;
       }
       if (requiresApiBase && !apiBase.trim()) {
-        setError(`${providerInfo.name} requires a Base URL.`);
+        setError(t('settings.errors.baseUrlRequired', { provider: providerInfo.name }));
         setStatus('error');
         return;
       }
@@ -468,7 +470,7 @@ export default function SettingsPage() {
           healthy: false,
           provider,
           model,
-          error: `${providerInfo.name} requires a Base URL.`,
+          error: t('settings.errors.baseUrlRequired', { provider: providerInfo.name }),
         });
         setStatus('idle');
         return;

--- a/apps/frontend/components/builder/forms/education-form.tsx
+++ b/apps/frontend/components/builder/forms/education-form.tsx
@@ -114,7 +114,12 @@ export const EducationForm: React.FC<EducationFormProps> = ({ data, onChange }) 
           </Button>
         </div>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <DndContext
+          id="education-items"
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
           <SortableContext
             items={data.map((item) => item.id)}
             strategy={verticalListSortingStrategy}

--- a/apps/frontend/components/builder/forms/experience-form.tsx
+++ b/apps/frontend/components/builder/forms/experience-form.tsx
@@ -164,7 +164,12 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
           </Button>
         </div>
       ) : (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <DndContext
+          id="experience-items"
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
           <SortableContext
             items={data.map((item) => item.id)}
             strategy={verticalListSortingStrategy}

--- a/apps/frontend/components/builder/forms/experience-form.tsx
+++ b/apps/frontend/components/builder/forms/experience-form.tsx
@@ -18,7 +18,7 @@ const RichTextEditor = dynamic(
   }
 );
 import { Experience } from '@/components/dashboard/resume-component';
-import { Plus, Trash2 } from 'lucide-react';
+import { AlignLeft, List, Plus, Trash2 } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
 import {
   DndContext,
@@ -80,6 +80,7 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
         location: '',
         years: '',
         description: [''],
+        descriptionStyles: ['bullet'],
       },
     ]);
   };
@@ -116,7 +117,24 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
     onChange(
       data.map((item) => {
         if (item.id === id) {
-          return { ...item, description: [...(item.description || []), ''] };
+          return {
+            ...item,
+            description: [...(item.description || []), ''],
+            descriptionStyles: [...(item.descriptionStyles || []), 'bullet'],
+          };
+        }
+        return item;
+      })
+    );
+  };
+
+  const handleToggleDescriptionStyle = (id: number, index: number) => {
+    onChange(
+      data.map((item) => {
+        if (item.id === id) {
+          const styles = [...(item.descriptionStyles || [])];
+          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
+          return { ...item, descriptionStyles: styles };
         }
         return item;
       })
@@ -129,7 +147,9 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          return { ...item, description: newDesc };
+          const newStyles = [...(item.descriptionStyles || [])];
+          newStyles.splice(index, 1);
+          return { ...item, description: newDesc, descriptionStyles: newStyles };
         }
         return item;
       })
@@ -256,6 +276,20 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
                               minHeight="60px"
                             />
                           </div>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleToggleDescriptionStyle(item.id, idx)}
+                            className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                            aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
+                            title={t('builder.genericItemForm.actions.togglePointStyle')}
+                          >
+                            {item.descriptionStyles?.[idx] === 'plain' ? (
+                              <AlignLeft className="w-3 h-3" />
+                            ) : (
+                              <List className="w-3 h-3" />
+                            )}
+                          </Button>
                           <Button
                             variant="ghost"
                             size="icon"

--- a/apps/frontend/components/builder/forms/experience-form.tsx
+++ b/apps/frontend/components/builder/forms/experience-form.tsx
@@ -291,7 +291,7 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
                             variant="ghost"
                             size="icon"
                             onClick={() => handleToggleDescriptionStyle(item.id, idx)}
-                            className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                            className="h-[60px] w-8 text-muted-foreground hover:text-primary self-end"
                             aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
                             title={t('builder.genericItemForm.actions.togglePointStyle')}
                           >

--- a/apps/frontend/components/builder/forms/experience-form.tsx
+++ b/apps/frontend/components/builder/forms/experience-form.tsx
@@ -20,6 +20,7 @@ const RichTextEditor = dynamic(
 import { Experience } from '@/components/dashboard/resume-component';
 import { AlignLeft, List, Plus, Trash2 } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
+import { alignDescriptionStyles, toggleDescriptionStyle } from '@/lib/utils/description-styles';
 import {
   DndContext,
   closestCenter,
@@ -132,9 +133,14 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
     onChange(
       data.map((item) => {
         if (item.id === id) {
-          const styles = [...(item.descriptionStyles || [])];
-          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
-          return { ...item, descriptionStyles: styles };
+          return {
+            ...item,
+            descriptionStyles: toggleDescriptionStyle(
+              item.description,
+              item.descriptionStyles,
+              index
+            ),
+          };
         }
         return item;
       })
@@ -147,7 +153,7 @@ export const ExperienceForm: React.FC<ExperienceFormProps> = ({ data, onChange }
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          const newStyles = [...(item.descriptionStyles || [])];
+          const newStyles = alignDescriptionStyles(item.description, item.descriptionStyles);
           newStyles.splice(index, 1);
           return { ...item, description: newDesc, descriptionStyles: newStyles };
         }

--- a/apps/frontend/components/builder/forms/generic-item-form.tsx
+++ b/apps/frontend/components/builder/forms/generic-item-form.tsx
@@ -16,7 +16,7 @@ const RichTextEditor = dynamic(
     ),
   }
 );
-import { Plus, Trash2 } from 'lucide-react';
+import { AlignLeft, List, Plus, Trash2 } from 'lucide-react';
 import type { CustomSectionItem } from '@/components/dashboard/resume-component';
 import { useTranslations } from '@/lib/i18n';
 
@@ -81,6 +81,7 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
         location: '',
         years: '',
         description: [''],
+        descriptionStyles: ['bullet'],
       },
     ]);
   };
@@ -117,7 +118,24 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
     onChange(
       items.map((item) => {
         if (item.id === id) {
-          return { ...item, description: [...(item.description || []), ''] };
+          return {
+            ...item,
+            description: [...(item.description || []), ''],
+            descriptionStyles: [...(item.descriptionStyles || []), 'bullet'],
+          };
+        }
+        return item;
+      })
+    );
+  };
+
+  const handleToggleDescriptionStyle = (id: number, index: number) => {
+    onChange(
+      items.map((item) => {
+        if (item.id === id) {
+          const styles = [...(item.descriptionStyles || [])];
+          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
+          return { ...item, descriptionStyles: styles };
         }
         return item;
       })
@@ -130,7 +148,9 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          return { ...item, description: newDesc };
+          const newStyles = [...(item.descriptionStyles || [])];
+          newStyles.splice(index, 1);
+          return { ...item, description: newDesc, descriptionStyles: newStyles };
         }
         return item;
       })
@@ -241,6 +261,20 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
                       minHeight="60px"
                     />
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleToggleDescriptionStyle(item.id, idx)}
+                    className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                    aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
+                    title={t('builder.genericItemForm.actions.togglePointStyle')}
+                  >
+                    {item.descriptionStyles?.[idx] === 'plain' ? (
+                      <AlignLeft className="w-3 h-3" />
+                    ) : (
+                      <List className="w-3 h-3" />
+                    )}
+                  </Button>
                   <Button
                     variant="ghost"
                     size="icon"

--- a/apps/frontend/components/builder/forms/generic-item-form.tsx
+++ b/apps/frontend/components/builder/forms/generic-item-form.tsx
@@ -271,7 +271,7 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
                     variant="ghost"
                     size="icon"
                     onClick={() => handleToggleDescriptionStyle(item.id, idx)}
-                    className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                    className="h-[60px] w-8 text-muted-foreground hover:text-primary self-end"
                     aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
                     title={t('builder.genericItemForm.actions.togglePointStyle')}
                   >

--- a/apps/frontend/components/builder/forms/generic-item-form.tsx
+++ b/apps/frontend/components/builder/forms/generic-item-form.tsx
@@ -19,6 +19,7 @@ const RichTextEditor = dynamic(
 import { AlignLeft, List, Plus, Trash2 } from 'lucide-react';
 import type { CustomSectionItem } from '@/components/dashboard/resume-component';
 import { useTranslations } from '@/lib/i18n';
+import { alignDescriptionStyles, toggleDescriptionStyle } from '@/lib/utils/description-styles';
 
 interface GenericItemFormProps {
   items: CustomSectionItem[];
@@ -133,9 +134,14 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
     onChange(
       items.map((item) => {
         if (item.id === id) {
-          const styles = [...(item.descriptionStyles || [])];
-          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
-          return { ...item, descriptionStyles: styles };
+          return {
+            ...item,
+            descriptionStyles: toggleDescriptionStyle(
+              item.description,
+              item.descriptionStyles,
+              index
+            ),
+          };
         }
         return item;
       })
@@ -148,7 +154,7 @@ export const GenericItemForm: React.FC<GenericItemFormProps> = ({
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          const newStyles = [...(item.descriptionStyles || [])];
+          const newStyles = alignDescriptionStyles(item.description, item.descriptionStyles);
           newStyles.splice(index, 1);
           return { ...item, description: newDesc, descriptionStyles: newStyles };
         }

--- a/apps/frontend/components/builder/forms/projects-form.tsx
+++ b/apps/frontend/components/builder/forms/projects-form.tsx
@@ -17,7 +17,7 @@ const RichTextEditor = dynamic(
   }
 );
 import { Project } from '@/components/dashboard/resume-component';
-import { Plus, Trash2, Github, Globe } from 'lucide-react';
+import { AlignLeft, List, Plus, Trash2, Github, Globe } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
 
 interface ProjectsFormProps {
@@ -40,6 +40,7 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
         github: '',
         website: '',
         description: [''],
+        descriptionStyles: ['bullet'],
       },
     ]);
   };
@@ -76,7 +77,24 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
     onChange(
       data.map((item) => {
         if (item.id === id) {
-          return { ...item, description: [...(item.description || []), ''] };
+          return {
+            ...item,
+            description: [...(item.description || []), ''],
+            descriptionStyles: [...(item.descriptionStyles || []), 'bullet'],
+          };
+        }
+        return item;
+      })
+    );
+  };
+
+  const handleToggleDescriptionStyle = (id: number, index: number) => {
+    onChange(
+      data.map((item) => {
+        if (item.id === id) {
+          const styles = [...(item.descriptionStyles || [])];
+          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
+          return { ...item, descriptionStyles: styles };
         }
         return item;
       })
@@ -89,7 +107,9 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          return { ...item, description: newDesc };
+          const newStyles = [...(item.descriptionStyles || [])];
+          newStyles.splice(index, 1);
+          return { ...item, description: newDesc, descriptionStyles: newStyles };
         }
         return item;
       })
@@ -209,6 +229,20 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
                       minHeight="60px"
                     />
                   </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleToggleDescriptionStyle(item.id, idx)}
+                    className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                    aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
+                    title={t('builder.genericItemForm.actions.togglePointStyle')}
+                  >
+                    {item.descriptionStyles?.[idx] === 'plain' ? (
+                      <AlignLeft className="w-3 h-3" />
+                    ) : (
+                      <List className="w-3 h-3" />
+                    )}
+                  </Button>
                   <Button
                     variant="ghost"
                     size="icon"

--- a/apps/frontend/components/builder/forms/projects-form.tsx
+++ b/apps/frontend/components/builder/forms/projects-form.tsx
@@ -19,6 +19,7 @@ const RichTextEditor = dynamic(
 import { Project } from '@/components/dashboard/resume-component';
 import { AlignLeft, List, Plus, Trash2, Github, Globe } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
+import { alignDescriptionStyles, toggleDescriptionStyle } from '@/lib/utils/description-styles';
 
 interface ProjectsFormProps {
   data: Project[];
@@ -92,9 +93,14 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
     onChange(
       data.map((item) => {
         if (item.id === id) {
-          const styles = [...(item.descriptionStyles || [])];
-          styles[index] = styles[index] === 'plain' ? 'bullet' : 'plain';
-          return { ...item, descriptionStyles: styles };
+          return {
+            ...item,
+            descriptionStyles: toggleDescriptionStyle(
+              item.description,
+              item.descriptionStyles,
+              index
+            ),
+          };
         }
         return item;
       })
@@ -107,7 +113,7 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
         if (item.id === id) {
           const newDesc = [...(item.description || [])];
           newDesc.splice(index, 1);
-          const newStyles = [...(item.descriptionStyles || [])];
+          const newStyles = alignDescriptionStyles(item.description, item.descriptionStyles);
           newStyles.splice(index, 1);
           return { ...item, description: newDesc, descriptionStyles: newStyles };
         }

--- a/apps/frontend/components/builder/forms/projects-form.tsx
+++ b/apps/frontend/components/builder/forms/projects-form.tsx
@@ -239,7 +239,7 @@ export const ProjectsForm: React.FC<ProjectsFormProps> = ({ data, onChange }) =>
                     variant="ghost"
                     size="icon"
                     onClick={() => handleToggleDescriptionStyle(item.id, idx)}
-                    className="h-[60px] w-8 text-muted-foreground hover:text-blue-700 self-end"
+                    className="h-[60px] w-8 text-muted-foreground hover:text-primary self-end"
                     aria-label={t('builder.genericItemForm.actions.togglePointStyle')}
                     title={t('builder.genericItemForm.actions.togglePointStyle')}
                   >

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -125,6 +125,7 @@ const ResumeBuilderContent = () => {
   const [isDownloading, setIsDownloading] = useState(false);
   const [, setLoadingState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
   const [templateSettings, setTemplateSettings] = useState<TemplateSettings>(() => {
+    if (typeof window === 'undefined') return DEFAULT_TEMPLATE_SETTINGS;
     try {
       const saved = localStorage.getItem(SETTINGS_STORAGE_KEY);
       if (saved) {

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -124,8 +124,24 @@ const ResumeBuilderContent = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [, setLoadingState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
-  const [templateSettings, setTemplateSettings] =
-    useState<TemplateSettings>(DEFAULT_TEMPLATE_SETTINGS);
+  const [templateSettings, setTemplateSettings] = useState<TemplateSettings>(() => {
+    try {
+      const saved = localStorage.getItem(SETTINGS_STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        return {
+          ...DEFAULT_TEMPLATE_SETTINGS,
+          ...parsed,
+          margins: { ...DEFAULT_TEMPLATE_SETTINGS.margins, ...parsed.margins },
+          spacing: { ...DEFAULT_TEMPLATE_SETTINGS.spacing, ...parsed.spacing },
+          fontSize: { ...DEFAULT_TEMPLATE_SETTINGS.fontSize, ...parsed.fontSize },
+        };
+      }
+    } catch {
+      // fall through to defaults
+    }
+    return DEFAULT_TEMPLATE_SETTINGS;
+  });
   const { improvedData } = useResumePreview();
   const improvedPreview = improvedData?.data?.resume_preview;
   const improvedCoverLetter = improvedData?.data?.cover_letter;
@@ -262,25 +278,6 @@ const ResumeBuilderContent = () => {
     () => withLocalizedDefaultSections(resumeData, t),
     [resumeData, t]
   );
-
-  // Load template settings from localStorage on mount
-  useEffect(() => {
-    const savedSettings = localStorage.getItem(SETTINGS_STORAGE_KEY);
-    if (savedSettings) {
-      try {
-        const parsed = JSON.parse(savedSettings);
-        setTemplateSettings({
-          ...DEFAULT_TEMPLATE_SETTINGS,
-          ...parsed,
-          margins: { ...DEFAULT_TEMPLATE_SETTINGS.margins, ...parsed.margins },
-          spacing: { ...DEFAULT_TEMPLATE_SETTINGS.spacing, ...parsed.spacing },
-          fontSize: { ...DEFAULT_TEMPLATE_SETTINGS.fontSize, ...parsed.fontSize },
-        });
-      } catch {
-        // Use defaults
-      }
-    }
-  }, []);
 
   // Save template settings to localStorage when they change
   useEffect(() => {

--- a/apps/frontend/components/builder/resume-form.tsx
+++ b/apps/frontend/components/builder/resume-form.tsx
@@ -376,7 +376,12 @@ export const ResumeForm: React.FC<ResumeFormProps> = ({ resumeData, onUpdate }) 
   };
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+    <DndContext
+      id="resume-sections"
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
       <SortableContext
         items={sortedAllSections.map((s) => s.id)}
         strategy={verticalListSortingStrategy}

--- a/apps/frontend/components/common/resume_previewer_context.tsx
+++ b/apps/frontend/components/common/resume_previewer_context.tsx
@@ -20,6 +20,7 @@ export interface ExperienceEntry {
   location?: string;
   years?: string;
   description: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 export interface EducationEntry {
@@ -36,6 +37,7 @@ export interface ProjectEntry {
   role?: string;
   years?: string;
   description: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 export interface AdditionalInfo {

--- a/apps/frontend/components/dashboard/resume-component.tsx
+++ b/apps/frontend/components/dashboard/resume-component.tsx
@@ -34,6 +34,7 @@ export interface Experience {
   location?: string;
   years?: string;
   description?: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 export interface Education {
@@ -52,6 +53,7 @@ export interface Project {
   github?: string;
   website?: string;
   description?: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 export interface AdditionalInfo {
@@ -106,6 +108,7 @@ export interface CustomSectionItem {
   location?: string;
   years?: string;
   description?: string[];
+  descriptionStyles?: ('bullet' | 'plain')[];
 }
 
 // Custom section data container

--- a/apps/frontend/components/resume/description-list.tsx
+++ b/apps/frontend/components/resume/description-list.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { SafeHtml } from './safe-html';
+import baseStyles from './styles/_base.module.css';
+
+export type DescriptionStyle = 'bullet' | 'plain';
+
+interface DescriptionListProps {
+  items?: string[];
+  styles?: DescriptionStyle[];
+  textClassName?: string;
+  marker?: string;
+  markerClassName?: string;
+}
+
+export const DescriptionList: React.FC<DescriptionListProps> = ({
+  items,
+  styles,
+  textClassName = baseStyles['resume-text-sm'],
+  marker = '•',
+  markerClassName = 'mr-1.5 flex-shrink-0',
+}) => {
+  if (!items || items.length === 0) return null;
+
+  return (
+    <ul className={cn(baseStyles['resume-list'], textClassName)}>
+      {items.map((desc, index) => {
+        const showMarker = styles?.[index] !== 'plain';
+
+        return (
+          <li key={index} className={cn('flex', showMarker && 'ml-4')}>
+            {showMarker && (
+              <span className={markerClassName} aria-hidden="true">
+                {marker}
+                {'\u00A0'}
+              </span>
+            )}
+            <span>
+              <SafeHtml html={desc} />
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/apps/frontend/components/resume/dynamic-resume-section.tsx
+++ b/apps/frontend/components/resume/dynamic-resume-section.tsx
@@ -6,7 +6,7 @@ import type {
   CustomSectionItem,
 } from '@/components/dashboard/resume-component';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 
 interface DynamicResumeSectionProps {
@@ -109,18 +109,7 @@ const ItemListSectionContent: React.FC<{ items: CustomSectionItem[] }> = ({ item
           )}
 
           {/* Description Points */}
-          {item.description && item.description.length > 0 && (
-            <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
-              {item.description.map((desc, index) => (
-                <li key={index} className="flex">
-                  <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                  <span>
-                    <SafeHtml html={desc} />
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
+          <DescriptionList items={item.description} styles={item.descriptionStyles} />
         </div>
       ))}
     </div>

--- a/apps/frontend/components/resume/resume-clean.tsx
+++ b/apps/frontend/components/resume/resume-clean.tsx
@@ -151,7 +151,7 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
               {workExperience.map((exp) => (
                 <div key={exp.id} className={baseStyles['resume-item']}>
                   {renderEntryHeader(exp.company, exp.title, exp.location, exp.years)}
-                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
+                  {renderBullets(exp.description, exp.descriptionStyles)}
                 </div>
               ))}
             </div>

--- a/apps/frontend/components/resume/resume-clean.tsx
+++ b/apps/frontend/components/resume/resume-clean.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 import { getSortedSections } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/clean.module.css';
 
@@ -124,21 +124,9 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
     );
   };
 
-  const renderBullets = (items?: string[]) => {
-    if (!items || items.length === 0) return null;
-    return (
-      <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
-        {items.map((desc, index) => (
-          <li key={index} className="flex">
-            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-            <span>
-              <SafeHtml html={desc} />
-            </span>
-          </li>
-        ))}
-      </ul>
-    );
-  };
+  const renderBullets = (items?: string[], styles?: ('bullet' | 'plain')[]) => (
+    <DescriptionList items={items} styles={styles} />
+  );
 
   const renderSection = (section: SectionMeta) => {
     switch (section.key) {
@@ -163,7 +151,7 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
               {workExperience.map((exp) => (
                 <div key={exp.id} className={baseStyles['resume-item']}>
                   {renderEntryHeader(exp.company, exp.title, exp.location, exp.years)}
-                  {renderBullets(exp.description)}
+                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -234,7 +222,7 @@ export const ResumeClean: React.FC<ResumeCleanProps> = ({
                       <span className={styles.entryMeta}>{formatDateRange(project.years)}</span>
                     )}
                   </div>
-                  {renderBullets(project.description)}
+                  <DescriptionList items={project.description} styles={project.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -376,7 +364,7 @@ const AdditionalSection: React.FC<{
 const DynamicResumeSectionClean: React.FC<{
   sectionMeta: SectionMeta;
   resumeData: ResumeData;
-  renderBullets: (items?: string[]) => React.ReactNode;
+  renderBullets: (items?: string[], styles?: ('bullet' | 'plain')[]) => React.ReactNode;
   renderEntryHeader: (
     primary?: string,
     role?: string,
@@ -413,7 +401,7 @@ const DynamicResumeSectionClean: React.FC<{
           {customSection.items.map((item) => (
             <div key={item.id} className={baseStyles['resume-item']}>
               {renderEntryHeader(item.title, item.subtitle, item.location, item.years)}
-              {renderBullets(item.description)}
+              {renderBullets(item.description, item.descriptionStyles)}
             </div>
           ))}
         </div>

--- a/apps/frontend/components/resume/resume-latex.tsx
+++ b/apps/frontend/components/resume/resume-latex.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 import { getSortedSections } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/latex.module.css';
 
@@ -119,21 +119,9 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
     </>
   );
 
-  const renderBullets = (items?: string[]) => {
-    if (!items || items.length === 0) return null;
-    return (
-      <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
-        {items.map((desc, index) => (
-          <li key={index} className="flex">
-            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-            <span>
-              <SafeHtml html={desc} />
-            </span>
-          </li>
-        ))}
-      </ul>
-    );
-  };
+  const renderBullets = (items?: string[], styles?: ('bullet' | 'plain')[]) => (
+    <DescriptionList items={items} styles={styles} />
+  );
 
   const renderSection = (section: SectionMeta) => {
     switch (section.key) {
@@ -158,7 +146,7 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
               {workExperience.map((exp) => (
                 <div key={exp.id} className={baseStyles['resume-item']}>
                   {renderEntryHeader(exp.company, exp.years, exp.title, exp.location)}
-                  {renderBullets(exp.description)}
+                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -230,7 +218,7 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
                       <span className={styles.entrySecondary}>{project.role}</span>
                     </div>
                   )}
-                  {renderBullets(project.description)}
+                  {renderBullets(project.description, project.descriptionStyles)}
                 </div>
               ))}
             </div>
@@ -374,7 +362,7 @@ const AdditionalSection: React.FC<{
 const DynamicResumeSectionLatex: React.FC<{
   sectionMeta: SectionMeta;
   resumeData: ResumeData;
-  renderBullets: (items?: string[]) => React.ReactNode;
+  renderBullets: (items?: string[], styles?: ('bullet' | 'plain')[]) => React.ReactNode;
 }> = ({ sectionMeta, resumeData, renderBullets }) => {
   const customSection = resumeData.customSections?.[sectionMeta.key];
   if (!customSection) return null;
@@ -420,7 +408,7 @@ const DynamicResumeSectionLatex: React.FC<{
                   )}
                 </div>
               )}
-              {renderBullets(item.description)}
+              {renderBullets(item.description, item.descriptionStyles)}
             </div>
           ))}
         </div>

--- a/apps/frontend/components/resume/resume-latex.tsx
+++ b/apps/frontend/components/resume/resume-latex.tsx
@@ -146,7 +146,7 @@ export const ResumeLatex: React.FC<ResumeLatexProps> = ({
               {workExperience.map((exp) => (
                 <div key={exp.id} className={baseStyles['resume-item']}>
                   {renderEntryHeader(exp.company, exp.years, exp.title, exp.location)}
-                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
+                  {renderBullets(exp.description, exp.descriptionStyles)}
                 </div>
               ))}
             </div>

--- a/apps/frontend/components/resume/resume-modern-two-column.tsx
+++ b/apps/frontend/components/resume/resume-modern-two-column.tsx
@@ -8,7 +8,7 @@ import type {
 import { getSortedSections, getSectionMeta } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
 import { DynamicResumeSection } from './dynamic-resume-section';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/modern-two-column.module.css';
 
@@ -208,20 +208,11 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                       </span>
                     </div>
 
-                    {exp.description && exp.description.length > 0 && (
-                      <ul
-                        className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}
-                      >
-                        {exp.description.map((desc, index) => (
-                          <li key={index} className="flex">
-                            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                            <span>
-                              <SafeHtml html={desc} />
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
+                    <DescriptionList
+                      items={exp.description}
+                      styles={exp.descriptionStyles}
+                      textClassName={baseStyles['resume-text-xs']}
+                    />
                   </div>
                 ))}
               </div>
@@ -298,20 +289,11 @@ export const ResumeModernTwoColumn: React.FC<ResumeModernTwoColumnProps> = ({
                           <span>{project.role}</span>
                         </div>
                       )}
-                      {project.description && project.description.length > 0 && (
-                        <ul
-                          className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}
-                        >
-                          {project.description.map((desc, index) => (
-                            <li key={index} className="flex">
-                              <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                              <span>
-                                <SafeHtml html={desc} />
-                              </span>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
+                      <DescriptionList
+                        items={project.description}
+                        styles={project.descriptionStyles}
+                        textClassName={baseStyles['resume-text-xs']}
+                      />
                     </div>
                   ))}
                 </div>

--- a/apps/frontend/components/resume/resume-modern.tsx
+++ b/apps/frontend/components/resume/resume-modern.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 import { getSortedSections } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/modern.module.css';
 
@@ -127,20 +127,7 @@ export const ResumeModern: React.FC<ResumeModernProps> = ({
                     <span>{exp.company}</span>
                     {exp.location && <span>{exp.location}</span>}
                   </div>
-                  {exp.description && exp.description.length > 0 && (
-                    <ul
-                      className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}
-                    >
-                      {exp.description.map((desc, index) => (
-                        <li key={index} className="flex">
-                          <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                          <span>
-                            <SafeHtml html={desc} />
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -214,20 +201,7 @@ export const ResumeModern: React.FC<ResumeModernProps> = ({
                       <span>{project.role}</span>
                     </div>
                   )}
-                  {project.description && project.description.length > 0 && (
-                    <ul
-                      className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}
-                    >
-                      {project.description.map((desc, index) => (
-                        <li key={index} className="flex">
-                          <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                          <span>
-                            <SafeHtml html={desc} />
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <DescriptionList items={project.description} styles={project.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -510,18 +484,7 @@ function renderDynamicContent(
                   {item.location && <span>{item.location}</span>}
                 </div>
               )}
-              {item.description && item.description.length > 0 && (
-                <ul className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}>
-                  {item.description.map((desc, index) => (
-                    <li key={index} className="flex">
-                      <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                      <span>
-                        <SafeHtml html={desc} />
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
+              <DescriptionList items={item.description} styles={item.descriptionStyles} />
             </div>
           ))}
         </div>

--- a/apps/frontend/components/resume/resume-single-column.tsx
+++ b/apps/frontend/components/resume/resume-single-column.tsx
@@ -8,7 +8,7 @@ import type {
 import { getSortedSections } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
 import { DynamicResumeSection } from './dynamic-resume-section';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/swiss-single.module.css';
 
@@ -127,20 +127,7 @@ export const ResumeSingleColumn: React.FC<ResumeSingleColumnProps> = ({
                     <span>{exp.company}</span>
                     {exp.location && <span>{exp.location}</span>}
                   </div>
-                  {exp.description && exp.description.length > 0 && (
-                    <ul
-                      className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}
-                    >
-                      {exp.description.map((desc, index) => (
-                        <li key={index} className="flex">
-                          <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                          <span>
-                            <SafeHtml html={desc} />
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <DescriptionList items={exp.description} styles={exp.descriptionStyles} />
                 </div>
               ))}
             </div>
@@ -214,20 +201,7 @@ export const ResumeSingleColumn: React.FC<ResumeSingleColumnProps> = ({
                       <span>{project.role}</span>
                     </div>
                   )}
-                  {project.description && project.description.length > 0 && (
-                    <ul
-                      className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-sm']}`}
-                    >
-                      {project.description.map((desc, index) => (
-                        <li key={index} className="flex">
-                          <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                          <span>
-                            <SafeHtml html={desc} />
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <DescriptionList items={project.description} styles={project.descriptionStyles} />
                 </div>
               ))}
             </div>

--- a/apps/frontend/components/resume/resume-two-column.tsx
+++ b/apps/frontend/components/resume/resume-two-column.tsx
@@ -4,7 +4,7 @@ import type { ResumeData, ResumeSectionHeadings } from '@/components/dashboard/r
 import { getSortedSections, getSectionMeta } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
 import { DynamicResumeSection } from './dynamic-resume-section';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/swiss-two-column.module.css';
 
@@ -243,20 +243,11 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
                       </span>
                     </div>
 
-                    {exp.description && exp.description.length > 0 && (
-                      <ul
-                        className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}
-                      >
-                        {exp.description.map((desc, index) => (
-                          <li key={index} className="flex">
-                            <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                            <span>
-                              <SafeHtml html={desc} />
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
+                    <DescriptionList
+                      items={exp.description}
+                      styles={exp.descriptionStyles}
+                      textClassName={baseStyles['resume-text-xs']}
+                    />
                   </div>
                 ))}
               </div>
@@ -333,20 +324,11 @@ export const ResumeTwoColumn: React.FC<ResumeTwoColumnProps> = ({
                           <span>{project.role}</span>
                         </div>
                       )}
-                      {project.description && project.description.length > 0 && (
-                        <ul
-                          className={`ml-4 ${baseStyles['resume-list']} ${baseStyles['resume-text-xs']}`}
-                        >
-                          {project.description.map((desc, index) => (
-                            <li key={index} className="flex">
-                              <span className="mr-1.5 flex-shrink-0">•&nbsp;</span>
-                              <span>
-                                <SafeHtml html={desc} />
-                              </span>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
+                      <DescriptionList
+                        items={project.description}
+                        styles={project.descriptionStyles}
+                        textClassName={baseStyles['resume-text-xs']}
+                      />
                     </div>
                   ))}
                 </div>

--- a/apps/frontend/components/resume/resume-vivid.tsx
+++ b/apps/frontend/components/resume/resume-vivid.tsx
@@ -8,7 +8,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 import { getSortedSections, getSectionMeta } from '@/lib/utils/section-helpers';
 import { formatDateRange } from '@/lib/utils';
-import { SafeHtml } from './safe-html';
+import { DescriptionList } from './description-list';
 import baseStyles from './styles/_base.module.css';
 import styles from './styles/vivid.module.css';
 
@@ -134,22 +134,17 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
 
   const renderArrowBullets = (
     items?: string[],
-    textClass: string = baseStyles['resume-text-xs']
-  ) => {
-    if (!items || items.length === 0) return null;
-    return (
-      <ul className={`ml-4 ${baseStyles['resume-list']} ${textClass}`}>
-        {items.map((desc, index) => (
-          <li key={index} className="flex">
-            <span className={`mr-1.5 ${styles.arrow}`}>➜&nbsp;</span>
-            <span>
-              <SafeHtml html={desc} />
-            </span>
-          </li>
-        ))}
-      </ul>
-    );
-  };
+    textClass: string = baseStyles['resume-text-xs'],
+    itemStyles?: ('bullet' | 'plain')[]
+  ) => (
+    <DescriptionList
+      items={items}
+      styles={itemStyles}
+      textClassName={textClass}
+      marker="➜"
+      markerClassName={`mr-1.5 ${styles.arrow}`}
+    />
+  );
 
   return (
     <>
@@ -209,7 +204,11 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
                     <div className={`${baseStyles['resume-row-tight']} ${styles.entryMeta}`}>
                       {[formatDateRange(exp.years), exp.location].filter(Boolean).join(' | ')}
                     </div>
-                    {renderArrowBullets(exp.description)}
+                    {renderArrowBullets(
+                      exp.description,
+                      baseStyles['resume-text-xs'],
+                      exp.descriptionStyles
+                    )}
                   </div>
                 ))}
               </div>
@@ -284,7 +283,11 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
                           </span>
                         )}
                       </div>
-                      {renderArrowBullets(project.description)}
+                      {renderArrowBullets(
+                        project.description,
+                        baseStyles['resume-text-xs'],
+                        project.descriptionStyles
+                      )}
                     </div>
                   ))}
                 </div>
@@ -400,7 +403,11 @@ export const ResumeVivid: React.FC<ResumeVividProps> = ({
 const DynamicResumeSectionVivid: React.FC<{
   sectionMeta: SectionMeta;
   resumeData: ResumeData;
-  renderArrowBullets: (items?: string[], textClass?: string) => React.ReactNode;
+  renderArrowBullets: (
+    items?: string[],
+    textClass?: string,
+    itemStyles?: ('bullet' | 'plain')[]
+  ) => React.ReactNode;
 }> = ({ sectionMeta, resumeData, renderArrowBullets }) => {
   const customSection = resumeData.customSections?.[sectionMeta.key];
   if (!customSection) return null;
@@ -448,7 +455,11 @@ const DynamicResumeSectionVivid: React.FC<{
                   </span>
                 )}
               </div>
-              {renderArrowBullets(item.description)}
+              {renderArrowBullets(
+                item.description,
+                baseStyles['resume-text-xs'],
+                item.descriptionStyles
+              )}
             </div>
           ))}
         </div>

--- a/apps/frontend/components/ui/confirm-dialog.tsx
+++ b/apps/frontend/components/ui/confirm-dialog.tsx
@@ -113,7 +113,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         <DialogHeader className="p-6 pb-4">
           <div className="flex items-start gap-4">
             {icon}
-            <div className="flex-1">
+            <div className="min-w-0 flex-1">
               <DialogTitle className="font-serif text-xl font-bold uppercase tracking-tight">
                 {title}
               </DialogTitle>

--- a/apps/frontend/i18n/config.ts
+++ b/apps/frontend/i18n/config.ts
@@ -2,7 +2,7 @@
  * Internationalization configuration
  */
 
-export const locales = ['en', 'es', 'zh', 'ja', 'pt', 'fr'] as const;
+export const locales = ['en', 'es', 'zh', 'ja', 'pt', 'fr', 'ko'] as const;
 export type Locale = (typeof locales)[number];
 
 export const defaultLocale: Locale = 'en';
@@ -14,6 +14,7 @@ export const localeNames: Record<Locale, string> = {
   ja: '日本語',
   pt: 'Português',
   fr: 'Français',
+  ko: '한국어',
 };
 
 export const localeFlags: Record<Locale, string> = {
@@ -23,4 +24,5 @@ export const localeFlags: Record<Locale, string> = {
   ja: '🇯🇵',
   pt: '🇧🇷',
   fr: '🇫🇷',
+  ko: '🇰🇷',
 };

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -203,7 +203,7 @@ export async function updateFeatureConfig(config: FeatureConfigUpdate): Promise<
 }
 
 // Language configuration types
-export type SupportedLanguage = 'en' | 'es' | 'zh' | 'ja' | 'pt' | 'fr';
+export type SupportedLanguage = 'en' | 'es' | 'zh' | 'ja' | 'pt' | 'fr' | 'ko';
 
 export interface LanguageConfig {
   ui_language: SupportedLanguage;

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -4,6 +4,7 @@ import { apiFetch } from './client';
 export type LLMProvider =
   | 'openai'
   | 'openai_compatible'
+  | 'azure_foundry'
   | 'anthropic'
   | 'openrouter'
   | 'gemini'
@@ -138,7 +139,15 @@ export async function fetchSystemStatus(): Promise<SystemStatus> {
 // Provider display names and default models
 export const PROVIDER_INFO: Record<
   LLMProvider,
-  { name: string; defaultModel: string; requiresKey: boolean }
+  {
+    name: string;
+    defaultModel: string;
+    requiresKey: boolean;
+    requiresBaseUrl?: boolean;
+    baseUrlLabel?: string;
+    baseUrlPlaceholder?: string;
+    baseUrlDescription?: string;
+  }
 > = {
   openai: { name: 'OpenAI', defaultModel: 'gpt-5-nano-2025-08-07', requiresKey: true },
   // OpenAI-compatible: llama.cpp, vLLM, LM Studio, and other servers that expose
@@ -148,6 +157,16 @@ export const PROVIDER_INFO: Record<
     name: 'OpenAI-Compatible (Local)',
     defaultModel: 'custom-model',
     requiresKey: false,
+  },
+  azure_foundry: {
+    name: 'Azure AI Foundry',
+    defaultModel: 'mistral-large-latest',
+    requiresKey: true,
+    requiresBaseUrl: true,
+    baseUrlLabel: 'Azure AI Foundry endpoint',
+    baseUrlPlaceholder: 'https://<resource>.services.ai.azure.com/openai/v1/responses',
+    baseUrlDescription:
+      'Paste the endpoint from Foundry. GPT deployments can use the service root or /openai/v1/responses; Azure AI Inference models can use the /models endpoint.',
   },
   anthropic: { name: 'Anthropic', defaultModel: 'claude-haiku-4-5-20251001', requiresKey: true },
   openrouter: {
@@ -373,6 +392,7 @@ export async function updateFeaturePrompts(update: FeaturePromptsUpdate): Promis
 // API Key Management types
 export type ApiKeyProvider =
   | 'openai'
+  | 'azure_foundry'
   | 'anthropic'
   | 'google'
   | 'openrouter'
@@ -401,6 +421,7 @@ export interface ApiKeyStatusResponse {
 
 export interface ApiKeysUpdateRequest {
   openai?: string;
+  azure_foundry?: string;
   anthropic?: string;
   google?: string;
   openrouter?: string;
@@ -419,6 +440,7 @@ export interface ApiKeysUpdateResponse {
 export const API_KEY_PROVIDER_INFO: Record<ApiKeyProvider, { name: string; description: string }> =
   {
     openai: { name: 'OpenAI', description: 'GPT-4, GPT-4o, etc.' },
+    azure_foundry: { name: 'Azure AI Foundry', description: 'Azure AI Inference models' },
     anthropic: { name: 'Anthropic', description: 'Claude 3.5, Claude 4, etc.' },
     google: { name: 'Google', description: 'Gemini 1.5, Gemini 2, etc.' },
     openrouter: { name: 'OpenRouter', description: 'Access multiple providers' },

--- a/apps/frontend/lib/api/resume.ts
+++ b/apps/frontend/lib/api/resume.ts
@@ -27,6 +27,7 @@ interface ProcessedResume {
     location?: string | null;
     years?: string;
     description?: string[];
+    descriptionStyles?: ('bullet' | 'plain')[];
   }>;
   education?: Array<{
     id: number;
@@ -43,6 +44,7 @@ interface ProcessedResume {
     github?: string | null;
     website?: string | null;
     description?: string[];
+    descriptionStyles?: ('bullet' | 'plain')[];
   }>;
   additional?: {
     technicalSkills?: string[];

--- a/apps/frontend/lib/i18n/messages.ts
+++ b/apps/frontend/lib/i18n/messages.ts
@@ -6,6 +6,7 @@ import zh from '@/messages/zh.json';
 import ja from '@/messages/ja.json';
 import pt from '@/messages/pt-BR.json';
 import fr from '@/messages/fr.json';
+import ko from '@/messages/ko.json';
 
 export type Messages = typeof en;
 
@@ -16,6 +17,7 @@ const allMessages: Record<Locale, Messages> = {
   ja,
   pt,
   fr,
+  ko,
 };
 
 export function getMessages(locale: Locale): Messages {

--- a/apps/frontend/lib/utils/description-styles.ts
+++ b/apps/frontend/lib/utils/description-styles.ts
@@ -1,0 +1,23 @@
+export type DescriptionStyle = 'bullet' | 'plain';
+
+export function alignDescriptionStyles(
+  descriptions: string[] | undefined,
+  styles: (DescriptionStyle | null | undefined)[] | undefined
+): DescriptionStyle[] {
+  return (descriptions || []).map((_, index) => (styles?.[index] === 'plain' ? 'plain' : 'bullet'));
+}
+
+export function toggleDescriptionStyle(
+  descriptions: string[] | undefined,
+  styles: (DescriptionStyle | null | undefined)[] | undefined,
+  index: number
+): DescriptionStyle[] {
+  const alignedStyles = alignDescriptionStyles(descriptions, styles);
+
+  if (index < 0 || index >= alignedStyles.length) {
+    return alignedStyles;
+  }
+
+  alignedStyles[index] = alignedStyles[index] === 'plain' ? 'bullet' : 'plain';
+  return alignedStyles;
+}

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "Can't reach the server. Make sure it's running.",
       "apiKeyRequired": "API key is required for the selected provider.",
+      "baseUrlRequired": "{provider} requires a Base URL.",
       "unknownProvider": "Unknown provider returned from backend: {provider}",
       "unableToSaveConfiguration": "Unable to save configuration",
       "failedToClearApiKeys": "Failed to clear API keys. Please try again.",

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "Description Points"
       },
       "actions": {
-        "addPoint": "Add Point"
+        "addPoint": "Add Point",
+        "togglePointStyle": "Toggle bullet marker"
       },
       "placeholders": {
         "title": "Title",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "Puntos de descripción"
       },
       "actions": {
-        "addPoint": "Agregar punto"
+        "addPoint": "Agregar punto",
+        "togglePointStyle": "Alternar viñeta"
       },
       "placeholders": {
         "title": "Título",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "No se puede acceder al servidor. Asegúrate de que esté en ejecución.",
       "apiKeyRequired": "Se requiere una clave API para el proveedor seleccionado.",
+      "baseUrlRequired": "{provider} requiere una URL base.",
       "unknownProvider": "Proveedor desconocido devuelto por el backend: {provider}",
       "unableToSaveConfiguration": "No se pudo guardar la configuración",
       "failedToClearApiKeys": "No se pudieron borrar las claves API. Inténtalo de nuevo.",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "Impossible d'atteindre le serveur. Assurez-vous qu'il est en cours d'exécution.",
       "apiKeyRequired": "La clé API est requise pour le fournisseur sélectionné.",
+      "baseUrlRequired": "{provider} nécessite une URL de base.",
       "unknownProvider": "Fournisseur inconnu retourné par le backend : {provider}",
       "unableToSaveConfiguration": "Impossible d'enregistrer la configuration",
       "failedToClearApiKeys": "Impossible d'effacer les clés API. Veuillez réessayer.",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -176,7 +176,8 @@
       "resume": "CV",
       "coverLetter": "LETTRE DE MOTIVATION",
       "outreach": "MESSAGE DE CONTACT",
-      "jdMatch": "CORRESPONDANCE FP"
+      "jdMatch": "CORRESPONDANCE FP",
+      "interviewPrep": "PRÉPARATION ENTRETIEN"
     },
     "footer": {
       "moduleLabel": "Module Créateur de CV",
@@ -195,7 +196,9 @@
       "outreachDescription": "Générez un message de prise de contact concis pour LinkedIn ou e-mail basé sur votre CV et la fiche de poste.",
       "generateButton": "Générer {title}",
       "coverLetterFooter": "Conseil : personnalisez d'abord pour de meilleurs résultats.",
-      "outreachFooter": "Conseil : restez bref et personnalisé."
+      "outreachFooter": "Conseil : restez bref et personnalisé.",
+      "interviewPrepDescription": "Générez une préparation à l'entretien adaptée au poste à partir de votre CV personnalisé et de la fiche de poste.",
+      "interviewPrepFooter": "Conseil : utilisez-la après la personnalisation pour préparer des réponses fiables et ancrées dans votre CV."
     },
     "regenerateDialog": {
       "title": "Régénérer {title} ?",
@@ -444,7 +447,8 @@
       "editorPanel": "Panneau d'édition",
       "coverLetterEditor": "Éditeur de lettre de motivation",
       "outreachEditor": "Éditeur de message de contact",
-      "jdMatchAnalysis": "Analyse de correspondance FP"
+      "jdMatchAnalysis": "Analyse de correspondance FP",
+      "interviewPrep": "Préparation à l'entretien"
     },
     "alerts": {
       "saveNotAvailable": "L'enregistrement n'est disponible que lors de la modification d'un CV existant.",
@@ -461,7 +465,8 @@
       "coverLetterDownloadFailed": "Impossible de télécharger la lettre de motivation : {error}",
       "outreachSaveFailed": "Impossible d'enregistrer le message de contact. Veuillez réessayer.",
       "coverLetterGenerateFailed": "Impossible de générer la lettre de motivation : {error}",
-      "outreachGenerateFailed": "Impossible de générer le message de contact : {error}"
+      "outreachGenerateFailed": "Impossible de générer le message de contact : {error}",
+      "interviewPrepGenerateFailed": "Impossible de générer la préparation à l'entretien : {error}"
     }
   },
   "enrichment": {
@@ -705,7 +710,11 @@
       "customPromptLabel": "Invite personnalisée (optionnelle)",
       "customPromptHelp": "Doit inclure ces espaces réservés (chacun entre accolades) : job_description, resume_data, output_language. Laissez vide pour utiliser l'invite par défaut.",
       "customPromptResetButton": "Rétablir la valeur par défaut",
-      "customPromptErrorMissing": "Espaces réservés manquants : {missing}"
+      "customPromptErrorMissing": "Espaces réservés manquants : {missing}",
+      "interviewPrep": {
+        "label": "Préparation à l'entretien",
+        "description": "Générez automatiquement une préparation à l'entretien avec les CV personnalisés enregistrés"
+      }
     },
     "promptSettings": {
       "title": "Paramètres d'invite",
@@ -1005,6 +1014,25 @@
       "loadFailed": "Impossible de charger les candidatures.",
       "moveFailed": "Impossible de déplacer la candidature.",
       "deleteFailed": "Impossible de supprimer la ou les candidatures."
+    }
+  },
+  "interviewPrep": {
+    "title": "Préparation à l'entretien",
+    "regenerate": "Régénérer",
+    "unavailableTitle": "Préparation à l'entretien indisponible",
+    "loadingContextDescription": "Vérification du contexte du poste pour ce CV personnalisé avant la génération.",
+    "missingContextDescription": "Ce CV personnalisé ne contient pas le contexte de poste enregistré nécessaire pour générer la préparation à l'entretien. Personnalisez à nouveau le CV avec une fiche de poste pour utiliser ce flux.",
+    "saveRequiredDescription": "Enregistrez ce CV personnalisé avant de générer la préparation à l'entretien.",
+    "focusArea": "Point d'attention",
+    "suggestedAnswerPoints": "Points de réponse suggérés",
+    "whyItMatters": "Pourquoi c'est important",
+    "preparationSuggestion": "Suggestion de préparation",
+    "sections": {
+      "roleFit": "Analyse d'adéquation au poste",
+      "resumeQuestions": "Questions basées sur le CV",
+      "projectFollowUps": "Questions de suivi sur les projets",
+      "skillGaps": "Écarts de compétences",
+      "talkingPoints": "Points à aborder"
     }
   }
 }

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -289,7 +289,8 @@
         "descriptionPoints": "Points de description"
       },
       "actions": {
-        "addPoint": "Ajouter un point"
+        "addPoint": "Ajouter un point",
+        "togglePointStyle": "Basculer la puce"
       },
       "placeholders": {
         "title": "Titre",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "説明ポイント"
       },
       "actions": {
-        "addPoint": "ポイントを追加"
+        "addPoint": "ポイントを追加",
+        "togglePointStyle": "箇条書き記号を切り替え"
       },
       "placeholders": {
         "title": "タイトル",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "サーバーに接続できません。サーバーが起動していることを確認してください。",
       "apiKeyRequired": "選択したプロバイダーには API キーが必要です。",
+      "baseUrlRequired": "{provider} にはベース URL が必要です。",
       "unknownProvider": "バックエンドから未知のプロバイダーが返されました: {provider}",
       "unableToSaveConfiguration": "設定を保存できません",
       "failedToClearApiKeys": "API キーの消去に失敗しました。もう一度お試しください。",

--- a/apps/frontend/messages/ko.json
+++ b/apps/frontend/messages/ko.json
@@ -1,0 +1,1038 @@
+{
+  "common": {
+    "save": "저장",
+    "saving": "저장 중...",
+    "cancel": "취소",
+    "delete": "삭제",
+    "edit": "편집",
+    "download": "다운로드",
+    "loading": "불러오는 중...",
+    "uploading": "업로드 중...",
+    "checking": "확인 중...",
+    "processing": "처리 중...",
+    "generating": "생성 중...",
+    "error": "오류",
+    "success": "성공",
+    "confirm": "확인",
+    "back": "뒤로",
+    "retry": "다시 시도",
+    "next": "다음",
+    "continue": "계속",
+    "finish": "완료",
+    "optional": "선택 사항",
+    "close": "닫기",
+    "ok": "확인",
+    "search": "검색",
+    "filter": "필터",
+    "reset": "초기화",
+    "apply": "적용",
+    "selectOption": "옵션을 선택하세요...",
+    "unknown": "알 수 없음",
+    "keysCleared": "API 키가 성공적으로 삭제되었습니다",
+    "databaseReset": "데이터베이스가 성공적으로 초기화되었습니다",
+    "popupBlocked": "팝업이 차단되었습니다. 팝업을 허용하거나 다음 URL을 직접 열어주세요: {url}"
+  },
+  "home": {
+    "brandLine1": "Resume",
+    "brandLine2": "Matcher",
+    "docs": "문서",
+    "launchApp": "앱 실행"
+  },
+  "nav": {
+    "dashboard": "대시보드",
+    "builder": "이력서 빌더",
+    "tailor": "이력서 맞춤화",
+    "settings": "설정",
+    "backToDashboard": "대시보드로 돌아가기",
+    "goToSettings": "설정으로 이동",
+    "applicationTracker": "지원 현황 트래커"
+  },
+  "dashboard": {
+    "title": "대시보드",
+    "subtitle": "이력서와 지원 현황을 관리하세요",
+    "myResumes": "내 이력서",
+    "noResumes": "아직 이력서가 없습니다",
+    "noResumesDescription": "첫 이력서를 업로드하여 시작하세요",
+    "uploadResume": "이력서 업로드",
+    "createNew": "새로 만들기",
+    "lastModified": "마지막 수정",
+    "actions": "작업",
+    "preview": "미리보기",
+    "viewResume": "이력서 보기",
+    "editResume": "이력서 편집",
+    "deleteResume": "이력서 삭제",
+    "downloadPdf": "PDF 다운로드",
+    "tailorResume": "채용 공고에 맞춤화",
+    "selectModule": "모듈 선택",
+    "masterResume": "마스터 이력서",
+    "tailoredResume": "맞춤화된 이력서",
+    "initializeMasterResume": "마스터 이력서 초기화",
+    "initializeSequence": "초기화 시퀀스",
+    "refreshStatus": "상태 새로고침",
+    "retryProcessing": "처리 다시 시도",
+    "retryingProcessing": "다시 시도하는 중...",
+    "deleteAndReupload": "삭제 후 재업로드",
+    "processingFailedHint": "이 파일을 읽을 수 없습니다. 다시 시도하거나 다른 파일을 업로드하세요.",
+    "retrySuccess": "처리에 성공했습니다!",
+    "retryFailed": "다시 시도에 실패했습니다. 다른 파일을 업로드해 보세요.",
+    "createResume": "이력서 만들기",
+    "edited": "{date}에 수정됨",
+    "statusLine": "상태: {status}",
+    "status": {
+      "checking": "확인 중...",
+      "processing": "처리 중...",
+      "ready": "준비 완료",
+      "failed": "처리 실패",
+      "pending": "대기 중"
+    },
+    "llmNotConfiguredTitle": "[ LLM 미설정 ]",
+    "llmNotConfiguredMessage": "> API 키가 없습니다. 설정에서 구성하기 전까지 이력서 맞춤화가 비활성화됩니다.",
+    "setupRequiredTitle": "[ 설정 필요 ]",
+    "setupRequiredMessage": "> 이력서 맞춤화를 사용하려면 설정에서 API 키를 구성하세요.",
+    "uploadDialog": {
+      "success": "이력서가 성공적으로 업로드되었습니다.",
+      "successMaster": "이력서가 업로드되어 마스터로 설정되었습니다.",
+      "successMissingId": "업로드는 성공했지만 이력서 ID가 반환되지 않았습니다.",
+      "parsingFailed": "이력서는 업로드되었지만 AI 분석에 실패했습니다. 여전히 수동으로 맞춤화할 수 있습니다.",
+      "failed": "업로드에 실패했습니다.",
+      "dropzoneTitle": "클릭하거나 파일을 드래그하세요",
+      "dropzoneSubtitle": "PDF, DOC, DOCX (최대 4MB)",
+      "tryDifferentFile": "다른 파일 시도",
+      "parsingFailedKeepOpen": "AI 분석에 실패했습니다. 다른 파일을 시도하거나 이 대화상자를 닫으세요."
+    }
+  },
+  "builder": {
+    "title": "이력서 빌더",
+    "editMode": "편집 모드",
+    "previewMode": "미리보기 모드",
+    "createAndPreview": "만들고 미리보기",
+    "unsavedDraft": "저장되지 않은 초안",
+    "personalInfo": "개인 정보",
+    "summary": "요약",
+    "experience": "경력",
+    "education": "학력",
+    "skills": "기술",
+    "projects": "프로젝트",
+    "certifications": "자격증",
+    "languages": "언어",
+    "awards": "수상 내역",
+    "addSection": "섹션 추가",
+    "removeSection": "섹션 제거",
+    "saveChanges": "변경 사항 저장",
+    "discardChanges": "변경 사항 취소",
+    "placeholders": {
+      "summary": "전문 경력을 간략하게 설명해 주세요..."
+    },
+    "contentStats": {
+      "wordsChars": "{wordCount} 단어 / {charCount}자"
+    },
+    "additionalForm": {
+      "instructions": "항목을 줄바꿈으로 구분하여 입력하세요(각 항목마다 Enter를 누르세요).",
+      "placeholders": {
+        "technicalSkills": "React\nTypeScript\nNode.js",
+        "languages": "영어\n스페인어",
+        "certifications": "AWS Solution Architect\nGoogle Analytics",
+        "awards": "이달의 직원\n해커톤 우승"
+      }
+    },
+    "customSections": {
+      "dialogTitle": "사용자 지정 섹션 추가",
+      "dialogDescription": "이름과 유형을 지정하여 이력서에 새 섹션을 만듭니다.",
+      "sectionNameLabel": "섹션 이름",
+      "sectionNamePlaceholder": "예: 논문, 봉사 활동, 자격증",
+      "sectionTypeLabel": "섹션 유형",
+      "addCustomSectionButton": "사용자 지정 섹션 추가",
+      "sectionTypes": {
+        "textBlockLabel": "텍스트 블록",
+        "textBlockDescription": "단일 텍스트 영역(요약과 유사)",
+        "itemListLabel": "항목 목록",
+        "itemListDescription": "세부 정보가 있는 여러 항목(경력과 유사)",
+        "stringListLabel": "기술 목록",
+        "stringListDescription": "간단한 항목 목록(기술과 유사)"
+      },
+      "contentLabel": "내용",
+      "contentPlaceholder": "{name}에 대한 내용을 입력하세요...",
+      "defaultTextPlaceholder": "텍스트 내용을 입력하세요...",
+      "entryLabel": "항목",
+      "addEntryLabel": "항목 추가",
+      "itemsLabel": "항목",
+      "itemsPlaceholder": "항목을 한 줄에 하나씩 입력하세요",
+      "unknownSectionType": "알 수 없는 섹션 유형: {type}",
+      "unknownDefaultSection": "알 수 없는 기본 섹션: {section}"
+    },
+    "sectionHeader": {
+      "renameSection": "섹션 이름 바꾸기",
+      "customTag": "사용자 지정",
+      "hiddenFromPdfTag": "PDF에서 숨김",
+      "hideSection": "섹션 숨기기",
+      "showSection": "섹션 표시",
+      "moveUp": "위로 이동",
+      "moveDown": "아래로 이동",
+      "deleteSection": "섹션 삭제",
+      "deleteTitle": "섹션 삭제",
+      "deleteDescription": "\"{name}\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+    },
+    "previewTabs": {
+      "resume": "이력서",
+      "coverLetter": "자기소개서",
+      "outreach": "아웃리치 메일",
+      "jdMatch": "채용공고 매칭",
+      "interviewPrep": "면접 준비"
+    },
+    "footer": {
+      "moduleLabel": "이력서 빌더 모듈",
+      "singleColumn": "단일 열",
+      "twoColumn": "2단"
+    },
+    "pageSize": {
+      "usLetter": "US 레터"
+    },
+    "generatePrompt": {
+      "notAvailableTitle": "{title}을(를) 사용할 수 없음",
+      "notAvailableDescription": "{title}을(를) 생성하려면 먼저 채용 공고로 이력서를 맞춤화하세요.",
+      "goToDashboard": "대시보드로 이동",
+      "generateTitle": "{title} 생성",
+      "coverLetterDescription": "이력서와 채용 공고를 기반으로 맞춤화된 자기소개서를 생성합니다.",
+      "outreachDescription": "이력서와 채용 공고를 기반으로 링크드인이나 이메일용 간결한 아웃리치 메시지를 생성합니다.",
+      "generateButton": "{title} 생성",
+      "coverLetterFooter": "팁: 최상의 결과를 위해 먼저 맞춤화하세요.",
+      "outreachFooter": "팁: 짧고 개인화된 내용으로 작성하세요.",
+      "interviewPrepDescription": "맞춤화된 이력서와 채용 공고를 기반으로 직무별 면접 준비 자료를 생성합니다.",
+      "interviewPrepFooter": "팁: 맞춤화 후 이 기능을 사용해 이력서에 기반한 진실된 답변을 준비하세요."
+    },
+    "regenerateDialog": {
+      "title": "{title}을(를) 다시 생성하시겠습니까?",
+      "description": "현재 {title}을(를) 새로 생성된 것으로 교체합니다. 지금까지 편집한 내용은 사라집니다."
+    },
+    "regenerate": {
+      "buttonLabel": "AI 재생성",
+      "selectDialog": {
+        "title": "재생성할 항목 선택",
+        "subtitle": "개선하고 싶은 이력서 부분을 선택하세요",
+        "experience": "경력",
+        "projects": "프로젝트",
+        "skills": "기술",
+        "noItemsSelected": "항목을 하나 이상 선택하세요",
+        "noItemsAvailable": "재생성할 수 있는 항목이 없습니다. 먼저 경력, 프로젝트 또는 기술을 추가하세요.",
+        "itemCount": {
+          "one": "{count}개 항목",
+          "other": "{count}개 항목"
+        },
+        "continueButton": "계속"
+      },
+      "instructionDialog": {
+        "title": "무엇을 개선하고 싶으신가요?",
+        "subtitle": "AI를 안내할 구체적인 피드백을 제공하세요",
+        "defaultInstruction": "더 강력한 행동 동사와, 가능한 경우 정량화된 성과를 사용해 내용을 개선하세요.",
+        "selectedItems": "선택한 항목",
+        "placeholder": "예: 정량적 지표 추가, 리더십 역량 강조, 더 많은 행동 동사 사용...",
+        "hint": "만족스럽지 않은 부분을 구체적으로 알려주세요",
+        "backButton": "뒤로",
+        "generateButton": "생성"
+      },
+      "diffPreview": {
+        "title": "변경 사항 미리보기",
+        "subtitle": "적용하기 전에 재생성된 내용을 검토하세요",
+        "expandItem": "{item} 펼치기",
+        "collapseItem": "{item} 접기",
+        "partialFailures": "일부 항목({count}개)을 재생성하지 못했습니다. 성공한 항목은 검토하고 적용할 수 있습니다.",
+        "changesCount": "{count}개 항목 수정됨",
+        "rejectButton": "거부하고 다시 생성",
+        "acceptButton": "변경 사항 적용",
+        "originalLabel": "원본",
+        "newLabel": "새 항목",
+        "noContent": "내용 없음",
+        "applying": "적용 중...",
+        "loading": "개선된 내용을 생성하는 중..."
+      },
+      "errors": {
+        "generationFailed": "콘텐츠 생성에 실패했습니다. 다시 시도해 주세요.",
+        "applyFailed": "변경 사항 적용에 실패했습니다. 다시 시도해 주세요.",
+        "resumeChanged": "재생성 이후 이력서 내용이 변경되었습니다. 다시 생성한 후 시도해 주세요.",
+        "noChangesToApply": "적용할 변경 사항이 없습니다.",
+        "networkError": "네트워크 오류입니다. 연결 상태를 확인해 주세요."
+      }
+    },
+    "jdMatch": {
+      "yourResume": "내 이력서",
+      "matchingKeywordsHighlighted": "(일치하는 키워드가 강조 표시됨)",
+      "jobDescriptionTitle": "채용 공고",
+      "at": "@",
+      "atSeparator": " @ ",
+      "roleSeparator": "-",
+      "aboutTitle": "채용공고 매칭 안내",
+      "aboutDescription": "이 화면은 이력서가 채용 공고와 얼마나 잘 일치하는지 보여줍니다. 채용 공고의 키워드가 이력서에 노란색으로 강조 표시되어, 이미 다루고 있는 기술과 용어를 파악하는 데 도움이 됩니다.",
+      "highlightedKeywordsTitle": "강조된 키워드",
+      "highlightedKeywordsDescriptionTemplate": "__COLOR__(으)로 강조된 단어는 채용 공고와 이력서 양쪽에 모두 나타납니다. 일치율이 높을수록 채용 요건과의 적합도가 높다는 의미입니다.",
+      "highlightedKeywordsDescriptionPrefix": "다음 색으로 강조된 단어는",
+      "highlightColor": "노란색",
+      "highlightedKeywordsDescriptionSuffix": "채용 공고와 이력서 양쪽에 모두 나타납니다. 일치율이 높을수록 채용 요건과의 적합도가 높다는 의미입니다.",
+      "tipsTitle": "팁",
+      "tips": {
+        "items": {
+          "addMissingKeywords": "이력서 탭에서 누락된 키워드를 추가하세요",
+          "focusTechnicalSkills": "채용 공고에 언급된 기술 스킬과 도구에 집중하세요",
+          "matchActionVerbs": "채용 요건의 행동 동사를 맞추세요"
+        }
+      },
+      "stats": {
+        "keywordsExtracted": "{count}개 키워드 추출됨",
+        "matchesFound": "{count}개 일치 항목 발견",
+        "matchRateLabel": "일치율:"
+      }
+    },
+    "genericItemForm": {
+      "itemLabel": "항목",
+      "addItemLabel": "{label} 추가",
+      "fields": {
+        "title": "제목",
+        "organization": "조직",
+        "location": "위치",
+        "years": "연도",
+        "descriptionPoints": "설명 항목"
+      },
+      "actions": {
+        "addPoint": "항목 추가"
+      },
+      "placeholders": {
+        "title": "제목",
+        "organization": "조직",
+        "location": "위치",
+        "years": "2020년 1월 - 현재",
+        "description": "기여한 내용을 설명하세요..."
+      },
+      "noEntries": "// {label} 항목 없음",
+      "addFirstItem": "첫 {label} 추가"
+    },
+    "forms": {
+      "experience": {
+        "addJob": "경력 추가",
+        "addFirstJob": "첫 경력 추가",
+        "fields": {
+          "jobTitle": "직함",
+          "company": "회사"
+        },
+        "placeholders": {
+          "jobTitle": "시니어 개발자",
+          "company": "테크 코퍼레이션",
+          "location": "원격 / 도시",
+          "years": "2020년 1월 - 현재",
+          "description": "성과를 설명하세요..."
+        }
+      },
+      "education": {
+        "addSchool": "학교 추가",
+        "addFirstSchool": "첫 학교 추가",
+        "fields": {
+          "institution": "학교명",
+          "degree": "학위",
+          "description": "설명",
+          "descriptionOptional": "설명 (선택 사항)"
+        },
+        "placeholders": {
+          "institution": "학교 이름",
+          "degree": "학사 학위",
+          "years": "2016년 8월 - 2020년 5월",
+          "description": "추가 세부 정보..."
+        }
+      },
+      "projects": {
+        "addProject": "프로젝트 추가",
+        "addFirstProject": "첫 프로젝트 추가",
+        "fields": {
+          "projectName": "프로젝트 이름",
+          "role": "역할",
+          "website": "웹사이트"
+        },
+        "placeholders": {
+          "projectName": "Resume Matcher",
+          "role": "제작자",
+          "years": "2023년 3월",
+          "github": "github.com/username/project",
+          "website": "https://project-demo.com",
+          "description": "프로젝트 세부 내용..."
+        }
+      }
+    },
+    "formatting": {
+      "panelTitle": "템플릿 및 서식",
+      "template": "템플릿",
+      "templates": {
+        "swissSingle": {
+          "name": "단일 열",
+          "description": "콘텐츠 밀도가 높은 전통적인 전체 너비 레이아웃"
+        },
+        "swissTwoColumn": {
+          "name": "2단",
+          "description": "경력 중심 메인 열과 기술용 사이드바"
+        },
+        "modern": {
+          "name": "모던",
+          "description": "사용자 지정 가능한 테마 색상의 화려한 포인트"
+        },
+        "modernTwoColumn": {
+          "name": "모던 2단",
+          "description": "모던하고 화려한 포인트와 테마가 있는 2단 레이아웃"
+        },
+        "latex": {
+          "name": "LaTeX",
+          "description": "괘선 섹션 제목이 있는 클래식 세리프 학술 레이아웃"
+        },
+        "clean": {
+          "name": "클린",
+          "description": "큼직하고 절제된 섹션 제목의 미니멀한 산세리프 레이아웃"
+        },
+        "vivid": {
+          "name": "비비드",
+          "description": "강조 헤더와 화살표 불릿이 있는 화려한 2단 레이아웃"
+        }
+      },
+      "accentColor": "강조 색상",
+      "accentColors": {
+        "blue": "파랑",
+        "green": "초록",
+        "orange": "주황",
+        "red": "빨강"
+      },
+      "pageSize": "용지 크기",
+      "margins": "여백 (mm)",
+      "margin": {
+        "top": "위",
+        "bottom": "아래",
+        "left": "왼쪽",
+        "right": "오른쪽"
+      },
+      "spacing": "간격",
+      "spacingSection": "섹션",
+      "spacingItems": "항목",
+      "spacingLines": "줄",
+      "fontSize": "글꼴 크기",
+      "baseFontSize": "기본",
+      "headerScale": "제목",
+      "headerFontFamily": "제목",
+      "bodyFontFamily": "본문",
+      "fontNames": {
+        "serif": "세리프",
+        "sans": "산세리프",
+        "mono": "모노스페이스"
+      },
+      "options": "옵션",
+      "compactMode": "컴팩트 모드",
+      "contactIcons": "연락처 아이콘",
+      "effectiveOutput": "적용된 출력",
+      "effectiveMargins": "여백 (mm): 위{top} 아래{bottom} 왼{left} 오{right}",
+      "effectiveSectionGap": "섹션 간격",
+      "effectiveItemGap": "항목 간격",
+      "effectiveLineHeight": "줄 간격",
+      "effectiveBaseFont": "기본 글꼴",
+      "effectiveHeaderScale": "제목 배율",
+      "effectiveHeaderFont": "제목 글꼴",
+      "effectiveBodyFont": "본문 글꼴",
+      "compactHint": "컴팩트 모드는 간격과 줄 높이를 좁힙니다. 여백과 기본 글꼴 크기는 그대로 유지됩니다.",
+      "resetDefaults": "기본값으로 재설정"
+    },
+    "personalInfoForm": {
+      "placeholders": {
+        "name": "홍길동",
+        "title": "소프트웨어 엔지니어",
+        "email": "john@example.com",
+        "phone": "+82 10-0000-0000",
+        "location": "도시, 국가",
+        "website": "portfolio.com",
+        "linkedin": "linkedin.com/in/john",
+        "github": "github.com/john"
+      }
+    },
+    "leftPanel": {
+      "editorPanel": "편집 패널",
+      "coverLetterEditor": "자기소개서 편집기",
+      "outreachEditor": "아웃리치 메시지 편집기",
+      "jdMatchAnalysis": "채용공고 매칭 분석",
+      "interviewPrep": "면접 준비"
+    },
+    "alerts": {
+      "saveNotAvailable": "저장은 기존 이력서를 편집할 때만 사용할 수 있습니다.",
+      "saveFailed": "이력서 저장에 실패했습니다. 다시 시도해 주세요.",
+      "coverLetterSaveSuccess": "자기소개서가 저장되었습니다",
+      "outreachSaveSuccess": "아웃리치 메시지가 저장되었습니다",
+      "downloadSuccess": "이력서가 다운로드되었습니다",
+      "reloadFailed": "변경 사항은 적용되었지만 이력서를 다시 불러오지 못했습니다. 페이지를 새로고침해 주세요.",
+      "downloadNotAvailable": "다운로드는 저장된 이력서에서만 사용할 수 있습니다.",
+      "downloadFailed": "이력서 다운로드에 실패했습니다. 다시 시도해 주세요.",
+      "coverLetterSaveFailed": "자기소개서 저장에 실패했습니다. 다시 시도해 주세요.",
+      "coverLetterDownloadRequiresResume": "자기소개서를 다운로드하려면 먼저 이력서를 저장하세요.",
+      "coverLetterMissing": "자기소개서가 없습니다. 설정에서 자기소개서 생성을 활성화하고 이력서를 맞춤화하세요.",
+      "coverLetterDownloadFailed": "자기소개서 다운로드에 실패했습니다: {error}",
+      "outreachSaveFailed": "아웃리치 메시지 저장에 실패했습니다. 다시 시도해 주세요.",
+      "coverLetterGenerateFailed": "자기소개서 생성에 실패했습니다: {error}",
+      "outreachGenerateFailed": "아웃리치 메시지 생성에 실패했습니다: {error}",
+      "interviewPrepGenerateFailed": "면접 준비 자료 생성에 실패했습니다: {error}"
+    }
+  },
+  "enrichment": {
+    "title": "이력서 개선",
+    "loading": {
+      "analyzingTitle": "이력서를 분석하는 중...",
+      "analyzingDescription": "더 구체적인 설명이 필요한 부분을 찾는 중입니다",
+      "generatingTitle": "개선된 설명을 작성하는 중...",
+      "generatingDescription": "답변을 활용해 이력서를 개선하는 중입니다",
+      "applyingTitle": "개선 사항을 적용하는 중...",
+      "applyingDescription": "마스터 이력서를 업데이트하는 중입니다"
+    },
+    "questionProgress": "질문 {current} / {total}",
+    "itemType": {
+      "experience": "경력",
+      "project": "프로젝트"
+    },
+    "shortcutHint": "줄바꿈은 Shift+Enter, 계속하려면 Cmd/Ctrl+Enter를 누르세요",
+    "preview": {
+      "title": "새 내용 검토",
+      "description": "이력서에 추가될 새로운 항목을 검토하세요",
+      "applyButton": "이력서에 추가",
+      "keepingLabel": "유지",
+      "addingLabel": "추가",
+      "existingCount": "(기존 {count}개)",
+      "newCount": "(신규 {count}개)",
+      "noExistingDescription": "기존 설명 없음"
+    },
+    "complete": {
+      "title": "이력서가 개선되었습니다!",
+      "updatedCountSingular": "{count}개 항목이 성공적으로 업데이트되었습니다",
+      "updatedCountPlural": "{count}개 항목이 성공적으로 업데이트되었습니다",
+      "updatedFallback": "이력서가 개선된 설명으로 업데이트되었습니다",
+      "doneButton": "완료"
+    },
+    "noImprovements": {
+      "title": "이력서가 훌륭합니다!",
+      "defaultDescription": "개선이 필요한 항목을 찾지 못했습니다. 경력 및 프로젝트 설명이 이미 충분히 상세합니다."
+    },
+    "error": {
+      "title": "문제가 발생했습니다",
+      "unexpected": "예상치 못한 오류가 발생했습니다"
+    }
+  },
+  "tailor": {
+    "title": "이력서 맞춤화",
+    "subtitle": "특정 채용 공고에 맞게 이력서를 최적화하세요",
+    "heroTitle": "이력서 맞춤화",
+    "selectResume": "이력서 선택",
+    "pasteJobDescription": "채용 공고 붙여넣기",
+    "pasteJobDescriptionBelow": "아래에 채용 공고를 붙여넣으세요",
+    "jobDescriptionPlaceholder": "채용 공고를 여기에 붙여넣으세요...",
+    "promptLabel": "맞춤화 강도",
+    "promptDescription": "이력서를 채용 공고에 얼마나 강하게 맞출지 선택하세요.",
+    "promptOptions": {
+      "nudge": {
+        "label": "약하게 조정",
+        "description": "기존 경력을 더 잘 맞추도록 최소한으로 수정합니다."
+      },
+      "keywords": {
+        "label": "키워드 강화",
+        "description": "역할이나 범위는 바꾸지 않고 관련 키워드를 반영합니다."
+      },
+      "full": {
+        "label": "전체 맞춤화",
+        "description": "채용 공고를 활용해 전면적으로 맞춤화합니다."
+      }
+    },
+    "analyzeJob": "채용 공고 분석",
+    "generateTailored": "맞춤화된 이력서 생성",
+    "setupRequiredTitle": "[ 설정 필요 ]",
+    "noApiKeyMessage": "> API 키가 구성되지 않았습니다. 이력서 맞춤화에는 LLM 제공업체가 필요합니다.",
+    "configureApiKey": "API 키 구성",
+    "configureApiKeyFirst": "먼저 API 키를 구성하세요",
+    "charactersCount": "{count}자",
+    "matchScore": "일치 점수",
+    "suggestions": "제안",
+    "keywords": "포함할 키워드",
+    "footerTagline": "AI 기반 최적화 엔진",
+    "diffModal": {
+      "title": "AI 맞춤화 결과 검토",
+      "subtitle": "허위 정보가 추가되지 않았는지 변경 사항을 꼼꼼히 검토해 주세요",
+      "summary": "변경 요약",
+      "skillsAdded": "추가된 기술",
+      "skillsRemoved": "삭제된 기술",
+      "descriptionsModified": "수정된 설명",
+      "certificationsAdded": "추가된 자격증",
+      "highRiskChanges": "고위험 변경 사항",
+      "warningTitle": "고위험 추가 사항 {count}건 감지됨",
+      "warningMessage": "이 추가 항목들이 원본 이력서에 실제로 존재하거나 설명에 반영되어 있는지 확인해 주세요",
+      "summaryChanges": "요약 변경 사항",
+      "skillChanges": "기술 변경 사항",
+      "descriptionChanges": "경력 설명 변경 사항",
+      "experienceChanges": "경력 항목 변경 사항",
+      "educationChanges": "학력 변경 사항",
+      "projectChanges": "프로젝트 변경 사항",
+      "certificationChanges": "자격증 변경 사항",
+      "languageChanges": "언어 변경 사항",
+      "awardChanges": "수상 내역 변경 사항",
+      "rejectButton": "거부하고 다시 생성",
+      "confirmButton": "확인하고 저장"
+    },
+    "regenerateDialog": {
+      "title": "맞춤화된 이력서를 다시 생성하시겠습니까?",
+      "description": "현재 미리보기를 폐기하고 새로운 AI 맞춤화 결과를 요청합니다.",
+      "confirmLabel": "다시 생성"
+    },
+    "missingDiffDialog": {
+      "title": "변경 사항을 계산할 수 없습니다",
+      "description": "이 이력서의 차이를 계산할 수 없습니다. 구조화된 데이터가 없는 이전 형식의 이력서에서 발생할 수 있습니다. 맞춤화된 이력서를 계속 저장하거나, 취소하여 나중에 다시 검토할 수 있습니다.",
+      "confirmLabel": "차이 없이 계속"
+    },
+    "errors": {
+      "jobDescriptionTooShort": "채용 공고가 너무 짧습니다. 세부 내용을 추가한 후 다시 시도하세요.",
+      "apiKeyError": "API 키가 작동하지 않습니다. 설정에서 확인하세요.",
+      "rateLimit": "요청 한도에 도달했습니다. 약 1분 후 다시 시도해 주세요.",
+      "failedToGenerate": "이력서를 생성할 수 없습니다. 설정에서 API 키를 확인한 후 다시 시도하세요.",
+      "timeout": "요청이 시간 초과되었습니다. 더 짧은 채용 공고로 다시 시도하거나 연결 상태를 확인해 주세요.",
+      "failedToPreview": "이력서를 미리 볼 수 없습니다. 설정에서 API 키를 확인한 후 다시 시도하세요.",
+      "failedToConfirm": "변경 사항을 적용할 수 없습니다. 다시 시도해 주세요."
+    }
+  },
+  "settings": {
+    "title": "설정",
+    "subtitle": "환경설정을 구성하세요",
+    "aiProvider": "AI 제공업체",
+    "aiProviderDescription": "이력서 분석에 사용할 AI 제공업체를 선택하세요",
+    "apiKey": "API 키",
+    "apiKeyPlaceholder": "API 키를 입력하세요",
+    "saveApiKey": "API 키 저장",
+    "contentLanguage": "콘텐츠 언어",
+    "contentLanguageDescription": "생성되는 콘텐츠(이력서, 자기소개서)의 언어",
+    "uiLanguage": "UI 언어",
+    "uiLanguageDescription": "사용자 인터페이스의 언어",
+    "theme": "테마",
+    "themeDescription": "선호하는 색상 테마를 선택하세요",
+    "lightMode": "라이트",
+    "darkMode": "다크",
+    "systemMode": "시스템",
+    "dangerZone": "위험 구역",
+    "clearApiKeys": "API 키 삭제",
+    "clearApiKeysDescription": "저장된 모든 API 키를 설정에서 제거합니다. 이 작업은 되돌릴 수 없습니다.",
+    "resetDatabase": "데이터베이스 초기화",
+    "resetDatabaseDescription": "이력서, 채용 공고, 생성된 콘텐츠를 포함한 모든 데이터를 삭제합니다. 이 작업은 되돌릴 수 없습니다.",
+    "llmConfigurationTitle": "LLM 구성",
+    "providerLabel": "제공업체",
+    "statusCards": {
+      "llm": "LLM",
+      "database": "데이터베이스",
+      "resumes": "이력서",
+      "jobs": "채용 공고",
+      "improvements": "개선 사항",
+      "masterResume": "마스터 이력서"
+    },
+    "statusValues": {
+      "healthy": "정상",
+      "offline": "오프라인",
+      "connected": "연결됨",
+      "configured": "구성됨",
+      "notSet": "설정되지 않음"
+    },
+    "apiKeyMenu": {
+      "buttonLabel": "LLM API",
+      "title": "OpenAI API 키",
+      "description": "호스팅된 OpenAI 모델을 사용하려면 키를 입력하세요.",
+      "savedMessage": "API 키가 저장되었습니다.",
+      "loadError": "API 키를 불러올 수 없습니다",
+      "updateError": "API 키를 업데이트할 수 없습니다"
+    },
+    "setupRequired": {
+      "title": "[ 설정 필요 ]",
+      "description": "> API 키가 구성되지 않았습니다. 이력서 맞춤화를 사용하려면 아래에 LLM 제공업체의 API 키를 추가하세요."
+    },
+    "systemStatus": {
+      "title": "시스템 상태",
+      "refresh": "새로고침",
+      "unableToConnect": "서버에 연결할 수 없습니다",
+      "expectedAt": "예상 주소: {apiUrl}",
+      "lastFetched": {
+        "never": "없음",
+        "justNow": "방금 전",
+        "minutesAgo": "{minutes}분 전",
+        "hoursAgo": "{hours}시간 전"
+      }
+    },
+    "llmConfiguration": {
+      "selectedProvider": "선택됨: {provider}",
+      "modelLabel": "모델",
+      "defaultModel": "기본값: {model}",
+      "apiKeyLabel": "API 키",
+      "apiKeyOptionalForOllama": "(Ollama에서는 선택 사항)",
+      "apiKeyOptional": "(선택 사항)",
+      "apiKeyPlaceholder": "sk-...",
+      "apiKeyNotRequiredPlaceholder": "로컬 모델에는 필요하지 않습니다",
+      "apiKeyOptionalPlaceholder": "서버에 인증이 없다면 비워두세요",
+      "leaveBlankToKeepExistingKey": "기존 키를 유지하려면 비워두세요",
+      "baseUrlLabel": "기본 URL (선택 사항)",
+      "baseUrlPlaceholder": "예: https://api.openai.com/v1",
+      "baseUrlDescription": "프록시/어그리게이터 엔드포인트를 사용하려면 API 기본 URL을 재정의하세요. 제공업체 기본값을 사용하려면 비워두세요.",
+      "ollamaServerUrl": "Ollama 서버 URL",
+      "ollamaServerUrlPlaceholder": "http://localhost:11434",
+      "reasoningEffortLabel": "추론 강도",
+      "reasoningEffortAuto": "자동",
+      "reasoningEffortAutoDesc": "reasoning_effort를 전송하지 않습니다 — 최대 호환성을 위한 기본값",
+      "reasoningEffortMinimal": "최소",
+      "reasoningEffortLow": "낮음",
+      "reasoningEffortMedium": "중간",
+      "reasoningEffortHigh": "높음",
+      "reasoningEffortDescription": "추론 지원 모델(gpt-5 계열, Claude 3.7 이상, DeepSeek R1, OpenAI o1/o3)에만 영향을 줍니다. 지원하지 않는 제공업체에서는 이 값이 자동으로 무시됩니다.",
+      "testConnection": "연결 테스트",
+      "errorPrefix": "오류: {error}",
+      "connectionSuccessful": "연결 성공",
+      "connectionFailed": "연결 실패",
+      "connectionDetails": "제공업체: {provider} | 모델: {model}",
+      "testPromptLabel": "테스트 프롬프트",
+      "modelOutputLabel": "모델 출력",
+      "reasoningContentLabel": "모델 사고 과정",
+      "errorDetailLabel": "오류 세부 정보",
+      "healthErrors": {
+        "api_key_missing": "API 키가 구성되지 않았습니다. 설정에서 키를 추가해 주세요.",
+        "health_check_failed": "상태 확인에 실패했습니다.",
+        "duplicate_v1_path": "상태 확인에 실패했습니다. 기본 URL에 /v1 경로가 중복되어 있을 수 있습니다.",
+        "not_found_404": "상태 확인에 실패했습니다. 404 Not Found - 기본 URL이 제공업체와 일치하는지 확인하세요.",
+        "html_response": "상태 확인에 실패했습니다. 기본 URL이 HTML을 반환했습니다. 콘솔 URL이거나 지원되지 않는 게이트웨이 경로일 수 있습니다."
+      },
+      "healthWarnings": {
+        "empty_content": "상태 확인 시 LLM이 빈 응답을 반환했습니다."
+      }
+    },
+    "contentGeneration": {
+      "title": "콘텐츠 생성",
+      "description": "이력서 맞춤화 시 추가 콘텐츠 생성을 활성화합니다. 활성화하면 맞춤화된 이력서와 함께 이 문서들이 자동으로 생성됩니다.",
+      "coverLetter": {
+        "label": "자기소개서",
+        "description": "이력서와 함께 맞춤화된 자기소개서를 생성합니다"
+      },
+      "outreachMessage": {
+        "label": "콜드 아웃리치 메시지",
+        "description": "링크드인이나 이메일용 네트워킹 메시지를 생성합니다"
+      },
+      "customPromptLabel": "사용자 지정 프롬프트 (선택 사항)",
+      "customPromptHelp": "다음 플레이스홀더(각각 중괄호로 표시)를 포함해야 합니다: job_description, resume_data, output_language. 비워두면 기본 프롬프트를 사용합니다.",
+      "customPromptResetButton": "기본값으로 재설정",
+      "customPromptErrorMissing": "필수 플레이스홀더가 누락되었습니다: {missing}",
+      "interviewPrep": {
+        "label": "면접 준비",
+        "description": "저장된 맞춤화 이력서와 함께 면접 준비 자료를 자동으로 생성합니다"
+      }
+    },
+    "promptSettings": {
+      "title": "프롬프트 설정",
+      "description": "이력서 맞춤화에 사용할 기본 프롬프트를 선택하세요.",
+      "defaultLabel": "기본 맞춤화 프롬프트"
+    },
+    "footer": {
+      "status": {
+        "checking": "확인 중...",
+        "ready": "상태: 준비 완료",
+        "setupRequired": "상태: 설정 필요",
+        "offline": "상태: 오프라인"
+      }
+    },
+    "errors": {
+      "unableToConnectBackend": "서버에 연결할 수 없습니다. 서버가 실행 중인지 확인하세요.",
+      "apiKeyRequired": "선택한 제공업체에는 API 키가 필요합니다.",
+      "unknownProvider": "백엔드에서 알 수 없는 제공업체를 반환했습니다: {provider}",
+      "unableToSaveConfiguration": "구성을 저장할 수 없습니다",
+      "failedToClearApiKeys": "API 키 삭제에 실패했습니다. 다시 시도해 주세요.",
+      "failedToResetDatabase": "데이터베이스 초기화에 실패했습니다. 다시 시도해 주세요."
+    },
+    "apiKeys": {
+      "savedTitle": "저장된 API 키",
+      "deleteAria": "{provider} 키 삭제",
+      "deleteConfirmTitle": "API 키를 삭제하시겠습니까?",
+      "deleteConfirmDescription": "저장된 {provider} API 키를 삭제할까요? 나중에 다시 추가할 수 있습니다."
+    }
+  },
+  "resumeViewer": {
+    "resumeNotFound": "이력서를 찾을 수 없습니다",
+    "loading": "이력서를 불러오는 중...",
+    "useTailorFeature": "맞춤화 기능 사용",
+    "retryProcessing": "처리 다시 시도",
+    "deleteAndStartOver": "삭제 후 다시 시작",
+    "returnToDashboard": "대시보드로 돌아가기",
+    "enhanceResume": "이력서 개선",
+    "downloadResume": "이력서 다운로드",
+    "deletedTitle": "이력서가 삭제되었습니다",
+    "deletedDescriptionMaster": "마스터 이력서가 시스템에서 영구적으로 삭제되었습니다.",
+    "deletedDescriptionRegular": "이력서가 시스템에서 영구적으로 삭제되었습니다.",
+    "deleteFailedTitle": "삭제 실패",
+    "errors": {
+      "processingFailed": "이력서를 읽을 수 없습니다. 처리를 다시 시도하거나 삭제 후 다른 파일을 업로드하세요.",
+      "stillProcessing": "이력서를 아직 처리 중입니다. 잠시 기다린 후 페이지를 새로고침하세요.",
+      "notProcessedYet": "이력서가 아직 처리되지 않았습니다. 맞춤화 기능을 사용해 구조화된 이력서를 생성하세요.",
+      "noDataAvailable": "이용 가능한 이력서 데이터가 없습니다.",
+      "failedToLoad": "이력서 데이터를 불러오지 못했습니다.",
+      "failedToDelete": "이력서 삭제에 실패했습니다. 다시 시도해 주세요."
+    },
+    "titlePlaceholder": "이력서 제목을 입력하세요..."
+  },
+  "preview": {
+    "margins": "여백",
+    "calculating": "계산 중...",
+    "pageBreak": "페이지 나누기",
+    "pageCountSingular": "{count}페이지",
+    "pageCountPlural": "{count}페이지",
+    "zoomIn": "확대",
+    "zoomOut": "축소"
+  },
+  "resume": {
+    "personalInfo": {
+      "name": "성명",
+      "title": "직함",
+      "email": "이메일",
+      "phone": "전화번호",
+      "location": "위치",
+      "website": "웹사이트",
+      "linkedin": "LinkedIn",
+      "github": "GitHub"
+    },
+    "sections": {
+      "personalInfo": "개인 정보",
+      "summary": "요약",
+      "experience": "경력",
+      "education": "학력",
+      "projects": "프로젝트",
+      "skills": "기술 및 수상 내역",
+      "skillsOnly": "기술",
+      "certifications": "교육 및 자격증",
+      "languages": "언어",
+      "awards": "수상 내역",
+      "links": "링크"
+    },
+    "defaults": {
+      "name": "이름"
+    },
+    "additional": {
+      "technicalSkills": "기술 스킬"
+    },
+    "additionalLabels": {
+      "technicalSkills": "기술 스킬:",
+      "languages": "언어:",
+      "certifications": "자격증:",
+      "awards": "수상 내역:"
+    }
+  },
+  "coverLetter": {
+    "title": "자기소개서",
+    "generate": "자기소개서 생성",
+    "regenerate": "다시 생성",
+    "copyToClipboard": "클립보드에 복사",
+    "copied": "복사됨!",
+    "editor": {
+      "placeholder": "자기소개서 생성을 활성화한 상태로 이력서를 맞춤화하면 여기에 자기소개서가 표시됩니다...",
+      "tip": "팁: 좋은 자기소개서는 보통 300~400단어입니다. 필요에 따라 편집해 개인화하세요."
+    },
+    "preview": {
+      "defaultName": "이름",
+      "emptyTitle": "아직 자기소개서 내용이 없습니다.",
+      "emptyDescription": "설정에서 자기소개서 생성을 활성화한 후 이력서를 맞춤화하세요."
+    },
+    "print": {
+      "emptyContent": "이용 가능한 자기소개서 내용이 없습니다."
+    }
+  },
+  "outreach": {
+    "title": "아웃리치 메시지",
+    "generate": "아웃리치 메시지 생성",
+    "regenerate": "다시 생성",
+    "copy": "복사",
+    "copyToClipboard": "클립보드에 복사",
+    "copied": "복사됨!",
+    "editor": {
+      "placeholder": "아웃리치 메시지 생성을 활성화한 상태로 이력서를 맞춤화하면 여기에 콜드 아웃리치 메시지가 표시됩니다...",
+      "tip": "팁: 아웃리치 메시지는 간결하게(100~150단어) 유지하세요. 복사해서 링크드인이나 이메일에 붙여넣으세요."
+    },
+    "preview": {
+      "channels": {
+        "linkedin": "LinkedIn",
+        "email": "이메일"
+      },
+      "howToUseTitle": "사용 방법:",
+      "steps": {
+        "step1": "1. 위 버튼으로 메시지를 복사하세요",
+        "step2": "2. 링크드인이나 이메일 클라이언트를 여세요",
+        "step3": "3. 붙여넣고 필요에 따라 개인화하세요",
+        "step4": "4. 채용 담당자나 인사 담당자에게 보내세요"
+      },
+      "emptyTitle": "아직 아웃리치 메시지가 없습니다.",
+      "emptyDescription": "설정에서 아웃리치 메시지 생성을 활성화한 후 이력서를 맞춤화하세요."
+    }
+  },
+  "errors": {
+    "generic": "문제가 발생했습니다. 다시 시도해 주세요.",
+    "networkError": "네트워크 오류입니다. 연결 상태를 확인해 주세요.",
+    "unauthorized": "계속하려면 로그인해 주세요.",
+    "notFound": "요청한 리소스를 찾을 수 없습니다.",
+    "validationError": "일부 필드에 확인이 필요합니다. 강조 표시된 필드를 확인하고 다시 시도하세요.",
+    "boundary": {
+      "title": "문제가 발생했습니다",
+      "description": "예기치 않은 오류가 발생했습니다. 페이지를 새로고침해 보세요. 계속 발생하면 알려주세요.",
+      "tryAgain": "다시 시도",
+      "reloadPage": "페이지 새로고침"
+    }
+  },
+  "a11y": {
+    "removeItem": "항목 제거",
+    "removeDescription": "이 줄 제거",
+    "removeFile": "파일 제거"
+  },
+  "confirmations": {
+    "deleteResume": "이 이력서를 삭제하시겠습니까?",
+    "deleteResumeDescription": "이력서가 영구적으로 제거됩니다.",
+    "deleteMasterResumeTitle": "마스터 이력서 삭제",
+    "deleteMasterResumeDescription": "마스터 이력서가 영구적으로 제거됩니다.",
+    "deleteResumeFromSystemDescription": "이력서가 영구적으로 제거됩니다.",
+    "deleteResumeConfirmLabel": "이력서 삭제",
+    "keepResumeCancelLabel": "이력서 유지",
+    "discardChanges": "저장하지 않은 변경 사항을 취소하시겠습니까?",
+    "discardChangesDescription": "저장하지 않은 작업 내용이 사라집니다.",
+    "clearApiKeys": "모든 API 키를 삭제하시겠습니까?",
+    "clearApiKeysDescription": "AI 기능을 다시 사용하려면 키를 다시 입력해야 합니다.",
+    "resetDatabase": "모든 것을 초기화하고 처음부터 다시 시작하시겠습니까?",
+    "resetDatabaseDescription": "모든 이력서, 채용 공고, 생성된 문서가 영구적으로 삭제됩니다."
+  },
+  "resumeWizard": {
+    "title": "이력서 마법사",
+    "answerLabel": "답변",
+    "keepAddingPrompt": "무엇을 추가하거나 변경하고 싶으신가요?",
+    "readyHint": "탄탄한 이력서를 만들기에 충분한 정보가 모였습니다 — 준비되면 검토하고 완료하세요.",
+    "sections": {
+      "intro": "시작하기",
+      "contact": "연락처 정보",
+      "summary": "전문 요약",
+      "workExperience": "경력",
+      "internships": "인턴십",
+      "education": "학력",
+      "personalProjects": "프로젝트",
+      "skills": "기술",
+      "review": "검토"
+    },
+    "actions": {
+      "continue": "계속",
+      "skip": "건너뛰기",
+      "back": "뒤로",
+      "review": "검토 및 완료",
+      "create": "마스터 이력서 생성",
+      "keepAdding": "계속 추가",
+      "backToDashboard": "대시보드로 돌아가기"
+    },
+    "preview": {
+      "label": "실시간 초안",
+      "empty": "답변할수록 이력서가 여기에 표시됩니다.",
+      "unnamed": "이름 없는 이력서",
+      "experience": "경력",
+      "education": "학력",
+      "projects": "프로젝트",
+      "skills": "기술"
+    },
+    "errors": {
+      "turnFailed": "마법사가 답변을 저장하지 못했습니다. 다시 시도하세요.",
+      "finalizeFailed": "마법사가 마스터 이력서를 생성하지 못했습니다. 다시 시도하세요."
+    },
+    "entry": {
+      "kicker": "마스터 이력서 설정",
+      "title": "시작 방법을 선택하세요",
+      "description": "기존 문서로 마스터 이력서를 만들거나 AI 안내에 따라 단계별로 작성하세요.",
+      "upload": {
+        "kicker": "기존 파일",
+        "title": "이력서 업로드",
+        "description": "PDF, DOC, DOCX 파일로 시작하면 Resume Matcher가 이를 분석해 마스터 프로필로 만들어 줍니다.",
+        "action": "이력서 업로드"
+      },
+      "wizard": {
+        "kicker": "AI 안내",
+        "title": "AI 마법사로 작성",
+        "description": "핵심 질문에 답하면 마법사가 탄탄한 첫 마스터 이력서 초안을 구성해 줍니다.",
+        "action": "마법사 시작"
+      }
+    }
+  },
+  "tracker": {
+    "scroll": {
+      "prev": "왼쪽으로 스크롤",
+      "next": "오른쪽으로 스크롤",
+      "hint": "더 많은 단계를 보려면 스크롤하세요"
+    },
+    "title": "지원 현황 트래커",
+    "subtitle": "각 맞춤화된 이력서가 지원 파이프라인에서 어느 단계에 있는지 추적하세요.",
+    "addApplication": "지원 추가",
+    "columns": {
+      "saved": "저장됨",
+      "applied": "지원 완료",
+      "no_response": "응답 없음",
+      "response": "응답 받음",
+      "interview": "면접",
+      "accepted": "합격",
+      "rejected": "불합격",
+      "empty": "아직 항목이 없습니다"
+    },
+    "empty": {
+      "title": "아직 지원 내역이 없습니다",
+      "description": "채용 공고에 이력서를 맞춤화하거나 수동으로 추가하여 추적을 시작하세요."
+    },
+    "card": {
+      "companyUnknown": "회사명 미상",
+      "roleUnknown": "직무명 없음",
+      "sharedResume": "공유된 이력서",
+      "selectAria": "지원 선택",
+      "dragAria": "드래그하여 순서 변경"
+    },
+    "modal": {
+      "jobDescription": "채용 공고",
+      "noJobDescription": "등록된 채용 공고가 없습니다.",
+      "notes": "메모",
+      "notesPlaceholder": "이 지원에 대한 메모를 추가하세요…",
+      "saveNotes": "메모 저장",
+      "resumeUnavailable": "지원에 사용한 이력서를 더 이상 사용할 수 없습니다.",
+      "loadFailed": "이 지원 정보를 불러올 수 없습니다.",
+      "editResume": "이력서 편집"
+    },
+    "bulk": {
+      "selected": "{count}개 선택됨",
+      "moveTo": "이동할 위치…",
+      "clear": "지우기",
+      "deleteConfirmTitle": "지원 항목을 삭제하시겠습니까?",
+      "deleteConfirmDescription": "선택한 지원 항목 {count}개를 삭제할까요? 이 작업은 되돌릴 수 없습니다."
+    },
+    "manualAdd": {
+      "title": "지원 추가",
+      "description": "채용 공고를 붙여넣어 지원 내역을 추적하세요.",
+      "resume": "이력서",
+      "untitledResume": "제목 없는 이력서",
+      "jobDescription": "채용 공고",
+      "jobDescriptionPlaceholder": "채용 공고를 여기에 붙여넣으세요…",
+      "company": "회사",
+      "role": "직무",
+      "optional": "선택 사항",
+      "status": "상태",
+      "submit": "추가",
+      "validation": "이력서를 선택하고 채용 공고를 붙여넣으세요.",
+      "failed": "지원 항목을 생성할 수 없습니다."
+    },
+    "errors": {
+      "loadFailed": "지원 내역을 불러올 수 없습니다.",
+      "moveFailed": "지원 항목을 이동할 수 없습니다.",
+      "deleteFailed": "지원 항목을 삭제할 수 없습니다."
+    }
+  },
+  "interviewPrep": {
+    "title": "면접 준비",
+    "regenerate": "다시 생성",
+    "unavailableTitle": "면접 준비를 사용할 수 없음",
+    "loadingContextDescription": "생성 전에 이 맞춤화된 이력서의 채용 공고 맥락을 확인하는 중입니다.",
+    "missingContextDescription": "이 맞춤화된 이력서에는 면접 준비 자료를 생성하는 데 필요한 저장된 채용 공고 맥락이 없습니다. 채용 공고와 함께 이력서를 다시 맞춤화한 후 이 기능을 사용하세요.",
+    "saveRequiredDescription": "면접 준비 자료를 생성하기 전에 이 맞춤화된 이력서를 저장하세요.",
+    "focusArea": "중점 영역",
+    "suggestedAnswerPoints": "답변 포인트 제안",
+    "whyItMatters": "중요한 이유",
+    "preparationSuggestion": "준비 제안",
+    "sections": {
+      "roleFit": "직무 적합도 분석",
+      "resumeQuestions": "이력서 기반 질문",
+      "projectFollowUps": "프로젝트 후속 질문",
+      "skillGaps": "역량 격차",
+      "talkingPoints": "핵심 포인트"
+    }
+  }
+}

--- a/apps/frontend/messages/ko.json
+++ b/apps/frontend/messages/ko.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "설명 항목"
       },
       "actions": {
-        "addPoint": "항목 추가"
+        "addPoint": "항목 추가",
+        "togglePointStyle": "글머리 기호 전환"
       },
       "placeholders": {
         "title": "제목",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "Não foi possível alcançar o servidor. Verifique se ele está rodando.",
       "apiKeyRequired": "Chave de API é necessária para o provedor selecionado.",
+      "baseUrlRequired": "{provider} requer uma URL base.",
       "unknownProvider": "Provedor desconhecido retornado do backend: {provider}",
       "unableToSaveConfiguration": "Não foi possível salvar a configuração",
       "failedToClearApiKeys": "Falha ao limpar chaves de API. Por favor, tente novamente.",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "Pontos de Descrição"
       },
       "actions": {
-        "addPoint": "Adicionar Ponto"
+        "addPoint": "Adicionar Ponto",
+        "togglePointStyle": "Alternar marcador"
       },
       "placeholders": {
         "title": "Título",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -292,7 +292,8 @@
         "descriptionPoints": "描述要点"
       },
       "actions": {
-        "addPoint": "添加要点"
+        "addPoint": "添加要点",
+        "togglePointStyle": "切换项目符号"
       },
       "placeholders": {
         "title": "标题",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -732,6 +732,7 @@
     "errors": {
       "unableToConnectBackend": "无法连接到服务器。请确认服务器正在运行。",
       "apiKeyRequired": "所选提供商需要 API 密钥。",
+      "baseUrlRequired": "{provider} 需要基础 URL。",
       "unknownProvider": "后端返回未知提供商：{provider}",
       "unableToSaveConfiguration": "无法保存配置",
       "failedToClearApiKeys": "清除 API 密钥失败，请重试。",

--- a/apps/frontend/tests/confirm-dialog.test.tsx
+++ b/apps/frontend/tests/confirm-dialog.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+
+vi.mock('@/lib/i18n', () => ({
+  useTranslations: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('ConfirmDialog', () => {
+  it('contains long descriptions within a scrollable flex column', () => {
+    const description = `Download failed: ${'unbroken-error-token-'.repeat(30)}`;
+
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Download failed"
+        description={description}
+        onConfirm={vi.fn()}
+      />
+    );
+
+    const descriptionElement = screen.getByText(description);
+    expect(descriptionElement).toHaveClass(
+      'max-h-60',
+      'overflow-y-auto',
+      'whitespace-pre-wrap',
+      '[overflow-wrap:anywhere]'
+    );
+    expect(descriptionElement.parentElement).toHaveClass('min-w-0', 'flex-1');
+  });
+});

--- a/apps/frontend/tests/description-list.test.tsx
+++ b/apps/frontend/tests/description-list.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DescriptionList } from '@/components/resume/description-list';
+
+describe('DescriptionList', () => {
+  it('renders bullet rows with a marker and plain rows without marker indentation', () => {
+    render(
+      <DescriptionList
+        items={['Core module', 'Built reliable workflows']}
+        styles={['plain', 'bullet']}
+      />
+    );
+
+    const rows = screen.getAllByRole('listitem');
+
+    expect(rows[0]).not.toHaveClass('ml-4');
+    expect(within(rows[0]).queryByText('•')).not.toBeInTheDocument();
+    expect(rows[0]).toHaveTextContent('Core module');
+
+    expect(rows[1]).toHaveClass('ml-4');
+    expect(within(rows[1]).getByText('•')).toBeInTheDocument();
+    expect(rows[1]).toHaveTextContent('Built reliable workflows');
+  });
+});

--- a/apps/frontend/tests/description-styles.test.ts
+++ b/apps/frontend/tests/description-styles.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { alignDescriptionStyles, toggleDescriptionStyle } from '@/lib/utils/description-styles';
+
+describe('description style helpers', () => {
+  it('aligns missing and sparse description styles to bullet defaults', () => {
+    expect(alignDescriptionStyles(['A', 'B', 'C'], undefined)).toEqual([
+      'bullet',
+      'bullet',
+      'bullet',
+    ]);
+    expect(alignDescriptionStyles(['A', 'B', 'C'], [undefined, null, 'plain'])).toEqual([
+      'bullet',
+      'bullet',
+      'plain',
+    ]);
+  });
+
+  it('toggles after aligning styles so old resumes do not create sparse arrays', () => {
+    expect(toggleDescriptionStyle(['A', 'B', 'C'], undefined, 2)).toEqual([
+      'bullet',
+      'bullet',
+      'plain',
+    ]);
+    expect(toggleDescriptionStyle(['A', 'B', 'C'], ['bullet', 'plain'], 1)).toEqual([
+      'bullet',
+      'bullet',
+      'bullet',
+    ]);
+  });
+});

--- a/apps/frontend/tests/i18n-locale-parity.test.ts
+++ b/apps/frontend/tests/i18n-locale-parity.test.ts
@@ -6,6 +6,7 @@ import zh from '@/messages/zh.json';
 import ja from '@/messages/ja.json';
 import pt from '@/messages/pt-BR.json';
 import fr from '@/messages/fr.json';
+import ko from '@/messages/ko.json';
 
 import { getMessages } from '@/lib/i18n/messages';
 import { locales, type Locale } from '@/i18n/config';
@@ -46,7 +47,7 @@ function keyKinds(
 }
 
 const REFERENCE = keyKinds(en);
-const LOCALES: Record<string, unknown> = { es, zh, ja, pt, fr };
+const LOCALES: Record<string, unknown> = { es, zh, ja, pt, fr, ko };
 
 describe('i18n locale parity (guards the next build break)', () => {
   it.each(Object.keys(LOCALES))('%s.json has every en.json key with a matching shape', (name) => {

--- a/docs/agent/llm-integration.md
+++ b/docs/agent/llm-integration.md
@@ -10,6 +10,7 @@ Backend uses LiteLLM to support multiple providers through a unified API:
 |----------|------|-------|
 | **Ollama** | Local | Free, runs on your machine |
 | **OpenAI** | Cloud | GPT-5 Nano, GPT-4o |
+| **Azure AI Foundry** | Cloud | Azure AI Inference / Foundry model endpoints |
 | **Anthropic** | Cloud | Claude Haiku 4.5 |
 | **Google Gemini** | Cloud | Gemini 3 Flash |
 | **OpenRouter** | Cloud | Access to multiple models |
@@ -95,6 +96,8 @@ Users configure their preferred AI provider via:
 
 - Settings page: `/settings`
 - API: `PUT /api/v1/config/llm-api-key`
+
+Azure AI Foundry uses LiteLLM's `azure_ai/` route for generic Azure AI Inference endpoints. Foundry-hosted Azure OpenAI endpoints such as `https://<resource>.services.ai.azure.com/openai/v1/responses` are normalized to the service root and routed through LiteLLM's `azure/` provider automatically. Set `LLM_PROVIDER=azure_foundry`, `LLM_MODEL` to the Foundry model or deployment name, `LLM_API_BASE` to the Azure AI endpoint, and store the Foundry API key in the `azure_foundry` key slot.
 
 ## Health Checks
 


### PR DESCRIPTION
7 contributor PRs from the last month, staged and verified on `dev`.

**Merge with a merge commit — do not squash. Keep the `dev` branch.**

## Features

- **Korean (ko) language support** — @moduvoice (#876). 766 translated strings; parity verified at 901/901 key paths with no missing or extra keys. Registered across i18n config, the message map, the `SupportedLanguage` union, backend `SUPPORTED_LANGUAGES` and `LANGUAGE_NAMES`.
- **Azure AI Foundry provider** — @sahayagodson (#892, via #898). Generic Foundry endpoints route via LiteLLM `azure_ai/`; Foundry-hosted GPT-5 deployments via `azure/gpt5_series/` with `api_version=v1`. Key stored in the existing Fernet-encrypted slot.
- **Plain description points** — @RedMoonnn (#882, via #898). Per-row bullet/plain toggle backed by a `descriptionStyles` array, with a shared `DescriptionList` renderer replacing the hand-rolled `<ul>` in all 7 templates. No DB migration — rides in the existing `processed_data` JSON column.

## Fixes

- **CJK fonts in the Docker image** — @Frankli9986 (#785, fixes #777). Adds `fonts-noto-cjk`; Chinese, Japanese and Korean now render in generated PDFs instead of tofu boxes. Image grows ~60–80 MB.
- **Persist Compact Mode / Contact Icons** — @gingeekrishna (#874, fixes #850). Moves the load into a lazy `useState` initializer, eliminating the race where the save effect overwrote saved settings with defaults on mount.
- **Contain long dialog descriptions** — @luochen211 (#885). Adds `min-w-0` so a long unbroken token wraps instead of blowing out the dialog width.
- **Stabilize DnD context ids** — @RedMoonnn (#881). Explicit `id` on each `DndContext`, removing a hydration mismatch on `/builder`.

## Maintainer changes on top

- Scoped the minimal-effort JSON retry to `azure_foundry`. It had been applied to every provider, silently lowering `reasoning_effort` for OpenAI GPT-5, Anthropic and DeepSeek on any JSON retry. Covered by a regression test verified to fail without the gate.
- Resolved the `fr.json` conflict in favour of the translations already on `dev`, keeping only `settings.errors.baseUrlRequired` from the incoming branch.
- Swiss token compliance: `hover:text-blue-700` → `hover:text-primary` in the point-style toggle across three builder forms.
- Backfilled `ko.json` for both batch-2 PRs, which predated Korean support.

## Verification

Run against `8d4f31c`, whose tree is byte-identical to the gate-tested integration tip:

```
locale parity   ok, 7 locales (en es fr ja ko pt-BR zh)
eslint          clean
prettier        clean
vitest          30 files, 195 tests passed
next build      compiled + TypeScript clean
pytest          510 passed, 1 deselected
```

Manually verified by the maintainer.

46 files changed, +1962 / −264. Contributors: @moduvoice, @sahayagodson, @RedMoonnn, @Frankli9986, @gingeekrishna, @luochen211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMmBLeE1yEETK1xNWqGCTv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Korean language support, Azure AI Foundry provider, and a plain/bullet toggle for resume descriptions. Fixes CJK PDF rendering and several UI stability issues.

- **New Features**
  - Korean (`ko`) locale added for UI and content generation; registered in frontend and backend.
  - Azure AI Foundry provider (`azure_foundry`) with `LLM_API_BASE` support; normalizes Foundry OpenAI endpoints and routes via `azure_ai/`; settings UI enforces base URL when needed; docs and `.env.example` updated.
  - Plain description points: per-row bullet/plain toggle stored in `descriptionStyles`; new shared `DescriptionList` used across all templates; defaults align to description length with no DB migration.

- **Bug Fixes**
  - PDF exports: include `fonts-noto-cjk` to render Chinese/Japanese/Korean text.
  - Settings: persist Compact Mode and Contact Icons by using a lazy `useState` initializer.
  - Dialogs: contain long unbroken text via `min-w-0` and better wrapping.
  - Builder: stabilize `DndContext` `id`s to avoid hydration mismatches.
  - LLM: scope minimal-effort JSON retry to `azure_foundry` only; resolve `fr.json` merge and backfill `ko.json`; use `hover:text-primary` for the point-style toggle.

<sup>Written for commit 8d4f31cc1ddb5cb46d7d5a105feecdd836400a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

