### PR TITLE
Fix cubic findings on #907 (1 P0, 6 P1)

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -151,14 +151,19 @@ def _normalize_api_base(provider: str, api_base: str | None, model: str | None =
         # would surface as a crash before any LLM error handling. Fall back to
         # the untouched base — a malformed endpoint should fail as a connection
         # error from the provider, not as a ValueError from URL parsing.
-        try:
-            port = parsed.port
-        except ValueError:
-            logging.warning("Invalid port in api_base; leaving it unnormalized")
-            return base
         host = parsed.hostname or ""
         if not host:
             return base
+        try:
+            port: int | None = parsed.port
+        except ValueError:
+            # Malformed port. Do NOT return `base` untouched — it may carry
+            # userinfo, which is exactly the credential leak this rebuild
+            # exists to prevent. Rebuild from the parsed hostname and drop the
+            # bad port; the endpoint then fails as a provider connection error
+            # rather than as a ValueError, and with no secret attached.
+            logging.warning("Invalid port in api_base; dropping it during normalization")
+            port = None
         netloc = f"{host}:{port}" if port else host
         return f"{parsed.scheme}://{netloc}"
 

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -48,6 +48,19 @@ from app.database import db
 # alone left the .env-driven setup path able to persist an unusable config.
 PROVIDERS_REQUIRING_BASE_URL: frozenset[str] = frozenset({"azure_foundry"})
 
+
+def _effective_api_base(stored: dict) -> str | None:
+    """Resolve the base URL the LLM layer will actually use.
+
+    ``stored.get("api_base", default)`` returns None when the key is PRESENT
+    with a null value — which is exactly what an explicit "clear the field"
+    writes. That made validation (which fell back to the env var) disagree with
+    config construction (which did not): saving with LLM_API_BASE set passed
+    the required-base-URL check and then handed api_base=None to LiteLLM.
+    Every site resolves through here so they cannot drift again.
+    """
+    return stored.get("api_base") or settings.llm_api_base or None
+
 router = APIRouter(prefix="/config", tags=["Configuration"])
 
 
@@ -108,7 +121,7 @@ async def get_llm_config_endpoint() -> LLMConfigResponse:
         provider=provider,
         model=stored.get("model", settings.llm_model),
         api_key=_mask_api_key(resolve_api_key(stored, provider)),
-        api_base=stored.get("api_base", settings.llm_api_base),
+        api_base=_effective_api_base(stored),
         reasoning_effort=reasoning_effort or None,
     )
 
@@ -160,7 +173,7 @@ async def update_llm_config(
     # endpoint. Fail at save time with a field name instead of surfacing an
     # opaque LiteLLM error on the user's first generation.
     if resolved_provider in PROVIDERS_REQUIRING_BASE_URL and not (
-        stored.get("api_base") or settings.llm_api_base
+        _effective_api_base(stored)
     ):
         # Structured detail using the same {code, field, missing} shape as
         # update_feature_prompts below, so the UI has one schema to read for
@@ -179,7 +192,7 @@ async def update_llm_config(
         provider=resolved_provider,
         model=stored.get("model", settings.llm_model),
         api_key=resolve_api_key(stored, resolved_provider),
-        api_base=stored.get("api_base", settings.llm_api_base),
+        api_base=_effective_api_base(stored),
         reasoning_effort=resolved_reasoning_effort,
     )
 
@@ -228,7 +241,7 @@ async def test_llm_connection(request: LLMConfigRequest | None = None) -> dict:
         api_base=(
             request.api_base
             if request and request.api_base is not None
-            else stored.get("api_base", settings.llm_api_base)
+            else _effective_api_base(stored)
         ),
         reasoning_effort=(
             (request.reasoning_effort or None)

--- a/apps/backend/tests/integration/test_llm_contract.py
+++ b/apps/backend/tests/integration/test_llm_contract.py
@@ -452,7 +452,22 @@ class TestAzureFoundryTransport:
             "https://example.services.ai.azure.com:abc/openai/v1",
         ):
             out = _normalize_api_base("azure_foundry", bad, "gpt-5-mini")
-            assert out == bad  # left unnormalized, but no exception
+            # Rebuilt from the parsed hostname with the bad port dropped. It
+            # must NOT return the raw input: that path preserved userinfo and
+            # reintroduced the credential leak this rebuild exists to prevent.
+            assert out == "https://example.services.ai.azure.com"
+
+    async def test_malformed_port_does_not_leak_credentials(self):
+        """The malformed-port fallback must still strip userinfo."""
+        from app.llm import _normalize_api_base
+
+        out = _normalize_api_base(
+            "azure_foundry",
+            "https://user:secret@example.services.ai.azure.com:99999/openai/v1",
+            "gpt-5-mini",
+        )
+        assert "secret" not in (out or "")
+        assert out == "https://example.services.ai.azure.com"
 
     async def test_explicit_port_is_preserved(self):
         from app.llm import _normalize_api_base

--- a/apps/frontend/components/builder/resume-builder.tsx
+++ b/apps/frontend/components/builder/resume-builder.tsx
@@ -222,7 +222,13 @@ const ResumeBuilderContent = () => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const resumeId = searchParams.get('id');
+  // Monotonic edit counter. It is deliberately never reset: two savers can be
+  // in flight (a queued manual flush behind an autosave), and resetting it to 0
+  // on whichever finishes first invalidated the other's captured baseline, so a
+  // save that actually succeeded reported failure. "Everything is synced" is
+  // now `editVersionRef === syncedVersionRef`, which no other saver can forge.
   const editVersionRef = useRef(0);
+  const syncedVersionRef = useRef(0);
   const resumeSaveQueueRef = useRef<Promise<void>>(Promise.resolve());
   const unsyncedSinceRef = useRef<number | null>(null);
 
@@ -286,7 +292,7 @@ const ResumeBuilderContent = () => {
           setResumeData(data.processed_resume as ResumeData);
           setLastSavedData(data.processed_resume as ResumeData);
           setHasUnsavedChanges(false);
-          editVersionRef.current = 0;
+          syncedVersionRef.current = editVersionRef.current;
           unsyncedSinceRef.current = null;
         }
       } catch (error) {
@@ -380,7 +386,15 @@ const ResumeBuilderContent = () => {
   }, [hasUnsavedChanges]);
 
   useEffect(() => {
+    // P0: without this, navigating from resume A to resume B before A's GET
+    // resolves lets A's response land under B's id — and because the response
+    // also flips loadingState to 'loaded', autosave then writes A's content
+    // into B. Every state write below is gated on the effect still being
+    // current. (The JD effect below already did this; this one did not.)
+    let cancelled = false;
+
     const loadResumeData = async () => {
+      if (cancelled) return;
       setLoadingState('loading');
       setPendingDraftRestore(null);
 
@@ -388,6 +402,7 @@ const ResumeBuilderContent = () => {
       if (resumeId) {
         try {
           const data = await fetchResume(resumeId);
+          if (cancelled) return;
           // Track if this is a tailored resume (has parent_id)
           setIsTailoredResume(Boolean(data.parent_id));
           // Store resume title for downloads
@@ -408,7 +423,7 @@ const ResumeBuilderContent = () => {
             setResumeData(serverData);
             setLastSavedData(serverData);
             setHasUnsavedChanges(false);
-            editVersionRef.current = 0;
+            syncedVersionRef.current = editVersionRef.current;
             unsyncedSinceRef.current = null;
             setAutoSaveError(null);
             if (shouldPromptForDraftRestore(localDraft, serverData)) {
@@ -428,7 +443,7 @@ const ResumeBuilderContent = () => {
               setResumeData(serverData);
               setLastSavedData(serverData);
               setHasUnsavedChanges(false);
-              editVersionRef.current = 0;
+              syncedVersionRef.current = editVersionRef.current;
               unsyncedSinceRef.current = null;
               setAutoSaveError(null);
               if (shouldPromptForDraftRestore(localDraft, serverData)) {
@@ -443,6 +458,7 @@ const ResumeBuilderContent = () => {
             }
           }
         } catch (err) {
+          if (cancelled) return;
           // Do NOT fall through to the localStorage draft restore below. That
           // path sets hasUnsavedChanges=true, which arms autosave and would
           // PATCH a stale draft over a server copy we failed to read and
@@ -490,6 +506,10 @@ const ResumeBuilderContent = () => {
     };
 
     loadResumeData();
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     improvedData?.data?.job_id,
     improvedData?.data?.resume_id,
@@ -618,7 +638,7 @@ const ResumeBuilderContent = () => {
 
         if (editVersionRef.current === versionAtSchedule) {
           setHasUnsavedChanges(false);
-          editVersionRef.current = 0;
+          syncedVersionRef.current = versionAtSchedule;
           unsyncedSinceRef.current = null;
           clearStoredResumeDraft(resumeId);
         }
@@ -666,9 +686,12 @@ const ResumeBuilderContent = () => {
         setLastSavedData((response?.processed_resume as ResumeData) ?? canonicalPayload);
         setAutoSaveError(null);
 
-        if (editVersionRef.current === versionAtFlush) {
+        // Compare against syncedVersionRef, not a zeroed counter: an autosave
+        // completing ahead of this queued save used to reset the baseline and
+        // make a successful PATCH look like a failure to the caller.
+        syncedVersionRef.current = Math.max(syncedVersionRef.current, versionAtFlush);
+        if (editVersionRef.current === syncedVersionRef.current) {
           setHasUnsavedChanges(false);
-          editVersionRef.current = 0;
           unsyncedSinceRef.current = null;
           setLastAutoSavedAt(Date.now());
           clearStoredResumeDraft(resumeId);
@@ -708,12 +731,29 @@ const ResumeBuilderContent = () => {
   };
 
   const handleReset = () => {
+    const saveInFlight = isSaving || isAutoSaving;
     setResumeData(lastSavedData);
-    setHasUnsavedChanges(false);
-    editVersionRef.current = 0;
-    unsyncedSinceRef.current = null;
+
+    // Bump the version so any save already in flight cannot claim the reset
+    // state as synced when it lands — its captured baseline is now stale.
+    editVersionRef.current += 1;
+
+    if (saveInFlight) {
+      // That in-flight PATCH is carrying the edits we just discarded, so the
+      // server is about to hold content the editor no longer shows. Stay dirty
+      // and let autosave push the reset state, converging the two. Marking this
+      // clean is what left the discarded text on the server silently.
+      setHasUnsavedChanges(true);
+      unsyncedSinceRef.current = Date.now();
+      writeStoredResumeDraft(resumeId, lastSavedData);
+    } else {
+      setHasUnsavedChanges(false);
+      syncedVersionRef.current = editVersionRef.current;
+      unsyncedSinceRef.current = null;
+      clearStoredResumeDraft(resumeId);
+    }
+
     setAutoSaveError(null);
-    clearStoredResumeDraft(resumeId);
   };
 
   const handleRestoreLocalDraft = () => {

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -98,6 +98,12 @@ const hasCustomItemContent = (item: CustomSectionItem): boolean => {
 };
 
 const normalizeCustomSection = (section: CustomSection): CustomSection => {
+  // A persisted customSections entry can be null or a primitive; reading
+  // .sectionType off it throws. Guard the section value, not only its items.
+  if (!isObjectRecord(section)) {
+    return section;
+  }
+
   if (section.sectionType === 'itemList') {
     return {
       ...section,
@@ -140,6 +146,10 @@ export const normalizeResumeForSave = (resume: ResumeData): ResumeData => {
       .filter(isObjectRecord)
       .map(normalizeDescriptionFields)
       .filter(hasProjectContent),
+    // education was the one top-level collection left unguarded, so a null or
+    // primitive entry survived normalization and reached the render path.
+    // Education.description is a scalar, so there are no styles to align here.
+    education: (Array.isArray(resume.education) ? resume.education : []).filter(isObjectRecord),
     additional: resume.additional
       ? {
           ...resume.additional,

--- a/apps/frontend/tests/resume-builder-autosave.test.tsx
+++ b/apps/frontend/tests/resume-builder-autosave.test.tsx
@@ -18,8 +18,10 @@ import React from 'react';
 const fetchResume = vi.fn();
 const updateResume = vi.fn();
 
+let currentSearch = 'id=res-1';
+
 vi.mock('next/navigation', () => ({
-  useSearchParams: () => new URLSearchParams('id=res-1'),
+  useSearchParams: () => new URLSearchParams(currentSearch),
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
 }));
 
@@ -86,6 +88,7 @@ const importBuilder = async () =>
   (await import('@/components/builder/resume-builder')).ResumeBuilder;
 
 beforeEach(() => {
+  currentSearch = 'id=res-1';
   vi.useFakeTimers();
   localStorage.clear();
   fetchResume.mockReset();
@@ -202,6 +205,14 @@ describe('resume builder autosave', () => {
     // And the failure is surfaced rather than silently swallowed.
     expect(screen.getByRole('alert')).toBeInTheDocument();
   });
+
+  // NOTE: the P0 cross-resume race (a superseded load response landing under a
+  // different resume id) is NOT covered here. Reproducing it needs an in-place
+  // navigation with two overlapping in-flight fetches, and every version I
+  // built either passed with the fix reverted or failed with it applied — i.e.
+  // it tested the harness, not the behaviour. Rather than ship a green test
+  // that proves nothing, the gap is recorded. The fix is the `cancelled` flag
+  // in the load effect, mirroring the JD effect directly below it.
 
   it('H-01: the debounce does not collapse to zero while typing over a slow link', async () => {
     fetchResume.mockResolvedValue({ processed_resume: REAL_RESUME, parent_id: null, title: 'r' });

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -235,3 +235,27 @@ describe('normalization robustness — element level', () => {
     expect(out.customSections?.custom_1.items).toHaveLength(1);
   });
 });
+
+describe('normalization robustness — sections and education', () => {
+  const malformed = (over: Record<string, unknown>): ResumeData =>
+    ({ ...baseResume, ...over }) as unknown as ResumeData;
+
+  it('does not throw on a null customSections entry', () => {
+    expect(() =>
+      normalizeResumeForSave(malformed({ customSections: { broken: null, ok: undefined } }))
+    ).not.toThrow();
+  });
+
+  it('drops null and primitive education entries', () => {
+    const out = normalizeResumeForSave(
+      malformed({ education: [null, { id: 1, institution: 'MIT' }, 'nope'] })
+    );
+
+    expect(out.education).toHaveLength(1);
+    expect(out.education?.[0].institution).toBe('MIT');
+  });
+
+  it('does not throw when education is not an array', () => {
+    expect(() => normalizeResumeForSave(malformed({ education: null }))).not.toThrow();
+  });
+});


### PR DESCRIPTION
Addresses all 7 cubic findings from the #907 release review. Targets `dev` so #907 picks them up without a retarget.

## P0 — cross-resume data corruption

The load effect had no cancellation guard. Navigating from resume A to B before A's GET resolved let A's response land under B's id **and** flip `loadingState` to `loaded` — after which autosave wrote A's content into B. The JD effect directly below already used this pattern; the load effect did not.

This is **L-04**, which the original review recorded as non-blocking and which I deferred. That was wrong: it is a data-corruption path, not housekeeping.

## P1 — credential leak I reintroduced

Last round's malformed-port fallback returned the raw base URL, which preserves userinfo:

```
in : https://user:secret@host:99999/openai/v1
out: https://user:secret@host:99999/openai/v1   ← leaked
```

Now rebuilds from the parsed hostname and drops the bad port.

## P1 — the rest

- **`normalizeCustomSection`** dereferenced `section.sectionType` without checking the section value, so a null entry in the persisted dict threw.
- **`education`** was the one top-level collection never normalized; null/primitive entries survived into the payload.
- **`config.py`** resolved `api_base` three different ways. `stored.get("api_base", default)` returns `None` when the key is *present but null* — which is what "clear the field" writes — so validation fell back to the env var while config construction did not. Saving with `LLM_API_BASE` set passed the required-base-URL check and then handed `api_base=None` to LiteLLM. All sites now use `_effective_api_base()`.
- **`editVersionRef`** was reset to 0 by whichever save finished first, invalidating the other's baseline: a queued manual Save behind an autosave reported failure even though its PATCH succeeded. Counter is now monotonic with a separate `syncedVersionRef`.
- **Reset during an in-flight autosave** left the pre-reset edits on the server while the editor showed clean. Reset now invalidates the in-flight save's baseline and stays dirty so autosave converges.

## Verification

```
tsc --noEmit  clean    eslint  clean    prettier  clean    parity  ok
vitest        265 passed            pytest  530 passed (was 529)
next build    clean
```

5 new tests, all verified to fail with their fix reverted.

## One gap, stated rather than hidden

There is **no component test for the P0 race**. Every version I built either passed with the fix reverted or failed with it applied — it was testing the harness, not the behaviour. I removed it and recorded the gap in the test file instead of shipping a green test that proves nothing. The fix itself is the standard `cancelled` flag, mirroring the JD effect in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMmBLeE1yEETK1xNWqGCTv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 7 findings from #907, including a P0 cross-resume data corruption race. Improves save concurrency, prevents credential leaks, and hardens normalization.

- **Bug Fixes**
  - Cancel stale resume loads to stop cross-resume writes; gate state updates with a `cancelled` flag.
  - Make save versioning monotonic with `syncedVersionRef`; fix queued Save vs autosave and Reset during in-flight save so editor and server converge.
  - Prevent credential leak on malformed `api_base` ports by rebuilding from hostname and dropping the bad port.
  - Resolve `api_base` via `_effective_api_base()` everywhere so validation and runtime agree; enforce for `azure_foundry`.
  - Normalize inputs more defensively: guard `customSections` entries and filter `education` to objects only.

<sup>Written for commit e82f5fac3ecbe45b186dfdc8184d884588746676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

