### PR TITLE
Harden normalization and draft comparison (#903 review findings)

### DIFF
--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -62,7 +62,7 @@ import {
 } from 'lucide-react';
 import { useLanguage } from '@/lib/context/language-context';
 import { useTranslations } from '@/lib/i18n';
-import { RESUME_DRAFT_STORAGE_PREFIX } from '@/lib/utils/resume-draft-storage';
+import { RESUME_DRAFT_STORAGE_PREFIX, safeStorage } from '@/lib/utils/resume-draft-storage';
 import type { SupportedLanguage } from '@/lib/api/config';
 import type { Locale } from '@/i18n/config';
 
@@ -617,15 +617,22 @@ export default function SettingsPage() {
     try {
       await resetDatabase();
 
-      // Clear all related localStorage keys
-      localStorage.removeItem('master_resume_id');
-      localStorage.removeItem('resume_builder_draft');
-      Object.keys(localStorage)
-        .filter((key) => key.startsWith(RESUME_DRAFT_STORAGE_PREFIX))
-        .forEach((key) => localStorage.removeItem(key));
-      localStorage.removeItem('resume_builder_settings');
-      localStorage.removeItem('resume_matcher_content_language');
-      localStorage.removeItem('resume_matcher_ui_language');
+      // Clear all related localStorage keys. Routed through safeStorage so a
+      // context where storage throws (enterprise policy, iframe) cannot abort
+      // the reset flow *after* the server-side wipe has already succeeded.
+      safeStorage.remove('master_resume_id');
+      safeStorage.remove('resume_builder_draft');
+      try {
+        Object.keys(localStorage)
+          .filter((key) => key.startsWith(RESUME_DRAFT_STORAGE_PREFIX))
+          .forEach((key) => safeStorage.remove(key));
+      } catch {
+        // Enumerating localStorage can throw for the same reasons; the scoped
+        // drafts simply stay until their TTL expires.
+      }
+      safeStorage.remove('resume_builder_settings');
+      safeStorage.remove('resume_matcher_content_language');
+      safeStorage.remove('resume_matcher_ui_language');
 
       // Refresh status to show empty counts
       await refreshStatus();

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -75,6 +75,10 @@ const RESUME_AUTOSAVE_MAX_WAIT_MS = 12000;
 // Floor for the computed delay. Without it, once an unsynced streak exceeds the
 // max wait the delay pins to 0 and every keystroke schedules an immediate
 // full-document PATCH.
+// This floor deliberately wins over the remaining max-wait budget, so a save
+// can land up to MIN_DELAY after MAX_WAIT elapses. MAX_WAIT is a target for
+// how long edits may stay unsynced, not a hard deadline — dropping the floor
+// to honour it exactly is what produced one PATCH per keystroke.
 const RESUME_AUTOSAVE_MIN_DELAY_MS = 500;
 
 type Translate = (key: string, params?: Record<string, string | number>) => string;

--- a/apps/frontend/lib/utils/preview-error.ts
+++ b/apps/frontend/lib/utils/preview-error.ts
@@ -26,7 +26,7 @@ export function getPreviewErrorMessage(
     normalized.includes('api key') ||
     normalized.includes('unauthorized') ||
     normalized.includes('authentication') ||
-    errorMessage.includes('401')
+    normalized.includes('401')
   ) {
     return t('tailor.errors.apiKeyError');
   }
@@ -34,7 +34,7 @@ export function getPreviewErrorMessage(
   if (
     normalized.includes('rate limit') ||
     normalized.includes('insufficient_quota') ||
-    errorMessage.includes('429')
+    normalized.includes('429')
   ) {
     return t('tailor.errors.rateLimit');
   }
@@ -44,7 +44,7 @@ export function getPreviewErrorMessage(
     normalized.includes('timeout') ||
     normalized.includes('signal is aborted') ||
     normalized.includes('aborterror') ||
-    errorMessage.includes('504')
+    normalized.includes('504')
   ) {
     // Report the timeout the app is actually configured with, not a literal.
     // DEFAULT_TIMEOUT_MS is driven by NEXT_PUBLIC_REQUEST_TIMEOUT_MS and is

--- a/apps/frontend/lib/utils/resume-draft-storage.ts
+++ b/apps/frontend/lib/utils/resume-draft-storage.ts
@@ -11,6 +11,12 @@ const NEW_RESUME_DRAFT_ID = 'new';
  */
 export const RESUME_DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
+/**
+ * Tolerated clock skew for a draft stamped in the future. Beyond this the
+ * timestamp is treated as untrustworthy rather than as "very fresh".
+ */
+export const RESUME_DRAFT_MAX_CLOCK_SKEW_MS = 24 * 60 * 60 * 1000; // 1 day
+
 export interface ResumeDraftEnvelope {
   resumeId: string | null;
   updatedAt: number;
@@ -100,7 +106,12 @@ export function parseResumeDraft(
       // from a one-off tailor session survived forever and would be offered as
       // "unsaved work" months later. Expire it instead.
       const now = options.now ?? Date.now();
-      if (now - parsed.updatedAt > RESUME_DRAFT_MAX_AGE_MS) {
+      const age = now - parsed.updatedAt;
+      // Negative age means the draft is stamped in the future — a client clock
+      // that was ahead when it was written. Left unchecked it stays recoverable
+      // until that future date plus the max age. Allow a small skew window and
+      // reject anything beyond it.
+      if (age > RESUME_DRAFT_MAX_AGE_MS || age < -RESUME_DRAFT_MAX_CLOCK_SKEW_MS) {
         return null;
       }
 
@@ -117,8 +128,47 @@ export function parseResumeDraft(
   }
 }
 
+/**
+ * Structural deep-equality, insensitive to object key order.
+ *
+ * This gates a data-loss decision (whether to offer the "Restore Local Draft?"
+ * dialog), so it must not report a difference that isn't one. `JSON.stringify`
+ * equality is key-order sensitive: a client-authored draft and a
+ * Pydantic-serialised server response can carry identical data with different
+ * key order and compare unequal, surfacing a recovery prompt whose two options
+ * are indistinguishable. Arrays stay order-sensitive — order is meaningful for
+ * description rows and their parallel styles.
+ */
+const deepEqual = (left: unknown, right: unknown): boolean => {
+  if (left === right) return true;
+  if (typeof left !== typeof right) return false;
+  if (left === null || right === null) return false;
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    if (left.length !== right.length) return false;
+    return left.every((item, index) => deepEqual(item, right[index]));
+  }
+
+  if (typeof left === 'object' && typeof right === 'object') {
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const leftKeys = Object.keys(leftRecord);
+    const rightKeys = Object.keys(rightRecord);
+    if (leftKeys.length !== rightKeys.length) return false;
+    return leftKeys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(rightRecord, key) &&
+        deepEqual(leftRecord[key], rightRecord[key])
+    );
+  }
+
+  // NaN !== NaN, but two NaNs are not a meaningful "unsaved change".
+  return Number.isNaN(left) && Number.isNaN(right);
+};
+
 export function isSameResumeData(left: ResumeData, right: ResumeData): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
+  return deepEqual(left, right);
 }
 
 export function shouldPromptForDraftRestore(

--- a/apps/frontend/lib/utils/resume-draft-storage.ts
+++ b/apps/frontend/lib/utils/resume-draft-storage.ts
@@ -82,7 +82,11 @@ function isResumeDraftEnvelope(value: unknown): value is ResumeDraftEnvelope {
   return (
     'data' in value &&
     'updatedAt' in value &&
-    typeof value.updatedAt === 'number' &&
+    // Number.isFinite, not `typeof === 'number'`: NaN and ±Infinity pass the
+    // typeof check, and NaN then defeats BOTH expiry comparisons (every
+    // comparison against NaN is false), so a malformed draft would be treated
+    // as permanently fresh.
+    Number.isFinite(value.updatedAt) &&
     isResumeDataShape(value.data)
   );
 }

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -16,7 +16,12 @@ const isMeaningfulText = (value: unknown): value is string => {
 };
 
 const normalizeStringList = (items?: string[]): string[] | undefined => {
-  if (!items) return items;
+  // Only `undefined` means "field absent" — preserve it so the key stays out
+  // of the payload. Every other non-array (notably `null` from malformed
+  // persisted data) is coerced to []; the old `if (!items) return items`
+  // returned null unchanged, leaking it into a value typed `string[] |
+  // undefined` and crashing callers that assume an array.
+  if (items === undefined) return undefined;
   if (!Array.isArray(items)) return [];
   return items.filter(isMeaningfulText).map((item) => item.trim());
 };
@@ -48,34 +53,37 @@ const normalizeDescriptionFields = <T extends DescribedItem>(item: T): T => {
   };
 };
 
+// Optional chaining guards null/undefined but NOT a non-string: a numeric
+// `title` from malformed persisted data makes `.trim` undefined and throws
+// "item.title?.trim is not a function". isMeaningfulText type-checks first.
 const hasExperienceContent = (item: Experience): boolean => {
   return Boolean(
-    item.title?.trim() ||
-    item.company?.trim() ||
-    item.location?.trim() ||
-    item.years?.trim() ||
-    item.description?.length
+    isMeaningfulText(item.title) ||
+    isMeaningfulText(item.company) ||
+    isMeaningfulText(item.location) ||
+    isMeaningfulText(item.years) ||
+    (Array.isArray(item.description) && item.description.length)
   );
 };
 
 const hasProjectContent = (item: Project): boolean => {
   return Boolean(
-    item.name?.trim() ||
-    item.role?.trim() ||
-    item.years?.trim() ||
-    item.github?.trim() ||
-    item.website?.trim() ||
-    item.description?.length
+    isMeaningfulText(item.name) ||
+    isMeaningfulText(item.role) ||
+    isMeaningfulText(item.years) ||
+    isMeaningfulText(item.github) ||
+    isMeaningfulText(item.website) ||
+    (Array.isArray(item.description) && item.description.length)
   );
 };
 
 const hasCustomItemContent = (item: CustomSectionItem): boolean => {
   return Boolean(
-    item.title?.trim() ||
-    item.subtitle?.trim() ||
-    item.location?.trim() ||
-    item.years?.trim() ||
-    item.description?.length
+    isMeaningfulText(item.title) ||
+    isMeaningfulText(item.subtitle) ||
+    isMeaningfulText(item.location) ||
+    isMeaningfulText(item.years) ||
+    (Array.isArray(item.description) && item.description.length)
   );
 };
 
@@ -83,7 +91,11 @@ const normalizeCustomSection = (section: CustomSection): CustomSection => {
   if (section.sectionType === 'itemList') {
     return {
       ...section,
-      items: (section.items || []).map(normalizeDescriptionFields).filter(hasCustomItemContent),
+      // Array.isArray, not `|| []` — a malformed truthy non-array (an object
+      // from hand-edited storage) reaches .map and throws.
+      items: (Array.isArray(section.items) ? section.items : [])
+        .map(normalizeDescriptionFields)
+        .filter(hasCustomItemContent),
     };
   }
 
@@ -109,10 +121,10 @@ export const normalizeResumeForSave = (resume: ResumeData): ResumeData => {
 
   return {
     ...resume,
-    workExperience: (resume.workExperience || [])
+    workExperience: (Array.isArray(resume.workExperience) ? resume.workExperience : [])
       .map(normalizeDescriptionFields)
       .filter(hasExperienceContent),
-    personalProjects: (resume.personalProjects || [])
+    personalProjects: (Array.isArray(resume.personalProjects) ? resume.personalProjects : [])
       .map(normalizeDescriptionFields)
       .filter(hasProjectContent),
     additional: resume.additional

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -15,7 +15,9 @@ const isMeaningfulText = (value: unknown): value is string => {
   return typeof value === 'string' && value.trim().length > 0;
 };
 
-const normalizeStringList = (items?: string[]): string[] | undefined => {
+// Param is `unknown`, not `string[] | undefined`: this runs against persisted
+// data that TypeScript never validated, and the narrow type hid that.
+const normalizeStringList = (items?: unknown): string[] | undefined => {
   // Only `undefined` means "field absent" — preserve it so the key stays out
   // of the payload. Every other non-array (notably `null` from malformed
   // persisted data) is coerced to []; the old `if (!items) return items`
@@ -26,7 +28,15 @@ const normalizeStringList = (items?: string[]): string[] | undefined => {
   return items.filter(isMeaningfulText).map((item) => item.trim());
 };
 
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
 const normalizeDescriptionFields = <T extends DescribedItem>(item: T): T => {
+  // A null element inside an otherwise-valid array throws on property access.
+  // Guarding the container was not enough — persisted arrays can hold nulls.
+  if (!isObjectRecord(item)) {
+    return item;
+  }
   const descriptions = Array.isArray(item.description) ? item.description : [];
   // descriptionStyles is positional — styles[i] belongs to description[i]. It
   // must be filtered in lockstep, or dropping a blank description silently
@@ -94,6 +104,7 @@ const normalizeCustomSection = (section: CustomSection): CustomSection => {
       // Array.isArray, not `|| []` — a malformed truthy non-array (an object
       // from hand-edited storage) reaches .map and throws.
       items: (Array.isArray(section.items) ? section.items : [])
+        .filter(isObjectRecord)
         .map(normalizeDescriptionFields)
         .filter(hasCustomItemContent),
     };
@@ -122,9 +133,11 @@ export const normalizeResumeForSave = (resume: ResumeData): ResumeData => {
   return {
     ...resume,
     workExperience: (Array.isArray(resume.workExperience) ? resume.workExperience : [])
+      .filter(isObjectRecord)
       .map(normalizeDescriptionFields)
       .filter(hasExperienceContent),
     personalProjects: (Array.isArray(resume.personalProjects) ? resume.personalProjects : [])
+      .filter(isObjectRecord)
       .map(normalizeDescriptionFields)
       .filter(hasProjectContent),
     additional: resume.additional

--- a/apps/frontend/tests/resume-draft-storage.test.ts
+++ b/apps/frontend/tests/resume-draft-storage.test.ts
@@ -6,6 +6,8 @@ import {
   getResumeDraftStorageKey,
   parseResumeDraft,
   RESUME_DRAFT_MAX_AGE_MS,
+  RESUME_DRAFT_MAX_CLOCK_SKEW_MS,
+  isSameResumeData,
   shouldPromptForDraftRestore,
 } from '@/lib/utils/resume-draft-storage';
 
@@ -158,5 +160,62 @@ describe('draft expiry determinism', () => {
         now: writtenAt + RESUME_DRAFT_MAX_AGE_MS + 1,
       })
     ).toBeNull();
+  });
+});
+
+describe('isSameResumeData structural comparison', () => {
+  it('treats reordered object keys as equal', () => {
+    // A client-authored draft and a Pydantic-serialised server response can
+    // carry identical data in a different key order. JSON.stringify equality
+    // called that "unsaved work" and popped a recovery dialog whose two
+    // options were indistinguishable.
+    const left = { ...baseResume, personalInfo: { name: 'Ada', email: 'a@b.com' } };
+    const right = { ...baseResume, personalInfo: { email: 'a@b.com', name: 'Ada' } };
+
+    expect(isSameResumeData(left as ResumeData, right as ResumeData)).toBe(true);
+    expect(
+      shouldPromptForDraftRestore(
+        buildResumeDraft('abc-123', left as ResumeData),
+        right as ResumeData
+      )
+    ).toBe(false);
+  });
+
+  it('still reports a real difference', () => {
+    const left = { ...baseResume, summary: 'one' };
+    const right = { ...baseResume, summary: 'two' };
+
+    expect(isSameResumeData(left as ResumeData, right as ResumeData)).toBe(false);
+  });
+
+  it('keeps array order significant', () => {
+    const left = { ...baseResume, additional: { technicalSkills: ['a', 'b'] } };
+    const right = { ...baseResume, additional: { technicalSkills: ['b', 'a'] } };
+
+    expect(isSameResumeData(left as ResumeData, right as ResumeData)).toBe(false);
+  });
+});
+
+describe('draft clock skew', () => {
+  it('rejects a draft stamped far in the future', () => {
+    const now = 1_800_000_000_000;
+    const future = JSON.stringify({
+      resumeId: 'abc-123',
+      updatedAt: now + RESUME_DRAFT_MAX_CLOCK_SKEW_MS + 60_000,
+      data: baseResume,
+    });
+
+    expect(parseResumeDraft(future, 'abc-123', undefined, { now })).toBeNull();
+  });
+
+  it('tolerates small skew', () => {
+    const now = 1_800_000_000_000;
+    const slightlyAhead = JSON.stringify({
+      resumeId: 'abc-123',
+      updatedAt: now + 60_000,
+      data: baseResume,
+    });
+
+    expect(parseResumeDraft(slightlyAhead, 'abc-123', undefined, { now })).not.toBeNull();
   });
 });

--- a/apps/frontend/tests/resume-draft-storage.test.ts
+++ b/apps/frontend/tests/resume-draft-storage.test.ts
@@ -219,3 +219,22 @@ describe('draft clock skew', () => {
     expect(parseResumeDraft(slightlyAhead, 'abc-123', undefined, { now })).not.toBeNull();
   });
 });
+
+describe('draft timestamp validation', () => {
+  it('rejects a non-finite timestamp', () => {
+    // JSON.parse cannot produce NaN (it throws on the literal), but it DOES
+    // produce Infinity for an overflowing numeric literal. Both the TTL and
+    // skew comparisons already reject those; Number.isFinite in the shape
+    // check makes the invariant explicit rather than incidental.
+    const overflow = `{"resumeId":"abc-123","updatedAt":1e400,"data":${JSON.stringify(baseResume)}}`;
+    expect(parseResumeDraft(overflow, 'abc-123')).toBeNull();
+
+    const negOverflow = `{"resumeId":"abc-123","updatedAt":-1e400,"data":${JSON.stringify(baseResume)}}`;
+    expect(parseResumeDraft(negOverflow, 'abc-123')).toBeNull();
+  });
+
+  it('rejects a non-numeric timestamp', () => {
+    const stringy = `{"resumeId":"abc-123","updatedAt":"yesterday","data":${JSON.stringify(baseResume)}}`;
+    expect(parseResumeDraft(stringy, 'abc-123')).toBeNull();
+  });
+});

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -153,3 +153,53 @@ describe('resume normalization', () => {
     expect(experience).not.toHaveProperty('descriptionStyles');
   });
 });
+
+describe('normalization robustness against malformed persisted data', () => {
+  // These inputs are not reachable from the editor, but they ARE reachable from
+  // hand-edited localStorage or a legacy server row, and each one used to throw
+  // or leak a bad value into the canonical PATCH payload.
+  const malformed = (over: Record<string, unknown>): ResumeData =>
+    ({ ...baseResume, ...over }) as unknown as ResumeData;
+
+  it('coerces a null string list to [] instead of leaking null', () => {
+    const out = normalizeResumeForSave(
+      malformed({ additional: { technicalSkills: null, languages: undefined } })
+    );
+
+    expect(out.additional?.technicalSkills).toEqual([]);
+    // `undefined` still means "absent" and is preserved.
+    expect(out.additional?.languages).toBeUndefined();
+  });
+
+  it('does not throw on non-string scalar fields', () => {
+    expect(() =>
+      normalizeResumeForSave(
+        malformed({ workExperience: [{ id: 1, title: 5, description: ['ok'] }] })
+      )
+    ).not.toThrow();
+  });
+
+  it('does not throw on a non-array description', () => {
+    expect(() =>
+      normalizeResumeForSave(
+        malformed({ personalProjects: [{ id: 1, name: 'P', description: 'not-an-array' }] })
+      )
+    ).not.toThrow();
+  });
+
+  it('does not throw on a non-array custom itemList', () => {
+    expect(() =>
+      normalizeResumeForSave(
+        malformed({
+          customSections: { custom_1: { sectionType: 'itemList', items: { bogus: true } } },
+        })
+      )
+    ).not.toThrow();
+  });
+
+  it('does not throw when top-level collections are not arrays', () => {
+    expect(() =>
+      normalizeResumeForSave(malformed({ workExperience: null, personalProjects: 'nope' }))
+    ).not.toThrow();
+  });
+});

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -203,3 +203,35 @@ describe('normalization robustness against malformed persisted data', () => {
     ).not.toThrow();
   });
 });
+
+describe('normalization robustness — element level', () => {
+  const malformed = (over: Record<string, unknown>): ResumeData =>
+    ({ ...baseResume, ...over }) as unknown as ResumeData;
+
+  it('drops null and primitive entries inside otherwise-valid arrays', () => {
+    // Container guards were not enough: a null element throws on property
+    // access inside normalizeDescriptionFields.
+    const out = normalizeResumeForSave(
+      malformed({
+        workExperience: [null, { id: 1, title: 'Engineer' }, 'nope', undefined],
+        personalProjects: [null, { id: 2, name: 'Proj' }],
+      })
+    );
+
+    expect(out.workExperience).toHaveLength(1);
+    expect(out.workExperience?.[0].title).toBe('Engineer');
+    expect(out.personalProjects).toHaveLength(1);
+  });
+
+  it('drops null entries inside a custom itemList', () => {
+    const out = normalizeResumeForSave(
+      malformed({
+        customSections: {
+          custom_1: { sectionType: 'itemList', items: [null, { id: 1, title: 'C' }] },
+        },
+      })
+    );
+
+    expect(out.customSections?.custom_1.items).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Addresses the AI-review findings raised on #903, on top of the now-merged #902.

Targets `dev`, not `main`, so the release stays a plain `dev -> main` merge.

## Crash paths — all reproduced before fixing

```
normalizeStringList(null)       -> null        leaked into a string[] | undefined
item.title?.trim() on a number  -> TypeError   optional chaining does not type-check
(section.items || []).map(...)  -> TypeError   truthy non-array reaches .map
```

Not reachable from the editor, but reachable from hand-edited localStorage or a legacy server row. `normalizeStringList` now treats only `undefined` as absent and coerces every other non-array to `[]`; the three `has*Content` helpers use `isMeaningfulText` instead of optional-chained `.trim()`; array access is guarded with `Array.isArray` rather than `|| []`.

## `isSameResumeData` (P2 — and L-05 from the original review)

It was `JSON.stringify` equality, which is key-order sensitive. A client-authored draft and a Pydantic-serialised server response can hold identical data in different key order and compare unequal — surfacing a "Restore Local Draft?" dialog whose two options are indistinguishable. Since this gates a data-loss decision it now does a structural deep-compare. **Arrays stay order-sensitive**, because order is meaningful for description rows and their parallel `descriptionStyles`.

I deferred this in the original remediation as needing a design decision; the contained fix is comparing correctly, so it is done here.

## Also

- **Clock skew (P3)** — a draft written while the client clock ran ahead stayed recoverable until that future date plus the max age. Future stamps beyond a one-day allowance are now rejected.
- **`handleResetDatabase` (Copilot)** — cleared `localStorage` unguarded, so a context where storage throws aborted the reset *after* the server-side wipe had already succeeded. Routed through `safeStorage`.
- **`getPreviewErrorMessage` (Kilo)** — status-code checks used the original-case string while every other branch used the lowercased copy.

## One finding answered rather than changed

Copilot flagged that the 500ms autosave floor can push a save past `RESUME_AUTOSAVE_MAX_WAIT_MS` (11.9s elapsed -> 0.5s delay). That is intentional and now documented: `MAX_WAIT` is a target for how long edits may stay unsynced, not a hard deadline. Honouring it exactly is precisely what produced one full-document PATCH per keystroke (H-01).

## Verification

```
tsc --noEmit  clean    eslint  clean    prettier  clean    parity  ok, 7 locales
vitest        258 passed (was 248)      pytest  529 passed
next build    clean
```

Adds 10 tests; **six were verified to fail with their fix reverted**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMmBLeE1yEETK1xNWqGCTv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened resume normalization and draft comparison to prevent crashes from malformed data and stop false “Restore Local Draft?” prompts. Adds clock-skew handling, finite timestamp validation, and safer storage cleanup; also aligns preview error checks.

- **Bug Fixes**
  - Normalize robustly: coerce non-array string lists to `[]`, type-check scalars before `.trim()`, guard array access with `Array.isArray`, and drop null/non-object entries inside arrays.
  - Compare drafts structurally instead of via `JSON.stringify` (object key order-insensitive; arrays remain order-sensitive).
  - Reject drafts stamped in the future beyond 1 day and require a finite `updatedAt` to avoid NaN/Infinity slipping past expiry checks.
  - Route settings reset through `safeStorage` and make `localStorage` enumeration best-effort.
  - Match `401`/`429`/`504` against the lowercased error message in `getPreviewErrorMessage`.
  - Clarify that `RESUME_AUTOSAVE_MIN_DELAY_MS` can exceed the remaining max-wait budget by design.

<sup>Written for commit 0b7c31b87a198dd02bba0e02fc992a5e8698410b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

