### PR TITLE
Batch 3: resume autosave & draft recovery (#883) + CJK font fallback (#884)

### DIFF
--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -62,6 +62,7 @@ import {
 } from 'lucide-react';
 import { useLanguage } from '@/lib/context/language-context';
 import { useTranslations } from '@/lib/i18n';
+import { RESUME_DRAFT_STORAGE_PREFIX } from '@/lib/utils/resume-draft-storage';
 import type { SupportedLanguage } from '@/lib/api/config';
 import type { Locale } from '@/i18n/config';
 
@@ -595,6 +596,9 @@ export default function SettingsPage() {
       // Clear all related localStorage keys
       localStorage.removeItem('master_resume_id');
       localStorage.removeItem('resume_builder_draft');
+      Object.keys(localStorage)
+        .filter((key) => key.startsWith(RESUME_DRAFT_STORAGE_PREFIX))
+        .forEach((key) => localStorage.removeItem(key));
       localStorage.removeItem('resume_builder_settings');
       localStorage.removeItem('resume_matcher_content_language');
       localStorage.removeItem('resume_matcher_ui_language');

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -16,9 +16,9 @@ const geist = Geist({
 
 const notoSansSC = Noto_Sans_SC({
   variable: '--font-noto-sans-sc',
-  subsets: ['latin'],
-  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
+  weight: ['400', '500', '600', '700'],
   display: 'swap',
+  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -18,7 +18,6 @@ const notoSansSC = Noto_Sans_SC({
   variable: '--font-noto-sans-sc',
   weight: ['400', '500', '600', '700'],
   display: 'swap',
-  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -14,10 +14,17 @@ const geist = Geist({
   display: 'swap',
 });
 
+// CJK fallback for Chinese/Japanese/Korean resume content. Explicit
+// `preload: false` because the CJK unicode-ranges are not preloadable anyway
+// (Google exposes no `chinese-simplified` subset to next/font) and we don't
+// want to ship a large font to users who never render CJK. Turbopack already
+// skips preloading it, but the legacy webpack font path errors on a preloaded
+// font declared without `subsets`, so this keeps both pipelines building.
 const notoSansSC = Noto_Sans_SC({
   variable: '--font-noto-sans-sc',
   weight: ['400', '500', '600', '700'],
   display: 'swap',
+  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -16,6 +16,7 @@ const geist = Geist({
 
 const notoSansSC = Noto_Sans_SC({
   variable: '--font-noto-sans-sc',
+  subsets: ['latin'],
   weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
   display: 'swap',
 });

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Geist, Space_Grotesk } from 'next/font/google';
+import { Geist, Noto_Sans_SC, Space_Grotesk } from 'next/font/google';
 import './(default)/css/globals.css';
 
 const spaceGrotesk = Space_Grotesk({
@@ -14,6 +14,12 @@ const geist = Geist({
   display: 'swap',
 });
 
+const notoSansSC = Noto_Sans_SC({
+  variable: '--font-noto-sans-sc',
+  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
+  display: 'swap',
+});
+
 export const metadata: Metadata = {
   title: 'Resume Matcher',
   description: 'Build your resume with Resume Matcher',
@@ -25,7 +31,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en-US" className="h-full" suppressHydrationWarning>
       <body
-        className={`${geist.variable} ${spaceGrotesk.variable} antialiased bg-background text-ink-soft min-h-full`}
+        className={`${geist.variable} ${spaceGrotesk.variable} ${notoSansSC.variable} antialiased bg-background text-ink-soft min-h-full`}
       >
         {children}
       </body>

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, Suspense, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, Suspense, useCallback, useMemo, useRef } from 'react';
 import Image from 'next/image';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { type ResumeData } from '@/components/dashboard/resume-component';
@@ -53,14 +53,24 @@ import { type TemplateSettings, DEFAULT_TEMPLATE_SETTINGS } from '@/lib/types/te
 import { withLocalizedDefaultSections } from '@/lib/utils/section-helpers';
 import { useLanguage } from '@/lib/context/language-context';
 import { buildResumeFilename, downloadBlobAsFile, openUrlInNewTab } from '@/lib/utils/download';
+import { normalizeResumeForRender, normalizeResumeForSave } from '@/lib/utils/resume-normalization';
+import {
+  buildResumeDraft,
+  getResumeDraftStorageKey,
+  LEGACY_RESUME_DRAFT_STORAGE_KEY,
+  parseResumeDraft,
+  shouldPromptForDraftRestore,
+  type ResumeDraftEnvelope,
+} from '@/lib/utils/resume-draft-storage';
 import type { RegenerateItemInput } from '@/lib/api/enrichment';
 
 type TabId = 'resume' | 'cover-letter' | 'outreach' | 'interview-prep' | 'jd-match';
 type JobContextStatus = 'idle' | 'loading' | 'available' | 'missing';
 
-const STORAGE_KEY = 'resume_builder_draft';
 const SETTINGS_STORAGE_KEY = 'resume_builder_settings';
 const TAB_IDS: TabId[] = ['resume', 'cover-letter', 'outreach', 'interview-prep', 'jd-match'];
+const RESUME_AUTOSAVE_DEBOUNCE_MS = 2500;
+const RESUME_AUTOSAVE_MAX_WAIT_MS = 12000;
 
 type Translate = (key: string, params?: Record<string, string | number>) => string;
 
@@ -92,6 +102,49 @@ const buildInitialData = (t: Translate): ResumeData => ({
   },
 });
 
+type StoredResumeDraft = ResumeDraftEnvelope & { storageKey: string };
+
+const withStorageKey = (
+  draft: ResumeDraftEnvelope | null,
+  storageKey: string
+): StoredResumeDraft | null => {
+  return draft ? { ...draft, storageKey } : null;
+};
+
+const readStoredResumeDraft = (resumeId: string | null): StoredResumeDraft | null => {
+  const scopedKey = getResumeDraftStorageKey(resumeId);
+  const scopedDraft = withStorageKey(
+    parseResumeDraft(localStorage.getItem(scopedKey), resumeId),
+    scopedKey
+  );
+  if (scopedDraft) {
+    return scopedDraft;
+  }
+
+  const legacyDraft = withStorageKey(
+    parseResumeDraft(localStorage.getItem(LEGACY_RESUME_DRAFT_STORAGE_KEY), resumeId),
+    LEGACY_RESUME_DRAFT_STORAGE_KEY
+  );
+
+  return legacyDraft;
+};
+
+const writeStoredResumeDraft = (resumeId: string | null, data: ResumeData): void => {
+  localStorage.setItem(
+    getResumeDraftStorageKey(resumeId),
+    JSON.stringify(buildResumeDraft(resumeId, data))
+  );
+};
+
+const clearStoredResumeDraft = (resumeId: string | null): void => {
+  localStorage.removeItem(getResumeDraftStorageKey(resumeId));
+  localStorage.removeItem(LEGACY_RESUME_DRAFT_STORAGE_KEY);
+};
+
+const clearResumeDraftStorageKey = (storageKey: string): void => {
+  localStorage.removeItem(storageKey);
+};
+
 const ResumeBuilderContent = () => {
   const { t } = useTranslations();
   const { uiLanguage, contentLanguage } = useLanguage();
@@ -122,6 +175,10 @@ const ResumeBuilderContent = () => {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [lastSavedData, setLastSavedData] = useState<ResumeData>(() => initialData);
   const [isSaving, setIsSaving] = useState(false);
+  const [isAutoSaving, setIsAutoSaving] = useState(false);
+  const [autoSaveError, setAutoSaveError] = useState<string | null>(null);
+  const [lastAutoSavedAt, setLastAutoSavedAt] = useState<number | null>(null);
+  const [pendingDraftRestore, setPendingDraftRestore] = useState<StoredResumeDraft | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const [, setLoadingState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
   const [templateSettings, setTemplateSettings] =
@@ -134,12 +191,15 @@ const ResumeBuilderContent = () => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const resumeId = searchParams.get('id');
+  const editVersionRef = useRef(0);
+  const resumeSaveQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const unsyncedSinceRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (resumeId || hasUnsavedChanges || improvedPreview) {
       return;
     }
-    const savedDraft = localStorage.getItem(STORAGE_KEY);
+    const savedDraft = readStoredResumeDraft(null);
     if (savedDraft) {
       return;
     }
@@ -195,6 +255,8 @@ const ResumeBuilderContent = () => {
           setResumeData(data.processed_resume as ResumeData);
           setLastSavedData(data.processed_resume as ResumeData);
           setHasUnsavedChanges(false);
+          editVersionRef.current = 0;
+          unsyncedSinceRef.current = null;
         }
       } catch (error) {
         console.error('Failed to reload resume after applying regenerated changes:', error);
@@ -203,50 +265,57 @@ const ResumeBuilderContent = () => {
       }
     },
     onError: (errorMessage) => {
-      console.error('Error during regeneration or applying regenerated changes:', errorMessage);
-
       if (/network|fetch/i.test(errorMessage) || errorMessage.includes('Failed to fetch')) {
+        console.warn('Network error during regeneration or apply:', errorMessage);
         showNotification(t('builder.regenerate.errors.networkError'), 'danger');
         return;
       }
 
       if (/resume content changed|uniquely matched|please regenerate/i.test(errorMessage)) {
+        console.warn('Regenerated changes were based on a stale resume snapshot:', errorMessage);
         showNotification(t('builder.regenerate.errors.resumeChanged'), 'danger');
         return;
       }
 
       if (/generate/i.test(errorMessage)) {
+        console.warn('Generation failed:', errorMessage);
         showNotification(t('builder.regenerate.errors.generationFailed'), 'danger');
         return;
       }
 
+      console.error('Error during regeneration or applying regenerated changes:', errorMessage);
       showNotification(t('builder.regenerate.errors.applyFailed'), 'danger');
     },
   });
 
-  // Build regenerate items from resume data
+  const canonicalResumeDataForPreview = useMemo(
+    () => normalizeResumeForRender(resumeData),
+    [resumeData]
+  );
+
+  // Build regenerate items from canonical resume data so apply checks match the saved snapshot.
   const experienceItemsForRegenerate: RegenerateItemInput[] = useMemo(() => {
-    return (resumeData.workExperience || []).map((exp, idx) => ({
+    return (canonicalResumeDataForPreview.workExperience || []).map((exp, idx) => ({
       item_id: `exp_${idx}`,
       item_type: 'experience' as const,
       title: exp.title ?? '',
       subtitle: exp.company || undefined,
       current_content: Array.isArray(exp.description) ? exp.description : [],
     }));
-  }, [resumeData.workExperience]);
+  }, [canonicalResumeDataForPreview.workExperience]);
 
   const projectItemsForRegenerate: RegenerateItemInput[] = useMemo(() => {
-    return (resumeData.personalProjects || []).map((proj, idx) => ({
+    return (canonicalResumeDataForPreview.personalProjects || []).map((proj, idx) => ({
       item_id: `proj_${idx}`,
       item_type: 'project' as const,
       title: proj.name ?? '',
       subtitle: proj.role || undefined,
       current_content: Array.isArray(proj.description) ? proj.description : [],
     }));
-  }, [resumeData.personalProjects]);
+  }, [canonicalResumeDataForPreview.personalProjects]);
 
   const skillsItemForRegenerate: RegenerateItemInput | null = useMemo(() => {
-    const skills = resumeData.additional?.technicalSkills;
+    const skills = canonicalResumeDataForPreview.additional?.technicalSkills;
     if (skills && skills.length > 0) {
       return {
         item_id: 'skills',
@@ -256,11 +325,10 @@ const ResumeBuilderContent = () => {
       };
     }
     return null;
-  }, [resumeData.additional?.technicalSkills, t]);
-
+  }, [canonicalResumeDataForPreview.additional?.technicalSkills, t]);
   const localizedResumeDataForPreview = useMemo(
-    () => withLocalizedDefaultSections(resumeData, t),
-    [resumeData, t]
+    () => withLocalizedDefaultSections(canonicalResumeDataForPreview, t),
+    [canonicalResumeDataForPreview, t]
   );
 
   // Load template settings from localStorage on mount
@@ -302,6 +370,7 @@ const ResumeBuilderContent = () => {
   useEffect(() => {
     const loadResumeData = async () => {
       setLoadingState('loading');
+      setPendingDraftRestore(null);
 
       // Priority 1: Fetch from API if ID is in URL (most reliable)
       if (resumeId) {
@@ -322,8 +391,19 @@ const ResumeBuilderContent = () => {
           setInterviewPrepError(null);
           // Prefer processed_resume if available
           if (data.processed_resume) {
-            setResumeData(data.processed_resume as ResumeData);
-            setLastSavedData(data.processed_resume as ResumeData);
+            const serverData = data.processed_resume as ResumeData;
+            const localDraft = readStoredResumeDraft(resumeId);
+            setResumeData(serverData);
+            setLastSavedData(serverData);
+            setHasUnsavedChanges(false);
+            editVersionRef.current = 0;
+            unsyncedSinceRef.current = null;
+            setAutoSaveError(null);
+            if (shouldPromptForDraftRestore(localDraft, serverData)) {
+              setPendingDraftRestore(localDraft);
+            } else {
+              clearStoredResumeDraft(resumeId);
+            }
             setLoadingState('loaded');
             return;
           }
@@ -331,8 +411,19 @@ const ResumeBuilderContent = () => {
           if (data.raw_resume?.content) {
             try {
               const parsed = JSON.parse(data.raw_resume.content);
-              setResumeData(parsed);
-              setLastSavedData(parsed);
+              const serverData = parsed as ResumeData;
+              const localDraft = readStoredResumeDraft(resumeId);
+              setResumeData(serverData);
+              setLastSavedData(serverData);
+              setHasUnsavedChanges(false);
+              editVersionRef.current = 0;
+              unsyncedSinceRef.current = null;
+              setAutoSaveError(null);
+              if (shouldPromptForDraftRestore(localDraft, serverData)) {
+                setPendingDraftRestore(localDraft);
+              } else {
+                clearStoredResumeDraft(resumeId);
+              }
               setLoadingState('loaded');
               return;
             } catch {
@@ -359,24 +450,21 @@ const ResumeBuilderContent = () => {
         setInterviewPrep(improvedInterviewPrep);
         setInterviewPrepError(null);
         // Persist to localStorage as backup
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(improvedPreview));
+        writeStoredResumeDraft(resumeId, improvedPreview);
         setLoadingState('loaded');
         return;
       }
 
       // Priority 3: Restore from localStorage (browser refresh recovery)
-      const savedDraft = localStorage.getItem(STORAGE_KEY);
+      const savedDraft = readStoredResumeDraft(resumeId);
       if (savedDraft) {
-        try {
-          const parsed = JSON.parse(savedDraft);
-          setResumeData(parsed);
-          setLastSavedData(parsed);
-          setHasUnsavedChanges(true); // Mark as unsaved since it's a draft
-          setLoadingState('loaded');
-          return;
-        } catch {
-          localStorage.removeItem(STORAGE_KEY);
-        }
+        setResumeData(savedDraft.data);
+        setLastSavedData(savedDraft.data);
+        setHasUnsavedChanges(true); // Mark as unsaved since it's a draft
+        editVersionRef.current += 1;
+        unsyncedSinceRef.current = Date.now();
+        setLoadingState('loaded');
+        return;
       }
 
       // Fallback: Use initial data
@@ -429,42 +517,172 @@ const ResumeBuilderContent = () => {
     };
   }, [isTailoredResume, resumeId]);
 
-  const handleUpdate = useCallback((newData: ResumeData) => {
-    setResumeData(newData);
-    setHasUnsavedChanges(true);
-    // Auto-save draft to localStorage
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(newData));
-  }, []);
+  const handleUpdate = useCallback(
+    (newData: ResumeData) => {
+      editVersionRef.current += 1;
+      unsyncedSinceRef.current ??= Date.now();
+      setResumeData(newData);
+      setHasUnsavedChanges(true);
+      setAutoSaveError(null);
+      // Auto-save draft to localStorage
+      writeStoredResumeDraft(resumeId, newData);
+    },
+    [resumeId]
+  );
 
   const handleSettingsChange = useCallback((newSettings: TemplateSettings) => {
     setTemplateSettings(newSettings);
   }, []);
+
+  const queueResumeSave = useCallback(
+    (editorData: ResumeData) => {
+      if (!resumeId) {
+        return Promise.reject(new Error('Resume ID is required to save.'));
+      }
+
+      const canonicalPayload = normalizeResumeForSave(editorData);
+      const runSave = resumeSaveQueueRef.current
+        .catch(() => {
+          // Keep the queue alive after a failed save so the next edit can still persist.
+        })
+        .then(() => updateResume(resumeId, canonicalPayload));
+
+      resumeSaveQueueRef.current = runSave.then(
+        () => undefined,
+        () => undefined
+      );
+
+      return runSave.then((response) => ({ response, canonicalPayload }));
+    },
+    [resumeId]
+  );
+
+  useEffect(() => {
+    if (
+      !resumeId ||
+      !hasUnsavedChanges ||
+      isSaving ||
+      isAutoSaving ||
+      autoSaveError ||
+      regenerateWizard.step !== 'idle'
+    ) {
+      return;
+    }
+
+    const versionAtSchedule = editVersionRef.current;
+    const editorSnapshot = resumeData;
+    const elapsedSinceFirstEdit = unsyncedSinceRef.current
+      ? Date.now() - unsyncedSinceRef.current
+      : 0;
+    const saveDelay = Math.max(
+      0,
+      Math.min(RESUME_AUTOSAVE_DEBOUNCE_MS, RESUME_AUTOSAVE_MAX_WAIT_MS - elapsedSinceFirstEdit)
+    );
+    const timerId = window.setTimeout(async () => {
+      setIsAutoSaving(true);
+      try {
+        const { canonicalPayload } = await queueResumeSave(editorSnapshot);
+        setLastSavedData(canonicalPayload);
+        setLastAutoSavedAt(Date.now());
+        setAutoSaveError(null);
+
+        if (editVersionRef.current === versionAtSchedule) {
+          setHasUnsavedChanges(false);
+          editVersionRef.current = 0;
+          unsyncedSinceRef.current = null;
+          clearStoredResumeDraft(resumeId);
+        }
+      } catch (error) {
+        console.error('Failed to auto-save resume:', error);
+        setAutoSaveError(t('builder.alerts.autoSaveFailed'));
+      } finally {
+        setIsAutoSaving(false);
+      }
+    }, saveDelay);
+
+    return () => window.clearTimeout(timerId);
+  }, [
+    autoSaveError,
+    hasUnsavedChanges,
+    isAutoSaving,
+    isSaving,
+    queueResumeSave,
+    regenerateWizard.step,
+    resumeData,
+    resumeId,
+    t,
+  ]);
+
+  const flushResumeChanges = useCallback(
+    async (showErrorDialog = true): Promise<boolean> => {
+      if (!resumeId || (!hasUnsavedChanges && !autoSaveError)) {
+        return true;
+      }
+
+      try {
+        setIsSaving(true);
+        const editorSnapshot = resumeData;
+        const { canonicalPayload } = await queueResumeSave(editorSnapshot);
+        setLastSavedData(canonicalPayload);
+        setHasUnsavedChanges(false);
+        editVersionRef.current = 0;
+        unsyncedSinceRef.current = null;
+        setAutoSaveError(null);
+        setLastAutoSavedAt(Date.now());
+        clearStoredResumeDraft(resumeId);
+        return true;
+      } catch (error) {
+        console.error('Failed to save resume:', error);
+        setAutoSaveError(t('builder.alerts.autoSaveFailed'));
+        if (showErrorDialog) {
+          showNotification(t('builder.alerts.saveFailed'), 'danger');
+        }
+        return false;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [autoSaveError, hasUnsavedChanges, queueResumeSave, resumeData, resumeId, showNotification, t]
+  );
 
   const handleSave = async () => {
     if (!resumeId) {
       showNotification(t('builder.alerts.saveNotAvailable'), 'warning');
       return;
     }
-    try {
-      setIsSaving(true);
-      const updated = await updateResume(resumeId, resumeData);
-      const nextData = (updated.processed_resume || resumeData) as ResumeData;
-      setResumeData(nextData);
-      setLastSavedData(nextData);
-      setHasUnsavedChanges(false);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(nextData));
-    } catch (error) {
-      console.error('Failed to save resume:', error);
-      showNotification(t('builder.alerts.saveFailed'), 'danger');
-    } finally {
-      setIsSaving(false);
-    }
+    await flushResumeChanges(true);
   };
 
   const handleReset = () => {
     setResumeData(lastSavedData);
     setHasUnsavedChanges(false);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(lastSavedData));
+    editVersionRef.current = 0;
+    unsyncedSinceRef.current = null;
+    setAutoSaveError(null);
+    clearStoredResumeDraft(resumeId);
+  };
+
+  const handleRestoreLocalDraft = () => {
+    if (!pendingDraftRestore) return;
+    editVersionRef.current += 1;
+    unsyncedSinceRef.current = Date.now();
+    setResumeData(pendingDraftRestore.data);
+    setHasUnsavedChanges(true);
+    setAutoSaveError(null);
+    writeStoredResumeDraft(resumeId, pendingDraftRestore.data);
+    if (pendingDraftRestore.storageKey !== getResumeDraftStorageKey(resumeId)) {
+      clearResumeDraftStorageKey(pendingDraftRestore.storageKey);
+    }
+    setPendingDraftRestore(null);
+  };
+
+  const handleKeepServerDraft = () => {
+    if (pendingDraftRestore) {
+      clearResumeDraftStorageKey(pendingDraftRestore.storageKey);
+    } else {
+      clearStoredResumeDraft(resumeId);
+    }
+    setPendingDraftRestore(null);
   };
 
   const getCompanyFromTitle = (title: string | null | undefined): string | null => {
@@ -473,9 +691,27 @@ const ResumeBuilderContent = () => {
     return atIdx !== -1 ? title.substring(atIdx + 3).trim() : null;
   };
 
+  const handleBackToDashboard = async () => {
+    const didSave = await flushResumeChanges(true);
+    if (didSave) {
+      router.push('/dashboard');
+    }
+  };
+
+  const handleStartRegenerate = async () => {
+    const didSave = await flushResumeChanges(true);
+    if (didSave) {
+      regenerateWizard.startRegenerate();
+    }
+  };
+
   const handleDownload = async () => {
     if (!resumeId) {
       showNotification(t('builder.alerts.downloadNotAvailable'), 'warning');
+      return;
+    }
+    const didSave = await flushResumeChanges(true);
+    if (!didSave) {
       return;
     }
     try {
@@ -708,6 +944,29 @@ const ResumeBuilderContent = () => {
     }
   };
 
+  const resumeSaveStatus = (() => {
+    if (isSaving || isAutoSaving) {
+      return { label: t('builder.autoSave.saving'), tone: 'blue' as const };
+    }
+    if (autoSaveError) {
+      return { label: autoSaveError, tone: 'red' as const };
+    }
+    if (hasUnsavedChanges) {
+      return { label: t('builder.autoSave.localDraft'), tone: 'amber' as const };
+    }
+    if (resumeId && lastAutoSavedAt) {
+      return { label: t('builder.autoSave.saved'), tone: 'green' as const };
+    }
+    return null;
+  })();
+
+  const resumeSaveStatusStyles = {
+    amber: 'text-amber-600 bg-amber-50 border-amber-200',
+    blue: 'text-blue-700 bg-blue-50 border-blue-200',
+    green: 'text-green-700 bg-green-50 border-green-200',
+    red: 'text-red-700 bg-red-50 border-red-200',
+  };
+
   return (
     <div className="h-screen w-full bg-background flex justify-center items-center p-4 md:p-8">
       {/* Main Container */}
@@ -717,11 +976,7 @@ const ResumeBuilderContent = () => {
           {/* Top Row: Back button and Actions */}
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
             <div>
-              <Button
-                variant="link"
-                onClick={() => router.push('/dashboard')}
-                className="mb-2 -ml-1"
-              >
+              <Button variant="link" onClick={handleBackToDashboard} className="mb-2 -ml-1">
                 <ArrowLeft className="w-4 h-4" />
                 {t('nav.backToDashboard')}
               </Button>
@@ -733,10 +988,12 @@ const ResumeBuilderContent = () => {
                   {'// '}
                   {resumeId ? t('builder.editMode') : t('builder.createAndPreview')}
                 </p>
-                {hasUnsavedChanges && (
-                  <span className="flex items-center gap-1 text-xs font-mono text-amber-600 bg-amber-50 px-2 py-1 border border-amber-200">
+                {resumeSaveStatus && (
+                  <span
+                    className={`flex items-center gap-1 text-xs font-mono px-2 py-1 border ${resumeSaveStatusStyles[resumeSaveStatus.tone]}`}
+                  >
                     <AlertTriangle className="w-3 h-3" />
-                    {t('builder.unsavedDraft')}
+                    {resumeSaveStatus.label}
                   </span>
                 )}
               </div>
@@ -749,8 +1006,8 @@ const ResumeBuilderContent = () => {
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => regenerateWizard.startRegenerate()}
-                    disabled={!resumeId}
+                    onClick={handleStartRegenerate}
+                    disabled={!resumeId || isSaving}
                   >
                     <Sparkles className="w-4 h-4" />
                     {t('builder.regenerate.buttonLabel')}
@@ -766,7 +1023,13 @@ const ResumeBuilderContent = () => {
                   </Button>
                   <Button size="sm" onClick={handleSave} disabled={!resumeId || isSaving}>
                     <Save className="w-4 h-4" />
-                    {isSaving ? t('common.saving') : t('common.save')}
+                    {isSaving
+                      ? t('common.saving')
+                      : autoSaveError
+                        ? t('builder.autoSave.retrySave')
+                        : hasUnsavedChanges
+                          ? t('builder.autoSave.saveNow')
+                          : t('builder.autoSave.savedButton')}
                   </Button>
                   <Button
                     variant="success"
@@ -1129,6 +1392,20 @@ const ResumeBuilderContent = () => {
         cancelLabel={t('common.cancel')}
         variant="warning"
         onConfirm={handleConfirmRegenerate}
+      />
+
+      {/* Local Draft Recovery Dialog */}
+      <ConfirmDialog
+        open={pendingDraftRestore !== null}
+        onOpenChange={() => undefined}
+        title={t('builder.draftRecovery.title')}
+        description={t('builder.draftRecovery.description')}
+        confirmLabel={t('builder.draftRecovery.restoreDraft')}
+        cancelLabel={t('builder.draftRecovery.useServer')}
+        variant="warning"
+        closeOnConfirm={false}
+        onConfirm={handleRestoreLocalDraft}
+        onCancel={handleKeepServerDraft}
       />
 
       {/* Notification Dialog (replaces native alert()) */}

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -181,6 +181,7 @@ const ResumeBuilderContent = () => {
   const [autoSaveError, setAutoSaveError] = useState<string | null>(null);
   const [lastAutoSavedAt, setLastAutoSavedAt] = useState<number | null>(null);
   const [pendingDraftRestore, setPendingDraftRestore] = useState<StoredResumeDraft | null>(null);
+  const [showLeaveWithLocalDraftDialog, setShowLeaveWithLocalDraftDialog] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [, setLoadingState] = useState<'idle' | 'loading' | 'loaded' | 'error'>('idle');
   const [templateSettings, setTemplateSettings] =
@@ -703,7 +704,14 @@ const ResumeBuilderContent = () => {
     const didSave = await flushResumeChanges(true);
     if (didSave) {
       router.push('/dashboard');
+    } else {
+      setShowLeaveWithLocalDraftDialog(true);
     }
+  };
+
+  const handleLeaveWithLocalDraft = () => {
+    setShowLeaveWithLocalDraftDialog(false);
+    router.push('/dashboard');
   };
 
   const handleStartRegenerate = async () => {
@@ -1415,6 +1423,18 @@ const ResumeBuilderContent = () => {
         closeOnConfirm={false}
         onConfirm={handleRestoreLocalDraft}
         onCancel={handleKeepServerDraft}
+      />
+
+      {/* Leave With Local Draft Dialog */}
+      <ConfirmDialog
+        open={showLeaveWithLocalDraftDialog}
+        onOpenChange={setShowLeaveWithLocalDraftDialog}
+        title={t('builder.leaveWithLocalDraft.title')}
+        description={t('builder.leaveWithLocalDraft.description')}
+        confirmLabel={t('builder.leaveWithLocalDraft.leave')}
+        cancelLabel={t('builder.leaveWithLocalDraft.stay')}
+        variant="warning"
+        onConfirm={handleLeaveWithLocalDraft}
       />
 
       {/* Notification Dialog (replaces native alert()) */}

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -582,8 +582,11 @@ const ResumeBuilderContent = () => {
     const timerId = window.setTimeout(async () => {
       setIsAutoSaving(true);
       try {
-        const { canonicalPayload } = await queueResumeSave(editorSnapshot);
-        setLastSavedData(canonicalPayload);
+        const { response, canonicalPayload } = await queueResumeSave(editorSnapshot);
+        // Prefer the server's copy: it may rewrite the payload (e.g. aligning
+        // descriptionStyles), and comparing a stale client payload against the
+        // server state would surface a spurious draft-recovery prompt on reload.
+        setLastSavedData((response?.processed_resume as ResumeData) ?? canonicalPayload);
         setLastAutoSavedAt(Date.now());
         setAutoSaveError(null);
 
@@ -624,8 +627,8 @@ const ResumeBuilderContent = () => {
         setIsSaving(true);
         const versionAtFlush = editVersionRef.current;
         const editorSnapshot = resumeData;
-        const { canonicalPayload } = await queueResumeSave(editorSnapshot);
-        setLastSavedData(canonicalPayload);
+        const { response, canonicalPayload } = await queueResumeSave(editorSnapshot);
+        setLastSavedData((response?.processed_resume as ResumeData) ?? canonicalPayload);
         setAutoSaveError(null);
 
         if (editVersionRef.current === versionAtFlush) {

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -122,7 +122,9 @@ const readStoredResumeDraft = (resumeId: string | null): StoredResumeDraft | nul
   }
 
   const legacyDraft = withStorageKey(
-    parseResumeDraft(localStorage.getItem(LEGACY_RESUME_DRAFT_STORAGE_KEY), resumeId),
+    parseResumeDraft(localStorage.getItem(LEGACY_RESUME_DRAFT_STORAGE_KEY), resumeId, Date.now(), {
+      allowLegacyPlainData: !resumeId,
+    }),
     LEGACY_RESUME_DRAFT_STORAGE_KEY
   );
 
@@ -621,16 +623,22 @@ const ResumeBuilderContent = () => {
 
       try {
         setIsSaving(true);
+        const versionAtFlush = editVersionRef.current;
         const editorSnapshot = resumeData;
         const { canonicalPayload } = await queueResumeSave(editorSnapshot);
         setLastSavedData(canonicalPayload);
-        setHasUnsavedChanges(false);
-        editVersionRef.current = 0;
-        unsyncedSinceRef.current = null;
         setAutoSaveError(null);
-        setLastAutoSavedAt(Date.now());
-        clearStoredResumeDraft(resumeId);
-        return true;
+
+        if (editVersionRef.current === versionAtFlush) {
+          setHasUnsavedChanges(false);
+          editVersionRef.current = 0;
+          unsyncedSinceRef.current = null;
+          setLastAutoSavedAt(Date.now());
+          clearStoredResumeDraft(resumeId);
+          return true;
+        }
+
+        return false;
       } catch (error) {
         console.error('Failed to save resume:', error);
         setAutoSaveError(t('builder.alerts.autoSaveFailed'));
@@ -966,6 +974,7 @@ const ResumeBuilderContent = () => {
     green: 'text-green-700 bg-green-50 border-green-200',
     red: 'text-red-700 bg-red-50 border-red-200',
   };
+  const ResumeSaveStatusIcon = resumeSaveStatus?.tone === 'green' ? Check : AlertTriangle;
 
   return (
     <div className="h-screen w-full bg-background flex justify-center items-center p-4 md:p-8">
@@ -992,7 +1001,7 @@ const ResumeBuilderContent = () => {
                   <span
                     className={`flex items-center gap-1 text-xs font-mono px-2 py-1 border ${resumeSaveStatusStyles[resumeSaveStatus.tone]}`}
                   >
-                    <AlertTriangle className="w-3 h-3" />
+                    <ResumeSaveStatusIcon className="w-3 h-3" />
                     {resumeSaveStatus.label}
                   </span>
                 )}

--- a/apps/frontend/lib/types/template-settings.ts
+++ b/apps/frontend/lib/types/template-settings.ts
@@ -130,16 +130,16 @@ export const SECTION_HEADER_SCALE_MAP: Record<SpacingLevel, number> = {
 
 // Header font family mapping
 export const HEADER_FONT_MAP: Record<HeaderFontFamily, string> = {
-  serif: 'Georgia, var(--font-noto-sans-sc), ui-serif, Cambria, "Times New Roman", Times, serif',
+  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", var(--font-noto-sans-sc), Times, serif',
   'sans-serif':
-    'var(--font-noto-sans-sc), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
+    'ui-sans-serif, system-ui, var(--font-noto-sans-sc), sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 
 export const BODY_FONT_MAP: Record<BodyFontFamily, string> = {
-  serif: 'Georgia, var(--font-noto-sans-sc), ui-serif, Cambria, "Times New Roman", Times, serif',
+  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", var(--font-noto-sans-sc), Times, serif',
   'sans-serif':
-    'var(--font-noto-sans-sc), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
+    'ui-sans-serif, system-ui, var(--font-noto-sans-sc), sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 

--- a/apps/frontend/lib/types/template-settings.ts
+++ b/apps/frontend/lib/types/template-settings.ts
@@ -133,14 +133,14 @@ export const HEADER_FONT_MAP: Record<HeaderFontFamily, string> = {
   serif: 'ui-serif, Georgia, Cambria, "Times New Roman", var(--font-noto-sans-sc), Times, serif',
   'sans-serif':
     'ui-sans-serif, system-ui, var(--font-noto-sans-sc), sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
-  mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+  mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, var(--font-noto-sans-sc), monospace',
 };
 
 export const BODY_FONT_MAP: Record<BodyFontFamily, string> = {
   serif: 'ui-serif, Georgia, Cambria, "Times New Roman", var(--font-noto-sans-sc), Times, serif',
   'sans-serif':
     'ui-sans-serif, system-ui, var(--font-noto-sans-sc), sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
-  mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+  mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, var(--font-noto-sans-sc), monospace',
 };
 
 /**

--- a/apps/frontend/lib/types/template-settings.ts
+++ b/apps/frontend/lib/types/template-settings.ts
@@ -130,14 +130,16 @@ export const SECTION_HEADER_SCALE_MAP: Record<SpacingLevel, number> = {
 
 // Header font family mapping
 export const HEADER_FONT_MAP: Record<HeaderFontFamily, string> = {
-  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
-  'sans-serif': 'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
+  serif: 'Georgia, var(--font-noto-sans-sc), ui-serif, Cambria, "Times New Roman", Times, serif',
+  'sans-serif':
+    'var(--font-noto-sans-sc), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 
 export const BODY_FONT_MAP: Record<BodyFontFamily, string> = {
-  serif: 'ui-serif, Georgia, Cambria, "Times New Roman", Times, serif',
-  'sans-serif': 'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
+  serif: 'Georgia, var(--font-noto-sans-sc), ui-serif, Cambria, "Times New Roman", Times, serif',
+  'sans-serif':
+    'var(--font-noto-sans-sc), ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
   mono: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
 };
 

--- a/apps/frontend/lib/utils/resume-draft-storage.ts
+++ b/apps/frontend/lib/utils/resume-draft-storage.ts
@@ -1,0 +1,100 @@
+import type { ResumeData } from '@/components/dashboard/resume-component';
+
+export const LEGACY_RESUME_DRAFT_STORAGE_KEY = 'resume_builder_draft';
+export const RESUME_DRAFT_STORAGE_PREFIX = `${LEGACY_RESUME_DRAFT_STORAGE_KEY}:`;
+const NEW_RESUME_DRAFT_ID = 'new';
+
+export interface ResumeDraftEnvelope {
+  resumeId: string | null;
+  updatedAt: number;
+  data: ResumeData;
+}
+
+export function getResumeDraftStorageKey(resumeId: string | null | undefined): string {
+  return `${RESUME_DRAFT_STORAGE_PREFIX}${resumeId || NEW_RESUME_DRAFT_ID}`;
+}
+
+export function buildResumeDraft(
+  resumeId: string | null | undefined,
+  data: ResumeData,
+  updatedAt = Date.now()
+): ResumeDraftEnvelope {
+  return {
+    resumeId: resumeId || null,
+    updatedAt,
+    data,
+  };
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return !Array.isArray(value);
+}
+
+function isResumeDataShape(value: unknown): value is ResumeData {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  return (
+    isObjectRecord(value.personalInfo) &&
+    'workExperience' in value &&
+    'education' in value &&
+    'personalProjects' in value &&
+    isObjectRecord(value.additional)
+  );
+}
+
+function isResumeDraftEnvelope(value: unknown): value is ResumeDraftEnvelope {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  return (
+    'data' in value &&
+    'updatedAt' in value &&
+    typeof value.updatedAt === 'number' &&
+    isResumeDataShape(value.data)
+  );
+}
+
+export function parseResumeDraft(
+  rawDraft: string | null,
+  resumeId: string | null | undefined,
+  fallbackUpdatedAt = Date.now()
+): ResumeDraftEnvelope | null {
+  if (!rawDraft) return null;
+
+  try {
+    const parsed = JSON.parse(rawDraft) as unknown;
+    if (isResumeDraftEnvelope(parsed)) {
+      if ((parsed.resumeId || null) !== (resumeId || null)) {
+        return null;
+      }
+
+      return parsed;
+    }
+
+    if (!isResumeDataShape(parsed)) {
+      return null;
+    }
+
+    return buildResumeDraft(resumeId, parsed as ResumeData, fallbackUpdatedAt);
+  } catch {
+    return null;
+  }
+}
+
+export function isSameResumeData(left: ResumeData, right: ResumeData): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function shouldPromptForDraftRestore(
+  draft: ResumeDraftEnvelope | null,
+  serverData: ResumeData
+): boolean {
+  return Boolean(draft && !isSameResumeData(draft.data, serverData));
+}

--- a/apps/frontend/lib/utils/resume-draft-storage.ts
+++ b/apps/frontend/lib/utils/resume-draft-storage.ts
@@ -10,6 +10,10 @@ export interface ResumeDraftEnvelope {
   data: ResumeData;
 }
 
+interface ParseResumeDraftOptions {
+  allowLegacyPlainData?: boolean;
+}
+
 export function getResumeDraftStorageKey(resumeId: string | null | undefined): string {
   return `${RESUME_DRAFT_STORAGE_PREFIX}${resumeId || NEW_RESUME_DRAFT_ID}`;
 }
@@ -41,9 +45,9 @@ function isResumeDataShape(value: unknown): value is ResumeData {
 
   return (
     isObjectRecord(value.personalInfo) &&
-    'workExperience' in value &&
-    'education' in value &&
-    'personalProjects' in value &&
+    Array.isArray(value.workExperience) &&
+    Array.isArray(value.education) &&
+    Array.isArray(value.personalProjects) &&
     isObjectRecord(value.additional)
   );
 }
@@ -64,7 +68,8 @@ function isResumeDraftEnvelope(value: unknown): value is ResumeDraftEnvelope {
 export function parseResumeDraft(
   rawDraft: string | null,
   resumeId: string | null | undefined,
-  fallbackUpdatedAt = Date.now()
+  fallbackUpdatedAt = Date.now(),
+  options: ParseResumeDraftOptions = {}
 ): ResumeDraftEnvelope | null {
   if (!rawDraft) return null;
 
@@ -78,7 +83,7 @@ export function parseResumeDraft(
       return parsed;
     }
 
-    if (!isResumeDataShape(parsed)) {
+    if (options.allowLegacyPlainData === false || !isResumeDataShape(parsed)) {
       return null;
     }
 

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -1,0 +1,122 @@
+import type {
+  CustomSection,
+  CustomSectionItem,
+  Experience,
+  Project,
+  ResumeData,
+} from '@/components/dashboard/resume-component';
+
+type DescribedItem = {
+  description?: string[];
+};
+
+const isMeaningfulText = (value: unknown): value is string => {
+  return typeof value === 'string' && value.trim().length > 0;
+};
+
+const normalizeStringList = (items?: string[]): string[] | undefined => {
+  if (!items) return items;
+  return items.map((item) => item.trim()).filter(Boolean);
+};
+
+const normalizeDescriptionFields = <T extends DescribedItem>(item: T): T => {
+  const descriptions = item.description || [];
+  const nextDescriptions: string[] = [];
+
+  descriptions.forEach((description) => {
+    if (!isMeaningfulText(description)) {
+      return;
+    }
+
+    nextDescriptions.push(description.trim());
+  });
+
+  return {
+    ...item,
+    description: nextDescriptions,
+  };
+};
+
+const hasExperienceContent = (item: Experience): boolean => {
+  return Boolean(
+    item.title?.trim() ||
+    item.company?.trim() ||
+    item.location?.trim() ||
+    item.years?.trim() ||
+    item.description?.length
+  );
+};
+
+const hasProjectContent = (item: Project): boolean => {
+  return Boolean(
+    item.name?.trim() ||
+    item.role?.trim() ||
+    item.years?.trim() ||
+    item.github?.trim() ||
+    item.website?.trim() ||
+    item.description?.length
+  );
+};
+
+const hasCustomItemContent = (item: CustomSectionItem): boolean => {
+  return Boolean(
+    item.title?.trim() ||
+    item.subtitle?.trim() ||
+    item.location?.trim() ||
+    item.years?.trim() ||
+    item.description?.length
+  );
+};
+
+const normalizeCustomSection = (section: CustomSection): CustomSection => {
+  if (section.sectionType === 'itemList') {
+    return {
+      ...section,
+      items: (section.items || []).map(normalizeDescriptionFields).filter(hasCustomItemContent),
+    };
+  }
+
+  if (section.sectionType === 'stringList') {
+    return {
+      ...section,
+      strings: normalizeStringList(section.strings),
+    };
+  }
+
+  return section;
+};
+
+export const normalizeResumeForSave = (resume: ResumeData): ResumeData => {
+  const customSections = resume.customSections
+    ? Object.fromEntries(
+        Object.entries(resume.customSections).map(([key, section]) => [
+          key,
+          normalizeCustomSection(section),
+        ])
+      )
+    : resume.customSections;
+
+  return {
+    ...resume,
+    workExperience: (resume.workExperience || [])
+      .map(normalizeDescriptionFields)
+      .filter(hasExperienceContent),
+    personalProjects: (resume.personalProjects || [])
+      .map(normalizeDescriptionFields)
+      .filter(hasProjectContent),
+    additional: resume.additional
+      ? {
+          ...resume.additional,
+          technicalSkills: normalizeStringList(resume.additional.technicalSkills),
+          languages: normalizeStringList(resume.additional.languages),
+          certificationsTraining: normalizeStringList(resume.additional.certificationsTraining),
+          awards: normalizeStringList(resume.additional.awards),
+        }
+      : resume.additional,
+    customSections,
+  };
+};
+
+export const normalizeResumeForRender = (resume: ResumeData): ResumeData => {
+  return normalizeResumeForSave(resume);
+};

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -8,6 +8,7 @@ import type {
 
 type DescribedItem = {
   description?: unknown;
+  descriptionStyles?: unknown;
 };
 
 const isMeaningfulText = (value: unknown): value is string => {
@@ -22,19 +23,28 @@ const normalizeStringList = (items?: string[]): string[] | undefined => {
 
 const normalizeDescriptionFields = <T extends DescribedItem>(item: T): T => {
   const descriptions = Array.isArray(item.description) ? item.description : [];
+  // descriptionStyles is positional — styles[i] belongs to description[i]. It
+  // must be filtered in lockstep, or dropping a blank description silently
+  // shifts every later point's bullet/plain setting onto its neighbour.
+  const styles = Array.isArray(item.descriptionStyles) ? item.descriptionStyles : undefined;
   const nextDescriptions: string[] = [];
+  const nextStyles: unknown[] = [];
 
-  descriptions.forEach((description) => {
+  descriptions.forEach((description, index) => {
     if (!isMeaningfulText(description)) {
       return;
     }
 
     nextDescriptions.push(description.trim());
+    if (styles) {
+      nextStyles.push(styles[index] === 'plain' ? 'plain' : 'bullet');
+    }
   });
 
   return {
     ...item,
     description: nextDescriptions,
+    ...(styles ? { descriptionStyles: nextStyles } : {}),
   };
 };
 

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/components/dashboard/resume-component';
 
 type DescribedItem = {
-  description?: string[];
+  description?: unknown;
 };
 
 const isMeaningfulText = (value: unknown): value is string => {
@@ -16,11 +16,12 @@ const isMeaningfulText = (value: unknown): value is string => {
 
 const normalizeStringList = (items?: string[]): string[] | undefined => {
   if (!items) return items;
-  return items.map((item) => item.trim()).filter(Boolean);
+  if (!Array.isArray(items)) return [];
+  return items.filter(isMeaningfulText).map((item) => item.trim());
 };
 
 const normalizeDescriptionFields = <T extends DescribedItem>(item: T): T => {
-  const descriptions = item.description || [];
+  const descriptions = Array.isArray(item.description) ? item.description : [];
   const nextDescriptions: string[] = [];
 
   descriptions.forEach((description) => {

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -107,6 +107,20 @@
     "previewMode": "Preview Mode",
     "createAndPreview": "Create & Preview",
     "unsavedDraft": "Unsaved Draft",
+    "autoSave": {
+      "saving": "Syncing...",
+      "saved": "All changes saved",
+      "localDraft": "Draft saved locally",
+      "saveNow": "Save now",
+      "retrySave": "Retry save",
+      "savedButton": "Saved"
+    },
+    "draftRecovery": {
+      "title": "Restore Local Draft?",
+      "description": "A local browser draft is different from the saved server copy. Restore it to continue editing, or use the server copy and discard the local draft.",
+      "restoreDraft": "Restore Draft",
+      "useServer": "Use Server Copy"
+    },
     "personalInfo": "Personal Information",
     "summary": "Summary",
     "experience": "Experience",
@@ -453,6 +467,7 @@
     "alerts": {
       "saveNotAvailable": "Save is only available when editing an existing resume.",
       "saveFailed": "Failed to save resume. Please try again.",
+      "autoSaveFailed": "Couldn't sync. Draft is safe locally.",
       "coverLetterSaveSuccess": "Cover letter saved",
       "outreachSaveSuccess": "Outreach message saved",
       "downloadSuccess": "Resume downloaded",

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -121,6 +121,12 @@
       "restoreDraft": "Restore Draft",
       "useServer": "Use Server Copy"
     },
+    "leaveWithLocalDraft": {
+      "title": "Leave Without Syncing?",
+      "description": "The latest edits could not be synced to the server yet. A local browser draft is still saved, but it may not be available from another browser or device.",
+      "leave": "Leave Dashboard",
+      "stay": "Keep Editing"
+    },
     "personalInfo": "Personal Information",
     "summary": "Summary",
     "experience": "Experience",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -121,6 +121,12 @@
       "restoreDraft": "Restaurar borrador",
       "useServer": "Usar copia del servidor"
     },
+    "leaveWithLocalDraft": {
+      "title": "¿Salir sin sincronizar?",
+      "description": "Los últimos cambios aún no pudieron sincronizarse con el servidor. El borrador local sigue guardado en este navegador, pero puede no estar disponible desde otro navegador o dispositivo.",
+      "leave": "Ir al panel",
+      "stay": "Seguir editando"
+    },
     "personalInfo": "Información Personal",
     "summary": "Resumen",
     "experience": "Experiencia",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -107,6 +107,20 @@
     "previewMode": "Modo Vista Previa",
     "createAndPreview": "Crear y previsualizar",
     "unsavedDraft": "Borrador sin guardar",
+    "autoSave": {
+      "saving": "Sincronizando...",
+      "saved": "Todos los cambios guardados",
+      "localDraft": "Borrador guardado localmente",
+      "saveNow": "Guardar ahora",
+      "retrySave": "Reintentar guardado",
+      "savedButton": "Guardado"
+    },
+    "draftRecovery": {
+      "title": "¿Restaurar borrador local?",
+      "description": "Un borrador local del navegador es diferente de la copia guardada en el servidor. Restáuralo para seguir editando o usa la copia del servidor y descarta el borrador local.",
+      "restoreDraft": "Restaurar borrador",
+      "useServer": "Usar copia del servidor"
+    },
     "personalInfo": "Información Personal",
     "summary": "Resumen",
     "experience": "Experiencia",
@@ -453,6 +467,7 @@
     "alerts": {
       "saveNotAvailable": "Guardar solo está disponible al editar un currículum existente.",
       "saveFailed": "No se pudo guardar el currículum. Por favor, inténtalo de nuevo.",
+      "autoSaveFailed": "No se pudo sincronizar. El borrador está seguro localmente.",
       "coverLetterSaveSuccess": "Carta de presentación guardada",
       "outreachSaveSuccess": "Mensaje de contacto guardado",
       "downloadSuccess": "Currículum descargado",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -121,6 +121,12 @@
       "restoreDraft": "Restaurer le brouillon",
       "useServer": "Utiliser la copie serveur"
     },
+    "leaveWithLocalDraft": {
+      "title": "Quitter sans synchroniser ?",
+      "description": "Les dernières modifications n'ont pas encore pu être synchronisées avec le serveur. Un brouillon local reste enregistré dans ce navigateur, mais il peut ne pas être disponible depuis un autre navigateur ou appareil.",
+      "leave": "Aller au tableau de bord",
+      "stay": "Continuer l'édition"
+    },
     "personalInfo": "Informations personnelles",
     "summary": "Résumé",
     "experience": "Expérience",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -107,6 +107,20 @@
     "previewMode": "Mode aperçu",
     "createAndPreview": "Créer et prévisualiser",
     "unsavedDraft": "Brouillon non enregistré",
+    "autoSave": {
+      "saving": "Synchronisation...",
+      "saved": "Toutes les modifications sont enregistrées",
+      "localDraft": "Brouillon enregistré localement",
+      "saveNow": "Enregistrer maintenant",
+      "retrySave": "Réessayer",
+      "savedButton": "Enregistré"
+    },
+    "draftRecovery": {
+      "title": "Restaurer le brouillon local ?",
+      "description": "Un brouillon local du navigateur diffère de la copie enregistrée sur le serveur. Restaurez-le pour continuer l'édition, ou utilisez la copie du serveur et supprimez le brouillon local.",
+      "restoreDraft": "Restaurer le brouillon",
+      "useServer": "Utiliser la copie serveur"
+    },
     "personalInfo": "Informations personnelles",
     "summary": "Résumé",
     "experience": "Expérience",
@@ -449,6 +463,7 @@
     "alerts": {
       "saveNotAvailable": "L'enregistrement n'est disponible que lors de la modification d'un CV existant.",
       "saveFailed": "Impossible d'enregistrer le CV. Veuillez réessayer.",
+      "autoSaveFailed": "Impossible de synchroniser. Le brouillon est en sécurité localement.",
       "coverLetterSaveSuccess": "Lettre de motivation enregistrée",
       "outreachSaveSuccess": "Message de contact enregistré",
       "downloadSuccess": "CV téléchargé",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -107,6 +107,20 @@
     "previewMode": "プレビューモード",
     "createAndPreview": "作成＆プレビュー",
     "unsavedDraft": "未保存の下書き",
+    "autoSave": {
+      "saving": "同期中...",
+      "saved": "すべての変更を保存しました",
+      "localDraft": "下書きをローカルに保存しました",
+      "saveNow": "今すぐ保存",
+      "retrySave": "保存を再試行",
+      "savedButton": "保存済み"
+    },
+    "draftRecovery": {
+      "title": "ローカル下書きを復元しますか？",
+      "description": "ブラウザ内のローカル下書きがサーバーに保存された内容と異なります。復元して編集を続けるか、サーバー版を使用してローカル下書きを破棄できます。",
+      "restoreDraft": "下書きを復元",
+      "useServer": "サーバー版を使用"
+    },
     "personalInfo": "個人情報",
     "summary": "概要",
     "experience": "職歴",
@@ -453,6 +467,7 @@
     "alerts": {
       "saveNotAvailable": "既存の履歴書を編集中のみ保存できます。",
       "saveFailed": "履歴書の保存に失敗しました。もう一度お試しください。",
+      "autoSaveFailed": "同期できませんでした。下書きはローカルに安全に保存されています。",
       "coverLetterSaveSuccess": "カバーレターを保存しました",
       "outreachSaveSuccess": "連絡メールを保存しました",
       "downloadSuccess": "履歴書をダウンロードしました",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -121,6 +121,12 @@
       "restoreDraft": "下書きを復元",
       "useServer": "サーバー版を使用"
     },
+    "leaveWithLocalDraft": {
+      "title": "同期せずに移動しますか？",
+      "description": "最新の変更はまだサーバーに同期できていません。ローカル下書きはこのブラウザに保存されていますが、別のブラウザや端末では利用できない場合があります。",
+      "leave": "ダッシュボードへ移動",
+      "stay": "編集を続ける"
+    },
     "personalInfo": "個人情報",
     "summary": "概要",
     "experience": "職歴",

--- a/apps/frontend/messages/ko.json
+++ b/apps/frontend/messages/ko.json
@@ -467,7 +467,28 @@
       "outreachSaveFailed": "아웃리치 메시지 저장에 실패했습니다. 다시 시도해 주세요.",
       "coverLetterGenerateFailed": "자기소개서 생성에 실패했습니다: {error}",
       "outreachGenerateFailed": "아웃리치 메시지 생성에 실패했습니다: {error}",
-      "interviewPrepGenerateFailed": "면접 준비 자료 생성에 실패했습니다: {error}"
+      "interviewPrepGenerateFailed": "면접 준비 자료 생성에 실패했습니다: {error}",
+      "autoSaveFailed": "동기화하지 못했습니다. 초안은 로컬에 안전하게 저장되어 있습니다."
+    },
+    "autoSave": {
+      "saving": "동기화 중...",
+      "saved": "모든 변경 사항이 저장되었습니다",
+      "localDraft": "초안이 로컬에 저장되었습니다",
+      "saveNow": "지금 저장",
+      "retrySave": "저장 다시 시도",
+      "savedButton": "저장됨"
+    },
+    "draftRecovery": {
+      "title": "로컬 초안을 복원할까요?",
+      "description": "브라우저에 저장된 로컬 초안이 서버에 저장된 사본과 다릅니다. 초안을 복원해 편집을 계속하거나, 서버 사본을 사용하고 로컬 초안을 삭제할 수 있습니다.",
+      "restoreDraft": "초안 복원",
+      "useServer": "서버 사본 사용"
+    },
+    "leaveWithLocalDraft": {
+      "title": "동기화하지 않고 나갈까요?",
+      "description": "최신 편집 내용을 아직 서버에 동기화하지 못했습니다. 로컬 초안은 이 브라우저에 저장되어 있지만 다른 브라우저나 기기에서는 사용하지 못할 수 있습니다.",
+      "leave": "대시보드로 이동",
+      "stay": "편집 계속하기"
     }
   },
   "enrichment": {

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -107,6 +107,20 @@
     "previewMode": "Modo Visualização",
     "createAndPreview": "Criar e Visualizar",
     "unsavedDraft": "Rascunho Não Salvo",
+    "autoSave": {
+      "saving": "Sincronizando...",
+      "saved": "Todas as alterações salvas",
+      "localDraft": "Rascunho salvo localmente",
+      "saveNow": "Salvar agora",
+      "retrySave": "Tentar salvar novamente",
+      "savedButton": "Salvo"
+    },
+    "draftRecovery": {
+      "title": "Restaurar rascunho local?",
+      "description": "Um rascunho local do navegador é diferente da cópia salva no servidor. Restaure-o para continuar editando ou use a cópia do servidor e descarte o rascunho local.",
+      "restoreDraft": "Restaurar rascunho",
+      "useServer": "Usar cópia do servidor"
+    },
     "personalInfo": "Informações Pessoais",
     "summary": "Resumo",
     "experience": "Experiência",
@@ -453,6 +467,7 @@
     "alerts": {
       "saveNotAvailable": "Salvar só está disponível ao editar um currículo existente.",
       "saveFailed": "Falha ao salvar currículo. Por favor, tente novamente.",
+      "autoSaveFailed": "Não foi possível sincronizar. O rascunho está seguro localmente.",
       "coverLetterSaveSuccess": "Carta de apresentação salva",
       "outreachSaveSuccess": "Mensagem de contato salva",
       "downloadSuccess": "Currículo baixado",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -121,6 +121,12 @@
       "restoreDraft": "Restaurar rascunho",
       "useServer": "Usar cópia do servidor"
     },
+    "leaveWithLocalDraft": {
+      "title": "Sair sem sincronizar?",
+      "description": "As alterações mais recentes ainda não puderam ser sincronizadas com o servidor. Um rascunho local continua salvo neste navegador, mas pode não estar disponível em outro navegador ou dispositivo.",
+      "leave": "Ir para o painel",
+      "stay": "Continuar editando"
+    },
     "personalInfo": "Informações Pessoais",
     "summary": "Resumo",
     "experience": "Experiência",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -107,6 +107,20 @@
     "previewMode": "预览模式",
     "createAndPreview": "创建与预览",
     "unsavedDraft": "未保存草稿",
+    "autoSave": {
+      "saving": "同步中...",
+      "saved": "所有更改已保存",
+      "localDraft": "草稿已在本地保存",
+      "saveNow": "立即保存",
+      "retrySave": "重试保存",
+      "savedButton": "已保存"
+    },
+    "draftRecovery": {
+      "title": "恢复本地草稿？",
+      "description": "浏览器中的本地草稿与服务器已保存版本不同。你可以恢复本地草稿继续编辑，或使用服务器版本并丢弃本地草稿。",
+      "restoreDraft": "恢复草稿",
+      "useServer": "使用服务器版本"
+    },
     "personalInfo": "个人信息",
     "summary": "个人简介",
     "experience": "工作经历",
@@ -453,6 +467,7 @@
     "alerts": {
       "saveNotAvailable": "仅在编辑现有简历时可保存。",
       "saveFailed": "保存简历失败，请重试。",
+      "autoSaveFailed": "暂时无法同步，草稿已安全保存在本地。",
       "coverLetterSaveSuccess": "求职信已保存",
       "outreachSaveSuccess": "联系邮件已保存",
       "downloadSuccess": "简历已下载",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -121,6 +121,12 @@
       "restoreDraft": "恢复草稿",
       "useServer": "使用服务器版本"
     },
+    "leaveWithLocalDraft": {
+      "title": "未同步仍要离开？",
+      "description": "最新修改暂时无法同步到服务器。本地浏览器草稿仍已保存，但可能无法在其他浏览器或设备上使用。",
+      "leave": "离开到仪表盘",
+      "stay": "继续编辑"
+    },
     "personalInfo": "个人信息",
     "summary": "个人简介",
     "experience": "工作经历",

--- a/apps/frontend/tests/resume-draft-storage.test.ts
+++ b/apps/frontend/tests/resume-draft-storage.test.ts
@@ -59,12 +59,29 @@ describe('resume draft storage helpers', () => {
   it('rejects valid JSON that does not look like resume data', () => {
     expect(parseResumeDraft('"not a resume"', 'abc-123')).toBeNull();
     expect(parseResumeDraft(JSON.stringify({ data: 42, updatedAt: 1 }), 'abc-123')).toBeNull();
+    expect(
+      parseResumeDraft(
+        JSON.stringify({
+          ...baseResume,
+          workExperience: {},
+        }),
+        'abc-123'
+      )
+    ).toBeNull();
   });
 
   it('rejects an envelope for a different resume id', () => {
     const otherResumeDraft = buildResumeDraft('other-resume', baseResume, 1770000000000);
 
     expect(parseResumeDraft(JSON.stringify(otherResumeDraft), 'abc-123')).toBeNull();
+  });
+
+  it('can reject legacy plain drafts when they cannot be safely scoped', () => {
+    expect(
+      parseResumeDraft(JSON.stringify(baseResume), 'abc-123', 1770000000100, {
+        allowLegacyPlainData: false,
+      })
+    ).toBeNull();
   });
 
   it('only prompts restore when the draft differs from the server copy', () => {

--- a/apps/frontend/tests/resume-draft-storage.test.ts
+++ b/apps/frontend/tests/resume-draft-storage.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ResumeData } from '@/components/dashboard/resume-component';
+import {
+  buildResumeDraft,
+  getResumeDraftStorageKey,
+  parseResumeDraft,
+  shouldPromptForDraftRestore,
+} from '@/lib/utils/resume-draft-storage';
+
+const baseResume = {
+  personalInfo: {
+    name: 'Ada Lovelace',
+    title: 'Software Engineer',
+    email: 'ada@example.com',
+    phone: '',
+    location: '',
+    website: '',
+    linkedin: '',
+    github: '',
+  },
+  summary: '',
+  workExperience: [],
+  education: [],
+  personalProjects: [],
+  additional: {
+    technicalSkills: [],
+    languages: [],
+    certificationsTraining: [],
+    awards: [],
+  },
+} satisfies ResumeData;
+
+describe('resume draft storage helpers', () => {
+  it('scopes saved drafts by resume id', () => {
+    expect(getResumeDraftStorageKey('abc-123')).toBe('resume_builder_draft:abc-123');
+    expect(getResumeDraftStorageKey(null)).toBe('resume_builder_draft:new');
+  });
+
+  it('wraps draft data with identity and timestamp metadata', () => {
+    expect(buildResumeDraft('abc-123', baseResume, 1770000000000)).toEqual({
+      resumeId: 'abc-123',
+      updatedAt: 1770000000000,
+      data: baseResume,
+    });
+  });
+
+  it('parses both the new draft envelope and the legacy plain data shape', () => {
+    const envelope = buildResumeDraft('abc-123', baseResume, 1770000000000);
+    expect(parseResumeDraft(JSON.stringify(envelope), 'abc-123')).toEqual(envelope);
+
+    expect(parseResumeDraft(JSON.stringify(baseResume), 'abc-123', 1770000000100)).toEqual({
+      resumeId: 'abc-123',
+      updatedAt: 1770000000100,
+      data: baseResume,
+    });
+  });
+
+  it('rejects valid JSON that does not look like resume data', () => {
+    expect(parseResumeDraft('"not a resume"', 'abc-123')).toBeNull();
+    expect(parseResumeDraft(JSON.stringify({ data: 42, updatedAt: 1 }), 'abc-123')).toBeNull();
+  });
+
+  it('rejects an envelope for a different resume id', () => {
+    const otherResumeDraft = buildResumeDraft('other-resume', baseResume, 1770000000000);
+
+    expect(parseResumeDraft(JSON.stringify(otherResumeDraft), 'abc-123')).toBeNull();
+  });
+
+  it('only prompts restore when the draft differs from the server copy', () => {
+    expect(shouldPromptForDraftRestore(buildResumeDraft('abc-123', baseResume), baseResume)).toBe(
+      false
+    );
+
+    const changedDraft = buildResumeDraft('abc-123', {
+      ...baseResume,
+      education: [
+        {
+          institution: 'MIT',
+          degree: 'BS',
+          startDate: '2020',
+          endDate: '2024',
+          location: '',
+          gpa: '',
+          honors: [],
+          relevantCoursework: [],
+        },
+      ],
+    });
+
+    expect(shouldPromptForDraftRestore(changedDraft, baseResume)).toBe(true);
+  });
+});

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -82,4 +82,29 @@ describe('resume normalization', () => {
       'Accepted at a systems workshop',
     ]);
   });
+
+  it('ignores malformed persisted list and description values during normalization', () => {
+    const malformedState = {
+      ...baseResume,
+      workExperience: [
+        {
+          id: 1,
+          title: 'Engineer',
+          company: 'Analytical Engines Inc',
+          years: '2024 - Present',
+          description: 'not-an-array',
+        },
+      ],
+      additional: {
+        technicalSkills: ['TypeScript', null, '  '],
+        languages: 'not-an-array',
+      },
+    } as unknown as ResumeData;
+
+    const normalized = normalizeResumeForSave(malformedState);
+
+    expect(normalized.workExperience?.[0].description).toEqual([]);
+    expect(normalized.additional?.technicalSkills).toEqual(['TypeScript']);
+    expect(normalized.additional?.languages).toEqual([]);
+  });
 });

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ResumeData } from '@/components/dashboard/resume-component';
+import { normalizeResumeForRender, normalizeResumeForSave } from '@/lib/utils/resume-normalization';
+
+const baseResume = {
+  personalInfo: {
+    name: 'Ada Lovelace',
+    title: 'Software Engineer',
+    email: 'ada@example.com',
+  },
+  summary: '',
+  workExperience: [],
+  education: [],
+  personalProjects: [],
+  additional: {},
+} satisfies ResumeData;
+
+describe('resume normalization', () => {
+  it('drops empty description placeholders from the canonical save payload', () => {
+    const editorState: ResumeData = {
+      ...baseResume,
+      workExperience: [
+        {
+          id: 1,
+          title: 'Engineer',
+          company: 'Analytical Engines Inc',
+          years: '2024 - Present',
+          description: ['', 'Built reliable systems', '   '],
+        },
+      ],
+    };
+
+    expect(normalizeResumeForSave(editorState).workExperience?.[0]).toMatchObject({
+      description: ['Built reliable systems'],
+    });
+    expect(editorState.workExperience?.[0].description).toEqual([
+      '',
+      'Built reliable systems',
+      '   ',
+    ]);
+  });
+
+  it('drops entirely empty editor-only experience entries from the save payload', () => {
+    const editorState: ResumeData = {
+      ...baseResume,
+      workExperience: [
+        {
+          id: 1,
+          title: '',
+          company: '',
+          location: '',
+          years: '',
+          description: [''],
+        },
+      ],
+    };
+
+    expect(normalizeResumeForSave(editorState).workExperience).toEqual([]);
+  });
+
+  it('normalizes custom item-list sections for rendering and saving', () => {
+    const editorState: ResumeData = {
+      ...baseResume,
+      customSections: {
+        custom_1: {
+          sectionType: 'itemList',
+          items: [
+            {
+              id: 1,
+              title: 'Publication',
+              description: ['', 'Accepted at a systems workshop'],
+            },
+          ],
+        },
+      },
+    };
+
+    const normalized = normalizeResumeForRender(editorState);
+
+    expect(normalized.customSections?.custom_1.items?.[0].description).toEqual([
+      'Accepted at a systems workshop',
+    ]);
+  });
+});

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -107,4 +107,49 @@ describe('resume normalization', () => {
     expect(normalized.additional?.technicalSkills).toEqual(['TypeScript']);
     expect(normalized.additional?.languages).toEqual([]);
   });
+
+  it('keeps descriptionStyles aligned when blank description points are dropped', () => {
+    const editorState: ResumeData = {
+      ...baseResume,
+      workExperience: [
+        {
+          id: 1,
+          title: 'Engineer',
+          company: 'Analytical Engines Inc',
+          years: '2024 - Present',
+          description: ['', 'Led the migration', 'Cut costs 40%'],
+          descriptionStyles: ['bullet', 'plain', 'bullet'],
+        },
+      ],
+    };
+
+    const normalized = normalizeResumeForSave(editorState);
+    const experience = normalized.workExperience?.[0];
+
+    // The blank first point is dropped, so its style must be dropped with it —
+    // otherwise 'Led the migration' inherits 'bullet' and 'Cut costs 40%'
+    // inherits 'plain', silently flipping both.
+    expect(experience?.description).toEqual(['Led the migration', 'Cut costs 40%']);
+    expect(experience?.descriptionStyles).toEqual(['plain', 'bullet']);
+  });
+
+  it('leaves items without descriptionStyles untouched', () => {
+    const editorState: ResumeData = {
+      ...baseResume,
+      workExperience: [
+        {
+          id: 1,
+          title: 'Engineer',
+          company: 'Analytical Engines Inc',
+          years: '2024 - Present',
+          description: ['', 'Shipped it'],
+        },
+      ],
+    };
+
+    const experience = normalizeResumeForSave(editorState).workExperience?.[0];
+
+    expect(experience?.description).toEqual(['Shipped it']);
+    expect(experience).not.toHaveProperty('descriptionStyles');
+  });
 });


### PR DESCRIPTION
Lands batch 3 on `dev`. Both PRs are by @RedMoonnn and both needed maintainer fixes that could not be pushed to the contributor fork, so they are integrated here with **original authorship preserved** — see the commit list.

## Included

### #883 — resume autosave, draft recovery, regenerate sync
Debounced server autosave (2.5s debounce / 12s max wait) behind a serialized promise queue, per-resume localStorage draft envelopes replacing the single global key, a restore-conflict dialog, and a canonical normalization pass shared by the save payload and the regenerate list.

Maintainer fixes:
- **Fixed silent data corruption.** `normalizeResumeForSave` compacted the `description` array but let the parallel `descriptionStyles` array through the object spread untouched. The styles are positional, so dropping a blank point shifted every later point's bullet/plain setting onto its neighbour — on every autosave, and persisted, because the backend aligns styles by index. This did not conflict textually with #882; it would have merged clean and corrupted user data silently. Now filtered in lockstep, with a regression test verified to fail without the fix.
- `lastSavedData` now comes from the server response rather than the client payload, so a server-side rewrite cannot surface a spurious draft-recovery prompt on reload.
- Added the 15 `ko.json` strings for `autoSave`, `draftRecovery` and `leaveWithLocalDraft`, required for parity after #876.

### #884 — CJK font fallback
Registers Noto Sans SC via `next/font/google` and injects it into the serif and sans-serif stacks. Complements #785, which added CJK fonts to the Docker image: #785 fixes generated PDFs, this fixes the in-browser preview.

Maintainer fixes:
- **Closed the `mono` gap.** The PR added the fallback to serif and sans-serif but left both `mono` entries untouched, so CJK text still rendered as tofu under the mono template setting.
- Declared `preload: false` explicitly.

## Correction to an earlier review note

An earlier triage flagged #884 as a build break, on the basis that the next/font validator throws for a preloaded font declared without `subsets`. **That was wrong.** Next 16 builds with Turbopack, whose font pipeline does not run that legacy webpack validator — `next build` succeeds on the unmodified PR, and the built output is byte-identical with and without `preload: false` (same 2 preloaded fonts, same hashes). The flag is kept as correct intent and as protection for the webpack path, but it was not blocking. The real defect in #884 was the `mono` gap.

## Verification

```
locale parity   ok, 7 locales
eslint          clean
prettier        clean
vitest          32 files, 208 tests passed
next build      compiled + TypeScript clean
pytest          510 passed, 1 deselected
```

Closes #883
Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMmBLeE1yEETK1xNWqGCTv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds autosave and draft recovery to the resume builder with a safer save/regenerate flow, and adds a CJK font fallback in the in-browser preview (including mono). Fixes a bullet-style alignment bug that could corrupt data and reduces false recovery prompts.

- New Features
  - Debounced autosave (2.5s; 12s max wait) with a serialized save queue and a small “syncing/saved” status badge.
  - Per-resume draft envelopes in `localStorage` with a restore dialog when local and server copies differ; legacy global key is read and cleared.
  - Canonical normalization for save and regenerate; regenerate and download now wait for pending saves to finish.
  - CJK fallback: register `Noto_Sans_SC` via `next/font/google`, add it to serif/sans/mono stacks, and set `preload: false`.

- Bug Fixes
  - Keep `descriptionStyles` aligned with `description` when compacting; regression tests added.
  - Use the server response for `lastSavedData` to avoid spurious draft-recovery prompts.
  - Close the mono font gap so CJK doesn’t render as tofu; settings reset now clears all per-resume draft keys.

<sup>Written for commit e0354b05dd3baf78fcf7bfe83080f65f46739e93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

