### PR TITLE
feat(improver): similarity-based bullet matching for description diffs (#711 PR 1/3)

### DIFF
--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -1143,6 +1143,184 @@ def _extract_description_list(entry: Any) -> list[str]:
     return _normalize_string_list(entry.get("description", []), "workExperience.description")
 
 
+# Similarity-based bullet matching (RM #711 PR-1).
+#
+# The previous implementation ran SequenceMatcher over whole bullet strings as
+# atomic tokens, so `[A, B, C] -> [C, A, B]` produced a `replace` opcode that
+# paired unrelated bullets by position and reported them as `modified`. We now:
+#
+#   1. Tokenize each bullet at the WORD level (unicode-aware, CJK per-char).
+#   2. Score every (old, new) pair with SequenceMatcher.ratio() over the
+#      normalized token lists — exact normalized matches short-circuit to 1.0.
+#   3. Greedily pick highest-score pairs one-to-one until nothing remains that
+#      clears MATCH_THRESHOLD.
+#   4. Emit `modified` for content-changing pairs; emit `moved` only when
+#      `emit_moves=True` AND the pair is a pure reorder (contract shipped in
+#      PR-2). Unpaired items become `added` / `removed`.
+#
+# PR-1 keeps `emit_moves=False` by default so this ships without touching the
+# frontend/`change_type` enum contract; pure reorders are silently suppressed
+# (previous behaviour also did not emit them).
+
+# Default similarity threshold: values below this are treated as unrelated and
+# split into add/remove instead of forcing a bogus `modified` pair.
+#
+# Bullets are scored with max(token_ratio, char_ratio) so single-word edits on
+# short bullets (e.g. "Led team" -> "Led squad", token ratio 0.5 but char ratio
+# ~0.75) still cross the threshold, while genuinely unrelated bullets from the
+# issue-#711 LCS trap (e.g. "React form" vs "BackstopJS") stay well below it.
+_DEFAULT_MATCH_THRESHOLD: float = 0.55
+
+# Bullet count above which we skip the O(n*m) scoring pass and only pair on
+# exact normalized keys. Resume descriptions rarely exceed a few dozen bullets;
+# this cap is a defensive backstop for adversarial input.
+_FUZZY_MATCH_LIMIT: int = 100
+
+
+def _tokenize_for_similarity(text: str) -> list[str]:
+    """Return the normalized word/char token list used for similarity scoring.
+
+    - NFKC normalization + casefold makes width/case/compat forms equivalent.
+    - Latin runs (letters+digits) collapse into single word tokens; CJK
+      characters become one token each so we do not depend on whitespace in
+      languages that lack it.
+    - Whitespace is collapsed away; punctuation is dropped from the token
+      stream (it still lives in the original string used for rendering).
+    """
+    import unicodedata
+
+    normalized = unicodedata.normalize("NFKC", text or "").casefold()
+    tokens: list[str] = []
+    buffer: list[str] = []
+    for ch in normalized:
+        # CJK Unified Ideographs, Hiragana, Katakana, Hangul: one token each.
+        if (
+            "぀" <= ch <= "ヿ"
+            or "㐀" <= ch <= "鿿"
+            or "가" <= ch <= "힯"
+            or "豈" <= ch <= "﫿"
+        ):
+            if buffer:
+                tokens.append("".join(buffer))
+                buffer.clear()
+            tokens.append(ch)
+            continue
+        if ch.isalnum():
+            buffer.append(ch)
+        else:
+            if buffer:
+                tokens.append("".join(buffer))
+                buffer.clear()
+    if buffer:
+        tokens.append("".join(buffer))
+    return tokens
+
+
+@dataclass(frozen=True)
+class _BulletMatch:
+    old_index: int
+    new_index: int
+    score: float
+    exact: bool  # True iff normalized token lists are identical.
+
+
+def _match_bullets(
+    original_items: list[str],
+    improved_items: list[str],
+    threshold: float,
+) -> list[_BulletMatch]:
+    """One-to-one greedy pairing by token-level similarity.
+
+    Returns matches sorted by new_index for stable downstream rendering.
+    Uses deterministic tie-breaks so identical input always yields identical
+    output — required for reproducible diffs and snapshot tests.
+    """
+    old_tokens = [_tokenize_for_similarity(x) for x in original_items]
+    new_tokens = [_tokenize_for_similarity(x) for x in improved_items]
+
+    # Fast path: purely add/remove — nothing to match against.
+    if not old_tokens or not new_tokens:
+        return []
+
+    # Defensive backstop for adversarial input: skip fuzzy scoring above the
+    # limit, keep only exact anchors. See _FUZZY_MATCH_LIMIT.
+    if max(len(old_tokens), len(new_tokens)) > _FUZZY_MATCH_LIMIT:
+        matches: list[_BulletMatch] = []
+        used_new: set[int] = set()
+        for i, left in enumerate(old_tokens):
+            for j, right in enumerate(new_tokens):
+                if j in used_new or left != right or not left:
+                    continue
+                matches.append(_BulletMatch(i, j, 1.0, True))
+                used_new.add(j)
+                break
+        return sorted(matches, key=lambda m: (m.new_index, m.old_index))
+
+    # Score every candidate pair that clears the threshold. Empty token lists
+    # (bullets that normalize to nothing, e.g. pure punctuation) never match.
+    candidates: list[tuple[float, bool, int, int, int]] = []
+    for i, left in enumerate(old_tokens):
+        if not left:
+            continue
+        for j, right in enumerate(new_tokens):
+            if not right:
+                continue
+            if left == right:
+                score = 1.0
+                exact = True
+            else:
+                token_ratio = SequenceMatcher(
+                    None, left, right, autojunk=False
+                ).ratio()
+                # Char-level ratio catches single-word edits on short bullets
+                # ("Led team" -> "Led squad") that would otherwise score 0.5 on
+                # tokens and get dropped as unrelated. Use the normalized text
+                # so casing/whitespace don't distort it.
+                char_ratio = SequenceMatcher(
+                    None,
+                    " ".join(left),
+                    " ".join(right),
+                    autojunk=False,
+                ).ratio()
+                score = max(token_ratio, char_ratio)
+                exact = False
+            if exact or score >= threshold:
+                # tuple: (-score, not exact, |i-j|, i, j) so sort() gives us
+                # highest score first, exact matches before fuzzy at same
+                # score, and closer indices before farther on ties.
+                candidates.append((score, exact, abs(i - j), i, j))
+
+    candidates.sort(key=lambda c: (-c[0], not c[1], c[2], c[3], c[4]))
+
+    used_old: set[int] = set()
+    used_new: set[int] = set()
+    matches = []
+    for score, exact, _distance, i, j in candidates:
+        if i in used_old or j in used_new:
+            continue
+        used_old.add(i)
+        used_new.add(j)
+        matches.append(_BulletMatch(i, j, score, exact))
+
+    return sorted(matches, key=lambda m: (m.new_index, m.old_index))
+
+
+def _confidence_for_score(
+    score: float, confidences: DiffConfidence
+) -> str:
+    """Map a similarity score onto the string confidence tiers.
+
+    High score -> high confidence the two bullets are related edits of each
+    other. Anything at/above 0.85 is high; 0.65-0.85 keeps the caller's default
+    (usually medium); below 0.65 downgrades to low so the UI can flag it.
+    """
+    if score >= 0.85:
+        return "high"
+    if score >= 0.65:
+        return confidences.modified
+    return "low"
+
+
 def _append_list_changes(
     changes: list[ResumeFieldDiff],
     field_path: str,
@@ -1150,75 +1328,74 @@ def _append_list_changes(
     original_items: list[str],
     improved_items: list[str],
     confidences: DiffConfidence,
+    *,
+    match_threshold: float = _DEFAULT_MATCH_THRESHOLD,
+    emit_moves: bool = False,
 ) -> None:
-    matcher = SequenceMatcher(a=original_items, b=improved_items, autojunk=False)
-    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
-        if tag == "equal":
+    """Append ResumeFieldDiff records for a pair of bullet lists.
+
+    See module-level comment above the function for the algorithm.
+    """
+    matches = _match_bullets(original_items, improved_items, match_threshold)
+    matched_old = {m.old_index for m in matches}
+    matched_new = {m.new_index for m in matches}
+
+    # 1. Pairs first — either `modified` for edited content or (PR-2) `moved`
+    #    for pure reorders. Pure reorders are silently dropped in PR-1 because
+    #    the current `change_type` Literal does not include "moved".
+    for match in matches:
+        original_value = original_items[match.old_index]
+        new_value = improved_items[match.new_index]
+        if match.exact:
+            if match.old_index != match.new_index and emit_moves:
+                # PR-2 will land the `moved` enum; guarded so it's a no-op today.
+                changes.append(
+                    ResumeFieldDiff(
+                        field_path=field_path,
+                        field_type=field_type,
+                        change_type="moved",  # type: ignore[arg-type]
+                        original_value=original_value,
+                        new_value=new_value,
+                        confidence="high",
+                    )
+                )
             continue
-        if tag == "delete":
-            for item in original_items[i1:i2]:
-                changes.append(
-                    ResumeFieldDiff(
-                        field_path=field_path,
-                        field_type=field_type,
-                        change_type="removed",
-                        original_value=item,
-                        confidence=confidences.removed,
-                    )
+        changes.append(
+            ResumeFieldDiff(
+                field_path=field_path,
+                field_type=field_type,
+                change_type="modified",
+                original_value=original_value,
+                new_value=new_value,
+                confidence=_confidence_for_score(match.score, confidences),
+            )
+        )
+
+    # 2. Unmatched improved items become `added` in their new-order position.
+    for j, item in enumerate(improved_items):
+        if j not in matched_new:
+            changes.append(
+                ResumeFieldDiff(
+                    field_path=field_path,
+                    field_type=field_type,
+                    change_type="added",
+                    new_value=item,
+                    confidence=confidences.added,
                 )
-        elif tag == "insert":
-            for item in improved_items[j1:j2]:
-                changes.append(
-                    ResumeFieldDiff(
-                        field_path=field_path,
-                        field_type=field_type,
-                        change_type="added",
-                        new_value=item,
-                        confidence=confidences.added,
-                    )
+            )
+
+    # 3. Unmatched original items become `removed`.
+    for i, item in enumerate(original_items):
+        if i not in matched_old:
+            changes.append(
+                ResumeFieldDiff(
+                    field_path=field_path,
+                    field_type=field_type,
+                    change_type="removed",
+                    original_value=item,
+                    confidence=confidences.removed,
                 )
-        elif tag == "replace":
-            original_segment = original_items[i1:i2]
-            improved_segment = improved_items[j1:j2]
-            segment_len = max(len(original_segment), len(improved_segment))
-            for offset in range(segment_len):
-                original_value = (
-                    original_segment[offset] if offset < len(original_segment) else None
-                )
-                new_value = (
-                    improved_segment[offset] if offset < len(improved_segment) else None
-                )
-                if original_value is not None and new_value is not None:
-                    changes.append(
-                        ResumeFieldDiff(
-                            field_path=field_path,
-                            field_type=field_type,
-                            change_type="modified",
-                            original_value=original_value,
-                            new_value=new_value,
-                            confidence=confidences.modified,
-                        )
-                    )
-                elif new_value is not None:
-                    changes.append(
-                        ResumeFieldDiff(
-                            field_path=field_path,
-                            field_type=field_type,
-                            change_type="added",
-                            new_value=new_value,
-                            confidence=confidences.added,
-                        )
-                    )
-                elif original_value is not None:
-                    changes.append(
-                        ResumeFieldDiff(
-                            field_path=field_path,
-                            field_type=field_type,
-                            change_type="removed",
-                            original_value=original_value,
-                            confidence=confidences.removed,
-                        )
-                    )
+            )
 
 
 def calculate_resume_diff(

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -4,6 +4,7 @@ import copy
 import json
 import logging
 import re
+from collections import deque
 from difflib import SequenceMatcher
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -1224,10 +1225,17 @@ def _normalize_source(text: str) -> str:
     lists match. Otherwise a punctuation-only edit like ``C++`` -> ``C#`` would
     both tokenize to ``["c"]`` and be silently suppressed as an exact match
     (cubic review finding on RM#905).
+
+    Whitespace runs are collapsed (and trimmed) so spacing-only differences
+    such as ``Led  team`` -> ``Led team`` do not register as content changes -
+    consistent with the existing case/Unicode-compat-form equivalence
+    (architect review finding on RM#905). Punctuation is intentionally kept.
     """
+    import re
     import unicodedata
 
-    return unicodedata.normalize("NFKC", text or "").casefold()
+    normalized = unicodedata.normalize("NFKC", text or "").casefold()
+    return re.sub(r"\s+", " ", normalized).strip()
 
 
 @dataclass(frozen=True)
@@ -1264,24 +1272,23 @@ def _match_bullets(
     # limit, keep only exact anchors. See _FUZZY_MATCH_LIMIT.
     if max(len(old_tokens), len(new_tokens)) > _FUZZY_MATCH_LIMIT:
         matches: list[_BulletMatch] = []
-        used_new: set[int] = set()
-        # Index new items by normalized source so exact-anchor lookup is O(1)
-        # instead of O(n*m) (cubic review on RM#905): the previous double loop
-        # was quadratic even in this "fast" path. Only the first occurrence of
-        # each normalized key is anchorable; duplicates fall through to
-        # add/remove, which is correct for an exact-only backstop.
-        new_index_by_norm: dict[str, int] = {}
+        # Index new items by normalized source as per-key deques so duplicate
+        # keys are consumed one-to-one in O(n+m) (architect review on RM#905):
+        # a previous dict[str,int] kept only the first index and mis-paired
+        # large duplicate lists (121 identical bullets -> 120 added + 120
+        # removed). Each new index lives in exactly one queue and is popped at
+        # most once, so pairing stays one-to-one without a used-set; only
+        # count-imbalanced duplicates fall through to add/remove.
+        new_queues_by_norm: dict[str, deque[int]] = {}
         for j, norm in enumerate(new_norm):
-            if norm and norm not in new_index_by_norm:
-                new_index_by_norm[norm] = j
+            if norm:
+                new_queues_by_norm.setdefault(norm, deque()).append(j)
         for i, norm in enumerate(old_norm):
-            if not norm:
+            queue = new_queues_by_norm.get(norm)
+            if not queue:
                 continue
-            j = new_index_by_norm.get(norm)
-            if j is None or j in used_new:
-                continue
+            j = queue.popleft()
             matches.append(_BulletMatch(i, j, 1.0, True))
-            used_new.add(j)
         return sorted(matches, key=lambda m: (m.new_index, m.old_index))
 
     # Score every candidate pair that clears the threshold. Empty token lists

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -1216,12 +1216,26 @@ def _tokenize_for_similarity(text: str) -> list[str]:
     return tokens
 
 
+def _normalize_source(text: str) -> str:
+    """NFKC + casefold the raw bullet text, *preserving* punctuation.
+
+    Used for exact-match detection: two bullets are exact only when their
+    normalized source strings are identical, NOT merely when their alnum token
+    lists match. Otherwise a punctuation-only edit like ``C++`` -> ``C#`` would
+    both tokenize to ``["c"]`` and be silently suppressed as an exact match
+    (cubic review finding on RM#905).
+    """
+    import unicodedata
+
+    return unicodedata.normalize("NFKC", text or "").casefold()
+
+
 @dataclass(frozen=True)
 class _BulletMatch:
     old_index: int
     new_index: int
     score: float
-    exact: bool  # True iff normalized token lists are identical.
+    exact: bool  # True iff normalized source strings are identical.
 
 
 def _match_bullets(
@@ -1237,6 +1251,10 @@ def _match_bullets(
     """
     old_tokens = [_tokenize_for_similarity(x) for x in original_items]
     new_tokens = [_tokenize_for_similarity(x) for x in improved_items]
+    # Normalized source strings (punctuation preserved) drive exact-match
+    # detection so punctuation-only edits (C++ -> C#) are not suppressed.
+    old_norm = [_normalize_source(x) for x in original_items]
+    new_norm = [_normalize_source(x) for x in improved_items]
 
     # Fast path: purely add/remove — nothing to match against.
     if not old_tokens or not new_tokens:
@@ -1247,13 +1265,23 @@ def _match_bullets(
     if max(len(old_tokens), len(new_tokens)) > _FUZZY_MATCH_LIMIT:
         matches: list[_BulletMatch] = []
         used_new: set[int] = set()
-        for i, left in enumerate(old_tokens):
-            for j, right in enumerate(new_tokens):
-                if j in used_new or left != right or not left:
-                    continue
-                matches.append(_BulletMatch(i, j, 1.0, True))
-                used_new.add(j)
-                break
+        # Index new items by normalized source so exact-anchor lookup is O(1)
+        # instead of O(n*m) (cubic review on RM#905): the previous double loop
+        # was quadratic even in this "fast" path. Only the first occurrence of
+        # each normalized key is anchorable; duplicates fall through to
+        # add/remove, which is correct for an exact-only backstop.
+        new_index_by_norm: dict[str, int] = {}
+        for j, norm in enumerate(new_norm):
+            if norm and norm not in new_index_by_norm:
+                new_index_by_norm[norm] = j
+        for i, norm in enumerate(old_norm):
+            if not norm:
+                continue
+            j = new_index_by_norm.get(norm)
+            if j is None or j in used_new:
+                continue
+            matches.append(_BulletMatch(i, j, 1.0, True))
+            used_new.add(j)
         return sorted(matches, key=lambda m: (m.new_index, m.old_index))
 
     # Score every candidate pair that clears the threshold. Empty token lists
@@ -1265,25 +1293,35 @@ def _match_bullets(
         for j, right in enumerate(new_tokens):
             if not right:
                 continue
-            if left == right:
+            if old_norm[i] == new_norm[j] and old_norm[i]:
+                # Identical normalized source (punctuation included) -> exact,
+                # i.e. a pure reorder or a no-op rewrite.
                 score = 1.0
                 exact = True
             else:
-                token_ratio = SequenceMatcher(
-                    None, left, right, autojunk=False
-                ).ratio()
-                # Char-level ratio catches single-word edits on short bullets
-                # ("Led team" -> "Led squad") that would otherwise score 0.5 on
-                # tokens and get dropped as unrelated. Use the normalized text
-                # so casing/whitespace don't distort it.
-                char_ratio = SequenceMatcher(
-                    None,
-                    " ".join(left),
-                    " ".join(right),
-                    autojunk=False,
-                ).ratio()
-                score = max(token_ratio, char_ratio)
                 exact = False
+                if left == right:
+                    # Tokens match but normalized source differs: a
+                    # punctuation-only edit such as "C++" -> "C#" (both
+                    # tokenize to ["c"]). A real content change - score 1.0 so
+                    # it pairs and emits as `modified`, not suppressed (cubic
+                    # review on RM#905).
+                    score = 1.0
+                else:
+                    token_ratio = SequenceMatcher(
+                        None, left, right, autojunk=False
+                    ).ratio()
+                    # Char-level ratio catches single-word edits on short
+                    # bullets ("Led team" -> "Led squad") that would otherwise
+                    # score 0.5 on tokens and get dropped as unrelated. Use the
+                    # normalized text so casing/whitespace don't distort it.
+                    char_ratio = SequenceMatcher(
+                        None,
+                        " ".join(left),
+                        " ".join(right),
+                        autojunk=False,
+                    ).ratio()
+                    score = max(token_ratio, char_ratio)
             if exact or score >= threshold:
                 # tuple: (-score, not exact, |i-j|, i, j) so sort() gives us
                 # highest score first, exact matches before fuzzy at same

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -1291,44 +1291,52 @@ def _match_bullets(
             matches.append(_BulletMatch(i, j, 1.0, True))
         return sorted(matches, key=lambda m: (m.new_index, m.old_index))
 
-    # Score every candidate pair that clears the threshold. Empty token lists
-    # (bullets that normalize to nothing, e.g. pure punctuation) never match.
+    # Score every candidate pair that clears the threshold. Identical
+    # normalized source (incl. pure-punctuation bullets whose token list is
+    # empty) is an exact match in BOTH the fuzzy and the fast path, so
+    # identical "---" produces no diff. The empty-token skip below guards only
+    # fuzzy scoring, never the exact check - otherwise identical pure-
+    # punctuation bullets would be swallowed into add/remove in the fuzzy path
+    # only, diverging from the fast path (architect alignment on RM#905).
     candidates: list[tuple[float, bool, int, int, int]] = []
     for i, left in enumerate(old_tokens):
-        if not left:
-            continue
         for j, right in enumerate(new_tokens):
-            if not right:
-                continue
-            if old_norm[i] == new_norm[j] and old_norm[i]:
+            if old_norm[i] and old_norm[i] == new_norm[j]:
                 # Identical normalized source (punctuation included) -> exact,
-                # i.e. a pure reorder or a no-op rewrite.
+                # i.e. a pure reorder or a no-op rewrite. Applies to ALL
+                # bullets including empty-token (pure punctuation) ones, so
+                # identical "---" yields no diff - matching the fast path.
                 score = 1.0
                 exact = True
+            elif not left or not right:
+                # Empty token lists (pure punctuation) have no similarity to
+                # score. Only identical ones (caught above) match; distinct
+                # ones fall through to add/remove.
+                continue
+            elif left == right:
+                # Tokens match but normalized source differs: a
+                # punctuation-only edit such as "C++" -> "C#" (both
+                # tokenize to ["c"]). A real content change - score 1.0 so
+                # it pairs and emits as `modified`, not suppressed (cubic
+                # review on RM#905).
+                score = 1.0
+                exact = False
             else:
                 exact = False
-                if left == right:
-                    # Tokens match but normalized source differs: a
-                    # punctuation-only edit such as "C++" -> "C#" (both
-                    # tokenize to ["c"]). A real content change - score 1.0 so
-                    # it pairs and emits as `modified`, not suppressed (cubic
-                    # review on RM#905).
-                    score = 1.0
-                else:
-                    token_ratio = SequenceMatcher(
-                        None, left, right, autojunk=False
-                    ).ratio()
-                    # Char-level ratio catches single-word edits on short
-                    # bullets ("Led team" -> "Led squad") that would otherwise
-                    # score 0.5 on tokens and get dropped as unrelated. Use the
-                    # normalized text so casing/whitespace don't distort it.
-                    char_ratio = SequenceMatcher(
-                        None,
-                        " ".join(left),
-                        " ".join(right),
-                        autojunk=False,
-                    ).ratio()
-                    score = max(token_ratio, char_ratio)
+                token_ratio = SequenceMatcher(
+                    None, left, right, autojunk=False
+                ).ratio()
+                # Char-level ratio catches single-word edits on short
+                # bullets ("Led team" -> "Led squad") that would otherwise
+                # score 0.5 on tokens and get dropped as unrelated. Use the
+                # normalized text so casing/whitespace don't distort it.
+                char_ratio = SequenceMatcher(
+                    None,
+                    " ".join(left),
+                    " ".join(right),
+                    autojunk=False,
+                ).ratio()
+                score = max(token_ratio, char_ratio)
             if exact or score >= threshold:
                 # tuple: (-score, not exact, |i-j|, i, j) so sort() gives us
                 # highest score first, exact matches before fuzzy at same

--- a/apps/backend/app/services/improver.py
+++ b/apps/backend/app/services/improver.py
@@ -1231,7 +1231,6 @@ def _normalize_source(text: str) -> str:
     consistent with the existing case/Unicode-compat-form equivalence
     (architect review finding on RM#905). Punctuation is intentionally kept.
     """
-    import re
     import unicodedata
 
     normalized = unicodedata.normalize("NFKC", text or "").casefold()

--- a/apps/backend/tests/unit/test_resume_diff.py
+++ b/apps/backend/tests/unit/test_resume_diff.py
@@ -390,6 +390,42 @@ def test_whitespace_only_difference_is_not_a_content_change() -> None:
     assert _describe("workExperience[0].description", original, improved) == []
 
 
+def test_identical_pure_punctuation_is_no_diff_in_fuzzy_path() -> None:
+    # Architect alignment on RM#905: identical normalized source (incl. pure
+    # punctuation, whose token list is empty) must be an exact match in the
+    # fuzzy path too. Previously the empty-token skip ran first and swallowed
+    # identical "---" into add/remove only here, diverging from the fast path.
+    assert _describe("workExperience[0].description", ["---"], ["---"]) == []
+    assert _describe(
+        "workExperience[0].description",
+        ["---", "---", "---"],
+        ["---", "---", "---"],
+    ) == []
+
+
+def test_identical_pure_punctuation_is_no_diff_in_fast_path() -> None:
+    # Same invariant under the >100 fast path: an unchanged large list with a
+    # trailing pure-punctuation bullet produces no diff (guards against the two
+    # paths drifting apart again).
+    original = [f"Item {i}" for i in range(120)] + ["---"]
+    improved = [f"Item {i}" for i in range(120)] + ["---"]
+
+    assert _describe("wp", original, improved) == []
+
+
+def test_distinct_pure_punctuation_splits_into_add_remove() -> None:
+    # Distinct pure-punctuation bullets have no token similarity, so they must
+    # NOT pair as a modified edit - they split into add/remove. Checked in both
+    # the fuzzy and the fast path so the two stay consistent.
+    fuzzy = _describe("workExperience[0].description", ["---"], ["***"])
+    assert sorted(c.change_type for c in fuzzy) == ["added", "removed"]
+
+    original = [f"Item {i}" for i in range(120)] + ["---"]
+    improved = [f"Item {i}" for i in range(120)] + ["***"]
+    fast = _describe("wp", original, improved)
+    assert sorted(c.change_type for c in fast) == ["added", "removed"]
+
+
 def test_pure_reorder_produces_no_records_in_pr1() -> None:
     # PR-1 does not ship the `moved` enum: pure reorders must be silent so
     # the existing frontend does not receive an unknown change_type.

--- a/apps/backend/tests/unit/test_resume_diff.py
+++ b/apps/backend/tests/unit/test_resume_diff.py
@@ -1,4 +1,10 @@
 from app.services.improver import calculate_resume_diff
+from app.services.improver import (
+    _append_list_changes,
+    _match_bullets,
+    _tokenize_for_similarity,
+    DiffConfidence,
+)
 
 
 def test_skill_add_remove_case_insensitive() -> None:
@@ -273,3 +279,187 @@ def test_award_add() -> None:
 
     awards = [c for c in changes if c.field_type == "award" and c.change_type == "added"]
     assert [c.new_value for c in awards] == ["Employee of the Year 2022"]
+
+
+# --- Bullet-list similarity matching (PR-1 for RM #711) ---
+#
+# `_append_list_changes` used to run SequenceMatcher on whole-bullet tokens,
+# which paired unrelated bullets by position on reorder. These tests lock the
+# similarity-based behaviour: reorders don't force `modified`, and bullets
+# below the similarity threshold split into add/remove instead of misleading
+# side-by-side modifications.
+
+_DEFAULT_CONFIDENCES = DiffConfidence(added="medium", removed="low", modified="medium")
+
+
+def _describe(field_path: str, original: list[str], improved: list[str]):
+    """Small helper: run the list-diff helper and return its output."""
+    out: list = []
+    _append_list_changes(
+        out,
+        field_path=field_path,
+        field_type="description",
+        original_items=original,
+        improved_items=improved,
+        confidences=_DEFAULT_CONFIDENCES,
+    )
+    return out
+
+
+def test_tokenize_is_unicode_case_and_width_insensitive() -> None:
+    assert _tokenize_for_similarity("Hello, World!") == ["hello", "world"]
+    # Full-width digits normalize via NFKC to ASCII.
+    assert _tokenize_for_similarity("ＡＢＣ123") == ["abc123"]
+    # CJK: one token per ideograph, no whitespace required.
+    assert _tokenize_for_similarity("你好世界") == ["你", "好", "世", "界"]
+    # Whitespace only / punctuation only collapse to nothing.
+    assert _tokenize_for_similarity("   ") == []
+    assert _tokenize_for_similarity("---") == []
+
+
+def test_lcs_trap_unrelated_bullets_split_into_add_remove() -> None:
+    # Issue #711's motivating example: LCS greedily matches "the" and pairs
+    # completely unrelated bullets. Similarity matcher must split them.
+    original = ["Rewrote the React form validation flow"]
+    improved = ["Migrated the visual regression suite to BackstopJS"]
+
+    changes = _describe("workExperience[0].description", original, improved)
+
+    kinds = sorted(c.change_type for c in changes)
+    assert kinds == ["added", "removed"]
+    assert not any(c.change_type == "modified" for c in changes)
+
+
+def test_pure_reorder_produces_no_records_in_pr1() -> None:
+    # PR-1 does not ship the `moved` enum: pure reorders must be silent so
+    # the existing frontend does not receive an unknown change_type.
+    original = ["Alpha work", "Beta work", "Gamma work"]
+    improved = ["Gamma work", "Alpha work", "Beta work"]
+
+    changes = _describe("workExperience[0].description", original, improved)
+
+    assert changes == []
+
+
+def test_reorder_plus_rewrite_reports_one_modified_and_no_stray_records() -> None:
+    original = ["Alpha bullet one", "Beta bullet two", "Gamma bullet three"]
+    improved = [
+        "Gamma bullet three, rewritten with more detail",  # C reworded
+        "Alpha bullet one",                                # A moved
+        "Beta bullet two",                                 # B moved
+    ]
+
+    changes = _describe("workExperience[0].description", original, improved)
+
+    # Exactly one modified record (for C), no add/remove — A and B are exact
+    # reorders and get suppressed in PR-1.
+    kinds = sorted(c.change_type for c in changes)
+    assert kinds == ["modified"]
+    modified = next(c for c in changes if c.change_type == "modified")
+    assert modified.original_value == "Gamma bullet three"
+    assert modified.new_value == "Gamma bullet three, rewritten with more detail"
+
+
+def test_unmatched_items_emit_once_each_in_order() -> None:
+    original = ["Retired responsibility A", "Kept core work B"]
+    improved = ["Kept core work B", "Brand new deliverable C"]
+
+    changes = _describe("workExperience[0].description", original, improved)
+
+    # "Kept core work B" is an exact reorder -> suppressed in PR-1.
+    # Only new "C" (added) and old "A" (removed) remain.
+    assert [c.change_type for c in changes] == ["added", "removed"]
+    assert changes[0].new_value == "Brand new deliverable C"
+    assert changes[1].original_value == "Retired responsibility A"
+
+
+def test_threshold_boundary_and_single_word_bullets() -> None:
+    # Short bullets: token ratio alone would drop this, but char ratio saves it.
+    changes = _describe("workExperience[0].description", ["Led team"], ["Led squad"])
+    assert [c.change_type for c in changes] == ["modified"]
+
+    # Truly unrelated one-word bullets stay split.
+    changes = _describe("workExperience[0].description", ["Sales"], ["Cooking"])
+    assert sorted(c.change_type for c in changes) == ["added", "removed"]
+
+
+def test_duplicate_bullets_each_consume_one_slot() -> None:
+    # Three identical originals + two identical improved: matcher must pair
+    # 2 exactly (silent reorder) and drop the extra original as `removed`.
+    original = ["Wrote unit tests", "Wrote unit tests", "Wrote unit tests"]
+    improved = ["Wrote unit tests", "Wrote unit tests"]
+
+    changes = _describe("workExperience[0].description", original, improved)
+
+    assert [c.change_type for c in changes] == ["removed"]
+
+
+def test_non_latin_and_mixed_scripts_pair_correctly() -> None:
+    # Chinese bullet slightly reworded — should still pair as modified.
+    original = ["负责前端架构设计"]
+    improved = ["负责前端架构设计与优化"]
+
+    changes = _describe("workExperience[0].description", original, improved)
+
+    assert [c.change_type for c in changes] == ["modified"]
+    assert changes[0].original_value == original[0]
+    assert changes[0].new_value == improved[0]
+
+    # Mixed script: casing / width shouldn't produce a false modified.
+    original = ["Owned CI/CD pipeline"]
+    improved = ["Owned CI/CD pipeline"]
+    assert _describe("wp", original, improved) == []
+
+
+def test_empty_and_large_lists_do_not_raise() -> None:
+    assert _describe("wp", [], []) == []
+    # Empty original, non-empty improved: everything is added.
+    changes = _describe("wp", [], ["New A", "New B"])
+    assert [c.change_type for c in changes] == ["added", "added"]
+
+    # Above the fuzzy backstop: only exact anchors, no crash.
+    original = [f"Item {i}" for i in range(120)]
+    improved = original[::-1]  # pure reversal
+    changes = _describe("wp", original, improved)
+    assert changes == []  # all exact reorders, suppressed in PR-1
+
+
+def test_matcher_invariants_indexes_are_one_to_one() -> None:
+    original = ["A work", "B work", "C work", "D removed"]
+    improved = ["C work rewritten", "A work", "B work", "E added"]
+
+    matches = _match_bullets(original, improved, threshold=0.55)
+    old_ids = [m.old_index for m in matches]
+    new_ids = [m.new_index for m in matches]
+    # No index is consumed twice, and every matched pair references a legal
+    # original/improved slot.
+    assert len(old_ids) == len(set(old_ids))
+    assert len(new_ids) == len(set(new_ids))
+    assert all(0 <= i < len(original) for i in old_ids)
+    assert all(0 <= j < len(improved) for j in new_ids)
+
+
+def test_summary_count_matches_similarity_output() -> None:
+    # Reorder + one rewrite must land as exactly one `descriptions_modified`.
+    original = {
+        "workExperience": [
+            {"description": ["Old bullet 1", "Old bullet 2", "Old bullet 3"]}
+        ]
+    }
+    improved = {
+        "workExperience": [
+            {
+                "description": [
+                    "Old bullet 3 with more impact",
+                    "Old bullet 1",
+                    "Old bullet 2",
+                ]
+            }
+        ]
+    }
+
+    summary, changes = calculate_resume_diff(original, improved)
+
+    modified = [c for c in changes if c.field_type == "description" and c.change_type == "modified"]
+    assert len(modified) == 1
+    assert summary.descriptions_modified == 1

--- a/apps/backend/tests/unit/test_resume_diff.py
+++ b/apps/backend/tests/unit/test_resume_diff.py
@@ -362,6 +362,34 @@ def test_punctuation_only_edit_in_fast_path_is_not_suppressed() -> None:
     assert "C#" in added[0].new_value
 
 
+def test_fast_path_consumes_duplicate_anchors_one_to_one() -> None:
+    # Architect review on RM#905: the fast path must consume duplicate
+    # normalized keys one-to-one (per-key queue), not keep only the first
+    # index. Otherwise an unchanged 121-item duplicate list would emit
+    # 120 `added` + 120 `removed`.
+    original = ["Wrote unit tests"] * 121
+    improved = ["Wrote unit tests"] * 121
+
+    assert _describe("wp", original, improved) == []
+
+    # Count imbalance: the one extra original duplicate falls through to
+    # `removed`; nothing else changes.
+    original = ["Wrote unit tests"] * 121
+    improved = ["Wrote unit tests"] * 120
+
+    changes = _describe("wp", original, improved)
+    assert [c.change_type for c in changes] == ["removed"]
+
+
+def test_whitespace_only_difference_is_not_a_content_change() -> None:
+    # Architect review on RM#905: _normalize_source folds whitespace so a
+    # spacing/case change is not reported as a content edit.
+    original = ["Led  team to deliver"]  # double space
+    improved = ["Led team to deliver"]   # single space
+
+    assert _describe("workExperience[0].description", original, improved) == []
+
+
 def test_pure_reorder_produces_no_records_in_pr1() -> None:
     # PR-1 does not ship the `moved` enum: pure reorders must be silent so
     # the existing frontend does not receive an unknown change_type.

--- a/apps/backend/tests/unit/test_resume_diff.py
+++ b/apps/backend/tests/unit/test_resume_diff.py
@@ -330,6 +330,38 @@ def test_lcs_trap_unrelated_bullets_split_into_add_remove() -> None:
     assert not any(c.change_type == "modified" for c in changes)
 
 
+def test_punctuation_only_edit_is_not_suppressed() -> None:
+    # cubic review on RM#905: "C++" -> "C#" both tokenize to ["c"], so the old
+    # token-equality check treated them as exact and silently dropped the
+    # change. Exact must compare normalized SOURCE (punctuation preserved), so
+    # a punctuation-only edit lands as a real `modified`.
+    original = ["Built high-throughput services in C++"]
+    improved = ["Built high-throughput services in C#"]
+
+    changes = _describe("workExperience[0].description", original, improved)
+
+    assert [c.change_type for c in changes] == ["modified"]
+    assert "C++" in changes[0].original_value
+    assert "C#" in changes[0].new_value
+
+
+def test_punctuation_only_edit_in_fast_path_is_not_suppressed() -> None:
+    # Above the fuzzy backstop (>100 items) the fast path pairs on normalized
+    # SOURCE, not tokens, so a C++/C# swap must surface as add/remove instead
+    # of being silently exact-matched. Also exercises the O(n) index rewrite
+    # of the fast path (cubic #1 on RM#905).
+    original = [f"Item {i}" for i in range(120)] + ["Shipped C++ service"]
+    improved = [f"Item {i}" for i in range(120)] + ["Shipped C# service"]
+
+    changes = _describe("wp", original, improved)
+
+    assert sorted(c.change_type for c in changes) == ["added", "removed"]
+    removed = [c for c in changes if c.change_type == "removed"]
+    added = [c for c in changes if c.change_type == "added"]
+    assert "C++" in removed[0].original_value
+    assert "C#" in added[0].new_value
+
+
 def test_pure_reorder_produces_no_records_in_pr1() -> None:
     # PR-1 does not ship the `moved` enum: pure reorders must be silent so
     # the existing frontend does not receive an unknown change_type.


### PR DESCRIPTION
## Summary

Replaces the position/LCS-based `SequenceMatcher` pass inside `_append_list_changes` (`apps/backend/app/services/improver.py`) with a similarity matcher that scores every `(original, improved)` bullet pair and greedily picks one-to-one matches above a threshold.

Closes the LCS trap from #711 where reordering a bullet list produced `modified` pairs of unrelated bullets.

## Motivation (from issue #711)

When the LLM keeps a bullet's content but moves it in the list, the previous matcher pairs bullets by position, so unrelated content shows up in the diff preview as "modified" side-by-side. Example:

```
Original: [A, B, C]
Improved: [C, A, B]
```

The old `replace` opcode paired `A→C` (unrelated) and `B→A` (unrelated) as `modified`, and dropped `C→B` as add/remove. The preview UI showed two false content edits.

## Approach

- Tokenize each bullet at the word/character level (NFKC + casefold + CJK-per-char) so short bullets, mixed scripts and full-width digits behave consistently.
- Score every pair with `max(token_ratio, char_ratio)` from `difflib.SequenceMatcher`. Char-ratio catches short-bullet single-word edits ("Led team" → "Led squad", 0.5 token → ~0.75 char). Exact normalized matches short-circuit to 1.0.
- Sort candidates by (score desc, exact first, |Δindex| asc, i asc, j asc) — deterministic tie-break so identical input always yields identical output.
- Greedily consume until each old/new index has been used at most once.
- Emit `modified` for content-changing pairs; unpaired items become `added` / `removed`.

## What this PR does *not* do

To keep the change reviewable and stay compatible with the current frontend's `Literal["added", "removed", "modified"]` contract:

- **No `moved` change_type**. Pure reorders (exact match, index changed) are silently suppressed in this PR. That matches the previous shipped behaviour (LCS also produced no output for pure reorders) and avoids sending an unknown enum to today's frontend. The `moved` enum + `original_index`/`new_index` fields + Builder `bullet_changes` will land in the follow-up PR (issue #711 second half). The infrastructure is already in place — `_append_list_changes` takes a keyword-only `emit_moves: bool = False` that flips this on once the frontend is ready.
- **No inline word-level rendering**. That's issue #710 / the third PR in this series.
- **No schema changes**. `ResumeFieldDiff.change_type` is unchanged; no frontend types change; no new dependencies.

## Behaviour changes

| Case | Before | After |
| --- | --- | --- |
| `[A, B, C] → [C, A, B]` (pure reorder) | Two spurious `modified` + one add + one remove | No records (silent) |
| `[A, B, C] → [C', A, B]` (reorder + rewrite of C) | Bogus modified pairs (A→C', B→A) + wrong add/remove | One `modified` for C→C', A and B silent |
| Short single-word edit ("Led team" → "Led squad") | `modified` via LCS position | Still `modified` (char-ratio) |
| Unrelated bullets at same position | `modified` | Split into `added` + `removed` |
| Non-Latin bullets | LCS on codepoint arrays | Word/char tokenized with NFKC + casefold |
| >100 bullets | O(n×m) full scoring | Fast path: exact anchors only, then add/remove |

## Tests

- All 21 existing `apps/backend/tests/unit/test_resume_diff.py` cases still pass unchanged.
- 11 new fixtures for the similarity path: LCS trap, pure reorder, reorder+rewrite, unmatched ordering, threshold boundary, duplicate bullets, non-Latin/mixed scripts, empty and large lists (>100), matcher one-to-one invariants, and `descriptions_modified` count.

Local run:

```
$ pytest tests/service/test_improver.py tests/unit/test_apply_diffs.py \
        tests/unit/test_resume_diff.py tests/unit/test_verify_diffs.py -q
121 passed in 1.45s
```

## Risks / notes for reviewers

- The threshold `0.55` is defensive — happy to move it if maintainers have real-world fixture data that argues for tighter or looser. It's a private module constant so tuning stays a one-line change.
- The scoring is O(n×m×token_length), n and m capped at the fuzzy limit (100). Resume bullet lists rarely exceed a handful; the fast path handles adversarial input without regressing correctness.
- Deliberately not using scikit-learn / TF-IDF / LLM-reported mapping — the stdlib path stays zero-dep and deterministic, which was the direction issue #711 asked for.

Ref: #711

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces position-based list diffing with similarity-based bullet matching to pair edits by content and stop bogus modified diffs on reorders. Adds punctuation-aware exact matching, whitespace folding, and a linear fast path for large lists; no schema changes and pure reorders stay silent until `moved` ships. Addresses #711.

- **New Features**
  - Greedy one-to-one matches above 0.55 using max(word-token, char) ratios; deterministic tie-breaks.
  - Unicode-aware tokenization (NFKC + casefold; CJK per-char). Exact match compares normalized source with punctuation preserved; whitespace is folded.
  - Large lists (>100): exact anchors only with O(n+m) lookup and per-key queues for duplicates.

- **Bug Fixes**
  - Punctuation-only edits (e.g., "C++" → "C#") emit `modified`; identical pure-punctuation bullets (e.g., "---") produce no diff in both paths; distinct punctuation splits into `added` + `removed`.
  - Whitespace-only changes (e.g., double → single space) no longer emit diffs.
  - Duplicate anchors in the >100 fast path are consumed one-to-one; unrelated bullets at the same index split into `added` + `removed` instead of forced `modified`.

<sup>Written for commit 9564fe2bebef00e71796e3478f5adee4f94f08d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

