### PR TITLE
fix: #909 deferred finding #3 (api_base null bug) and #4 (customSections filter)

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -483,7 +483,7 @@ def get_llm_config() -> LLMConfig:
         provider=provider,
         model=model,
         api_key=api_key,
-        api_base=stored.get("api_base", settings.llm_api_base),
+        api_base=stored.get("api_base") or settings.llm_api_base or None,
         api_version=stored.get("api_version"),
         reasoning_effort=reasoning_effort,
     )

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -11,6 +11,7 @@ from app.llm import (
     _get_retry_temperature,
     _normalize_api_base,
     _supports_temperature,
+    get_llm_config,
     get_model_name,
     resolve_api_key,
 )
@@ -704,3 +705,67 @@ class TestScrubSecrets:
         assert "sk-abcd1234efgh5678" not in _scrub_secrets("key sk-abcd1234efgh5678 failed")
         assert "AIzaSyABCDEFGHIJ" not in _scrub_secrets("key AIzaSyABCDEFGHIJ failed")
         assert "tok_secret" not in _scrub_secrets("Authorization: Bearer tok_secret")
+
+
+class TestGetLlmConfigApiBase:
+    """Present-but-null api_base must fall back to the env default (issue #909 #3).
+
+    ``stored.get("api_base", default)`` returns None when the key is present
+    with a null value — which is exactly what an explicit "clear the Base URL"
+    writes. The router's ``_effective_api_base`` already handles this; the
+    runtime path in llm.py must agree so a cleared Base URL falls back to
+    LLM_API_BASE instead of reaching LiteLLM as None.
+    """
+
+    def test_present_null_api_base_falls_back_to_env_default(self, monkeypatch):
+        from app.llm import get_llm_config
+
+        class FakeSettings:
+            llm_provider = "openai"
+            llm_model = "gpt-4o"
+            llm_api_key = "env-key"
+            llm_api_base = "https://env-default.example/v1"
+            reasoning_effort = None
+
+        monkeypatch.setattr("app.llm.load_config_file", lambda: {"api_base": None})
+        monkeypatch.setattr("app.llm.settings", FakeSettings())
+
+        config = get_llm_config()
+
+        assert config.api_base == "https://env-default.example/v1"
+
+    def test_explicit_stored_api_base_wins_over_env_default(self, monkeypatch):
+        from app.llm import get_llm_config
+
+        class FakeSettings:
+            llm_provider = "openai"
+            llm_model = "gpt-4o"
+            llm_api_key = "env-key"
+            llm_api_base = "https://env-default.example/v1"
+            reasoning_effort = None
+
+        monkeypatch.setattr(
+            "app.llm.load_config_file", lambda: {"api_base": "https://stored.example/v1"}
+        )
+        monkeypatch.setattr("app.llm.settings", FakeSettings())
+
+        config = get_llm_config()
+
+        assert config.api_base == "https://stored.example/v1"
+
+    def test_absent_api_base_key_uses_env_default(self, monkeypatch):
+        from app.llm import get_llm_config
+
+        class FakeSettings:
+            llm_provider = "openai"
+            llm_model = "gpt-4o"
+            llm_api_key = "env-key"
+            llm_api_base = "https://env-default.example/v1"
+            reasoning_effort = None
+
+        monkeypatch.setattr("app.llm.load_config_file", lambda: {})
+        monkeypatch.setattr("app.llm.settings", FakeSettings())
+
+        config = get_llm_config()
+
+        assert config.api_base == "https://env-default.example/v1"

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -4,6 +4,7 @@ import type {
   Experience,
   Project,
   ResumeData,
+  SectionType,
 } from '@/components/dashboard/resume-component';
 
 type DescribedItem = {
@@ -30,6 +31,21 @@ const normalizeStringList = (items?: unknown): string[] | undefined => {
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
+
+// Mirrors the backend `SectionType` enum (apps/backend/app/schemas/models.py):
+// CustomSection validation fails on any other value, so a persisted entry with
+// a missing or bogus sectionType must be dropped, not passed through.
+const CUSTOM_SECTION_TYPES: ReadonlySet<string> = new Set<SectionType>([
+  'personalInfo',
+  'text',
+  'itemList',
+  'stringList',
+]);
+
+const isCustomSectionRecord = (value: unknown): value is CustomSection =>
+  isObjectRecord(value) &&
+  typeof value.sectionType === 'string' &&
+  CUSTOM_SECTION_TYPES.has(value.sectionType);
 
 const normalizeDescriptionFields = <T extends DescribedItem>(item: T): T => {
   // A null element inside an otherwise-valid array throws on property access.
@@ -134,8 +150,12 @@ export const normalizeResumeForSave = (resume: ResumeData): ResumeData => {
           // normalizeCustomSection returns null/primitive sections unchanged;
           // dropping them here keeps them out of the PATCH payload, where they
           // would fail backend CustomSection validation and crash consumers
-          // doing Object.entries(customSections) -> .sectionType.
-          .filter((entry): entry is readonly [string, CustomSection] => isObjectRecord(entry[1]))
+          // doing Object.entries(customSections) -> .sectionType. Object-ness
+          // alone is not enough — an entry must also carry a sectionType the
+          // backend schema actually accepts.
+          .filter((entry): entry is readonly [string, CustomSection] =>
+            isCustomSectionRecord(entry[1])
+          )
       )
     : resume.customSections;
 

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -32,20 +32,24 @@ const normalizeStringList = (items?: unknown): string[] | undefined => {
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-// Mirrors the backend `SectionType` enum (apps/backend/app/schemas/models.py):
-// CustomSection validation fails on any other value, so a persisted entry with
-// a missing or bogus sectionType must be dropped, not passed through.
-const CUSTOM_SECTION_TYPES: ReadonlySet<string> = new Set<SectionType>([
-  'personalInfo',
-  'text',
-  'itemList',
-  'stringList',
-]);
+// Exhaustive map keyed on the frontend `SectionType` union (which mirrors the
+// backend `SectionType` enum in apps/backend/app/schemas/models.py). A Record
+// keyed by SectionType makes TypeScript fail to compile if the union grows and
+// this map is not updated — so a new backend section type can never be silently
+// dropped from the save payload. CustomSection validation fails on any value
+// outside the union, so a persisted entry with a missing or bogus sectionType
+// must still be dropped, not passed through.
+const CUSTOM_SECTION_TYPES: Record<SectionType, true> = {
+  personalInfo: true,
+  text: true,
+  itemList: true,
+  stringList: true,
+};
 
 const isCustomSectionRecord = (value: unknown): value is CustomSection =>
   isObjectRecord(value) &&
   typeof value.sectionType === 'string' &&
-  CUSTOM_SECTION_TYPES.has(value.sectionType);
+  CUSTOM_SECTION_TYPES[value.sectionType as SectionType] === true;
 
 const normalizeDescriptionFields = <T extends DescribedItem>(item: T): T => {
   // A null element inside an otherwise-valid array throws on property access.

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -39,7 +39,7 @@ const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
 // dropped from the save payload. CustomSection validation fails on any value
 // outside the union, so a persisted entry with a missing or bogus sectionType
 // must still be dropped, not passed through.
-const CUSTOM_SECTION_TYPES: Record<SectionType, true> = {
+const CUSTOM_SECTION_TYPES: Readonly<Record<SectionType, true>> = {
   personalInfo: true,
   text: true,
   itemList: true,

--- a/apps/frontend/lib/utils/resume-normalization.ts
+++ b/apps/frontend/lib/utils/resume-normalization.ts
@@ -129,10 +129,13 @@ const normalizeCustomSection = (section: CustomSection): CustomSection => {
 export const normalizeResumeForSave = (resume: ResumeData): ResumeData => {
   const customSections = resume.customSections
     ? Object.fromEntries(
-        Object.entries(resume.customSections).map(([key, section]) => [
-          key,
-          normalizeCustomSection(section),
-        ])
+        Object.entries(resume.customSections)
+          .map(([key, section]) => [key, normalizeCustomSection(section)] as const)
+          // normalizeCustomSection returns null/primitive sections unchanged;
+          // dropping them here keeps them out of the PATCH payload, where they
+          // would fail backend CustomSection validation and crash consumers
+          // doing Object.entries(customSections) -> .sectionType.
+          .filter((entry): entry is readonly [string, CustomSection] => isObjectRecord(entry[1]))
       )
     : resume.customSections;
 

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -266,6 +266,62 @@ describe('normalization robustness — sections and education', () => {
     expect(out.customSections?.ok).toEqual({ sectionType: 'stringList', strings: ['Real'] });
   });
 
+  it('drops customSections entries whose sectionType is missing', () => {
+    const out = normalizeResumeForSave(
+      malformed({
+        customSections: {
+          noType: { foo: 'bar' },
+          empty: {},
+          ok: { sectionType: 'itemList', items: [{ id: 1, title: 'Real' }] },
+        },
+      })
+    );
+
+    expect(out.customSections?.noType).toBeUndefined();
+    expect(out.customSections?.empty).toBeUndefined();
+    expect(out.customSections?.ok).toEqual({
+      sectionType: 'itemList',
+      items: [{ id: 1, title: 'Real', description: [] }],
+    });
+  });
+
+  it('drops customSections entries with an invalid sectionType', () => {
+    const out = normalizeResumeForSave(
+      malformed({
+        customSections: {
+          bogus: { sectionType: 'bogus', items: [] },
+          ok: { sectionType: 'stringList', strings: ['Real'] },
+        },
+      })
+    );
+
+    expect(out.customSections?.bogus).toBeUndefined();
+    expect(out.customSections?.ok).toEqual({ sectionType: 'stringList', strings: ['Real'] });
+  });
+
+  it('keeps valid itemList and stringList customSections with content intact', () => {
+    const out = normalizeResumeForSave(
+      malformed({
+        customSections: {
+          item: {
+            sectionType: 'itemList',
+            items: [{ id: 1, title: 'A', description: ['', 'Kept'] }],
+          },
+          list: { sectionType: 'stringList', strings: ['One', '  Two  '] },
+        },
+      })
+    );
+
+    expect(out.customSections?.item).toEqual({
+      sectionType: 'itemList',
+      items: [{ id: 1, title: 'A', description: ['Kept'] }],
+    });
+    expect(out.customSections?.list).toEqual({
+      sectionType: 'stringList',
+      strings: ['One', 'Two'],
+    });
+  });
+
   it('drops null and primitive education entries', () => {
     const out = normalizeResumeForSave(
       malformed({ education: [null, { id: 1, institution: 'MIT' }, 'nope'] })

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -299,10 +299,12 @@ describe('normalization robustness — sections and education', () => {
     expect(out.customSections?.ok).toEqual({ sectionType: 'stringList', strings: ['Real'] });
   });
 
-  it('keeps valid itemList and stringList customSections with content intact', () => {
+  it('keeps every SectionType union member with content intact', () => {
     const out = normalizeResumeForSave(
       malformed({
         customSections: {
+          info: { sectionType: 'personalInfo', text: 'Header' },
+          text: { sectionType: 'text', text: 'Body' },
           item: {
             sectionType: 'itemList',
             items: [{ id: 1, title: 'A', description: ['', 'Kept'] }],
@@ -312,6 +314,8 @@ describe('normalization robustness — sections and education', () => {
       })
     );
 
+    expect(out.customSections?.info).toEqual({ sectionType: 'personalInfo', text: 'Header' });
+    expect(out.customSections?.text).toEqual({ sectionType: 'text', text: 'Body' });
     expect(out.customSections?.item).toEqual({
       sectionType: 'itemList',
       items: [{ id: 1, title: 'A', description: ['Kept'] }],

--- a/apps/frontend/tests/resume-normalization.test.ts
+++ b/apps/frontend/tests/resume-normalization.test.ts
@@ -246,6 +246,26 @@ describe('normalization robustness — sections and education', () => {
     ).not.toThrow();
   });
 
+  it('drops null and primitive customSections entries from the save payload', () => {
+    const out = normalizeResumeForSave(
+      malformed({
+        customSections: {
+          broken: null,
+          primitive: 'nope',
+          array: ['not', 'a', 'section'],
+          ok: { sectionType: 'stringList', strings: ['Real'] },
+        },
+      })
+    );
+
+    // Invalid entries must not reach the backend (CustomSection validation
+    // fails on them) nor crash consumers doing Object.entries -> .sectionType.
+    expect(out.customSections?.broken).toBeUndefined();
+    expect(out.customSections?.primitive).toBeUndefined();
+    expect(out.customSections?.array).toBeUndefined();
+    expect(out.customSections?.ok).toEqual({ sectionType: 'stringList', strings: ['Real'] });
+  });
+
   it('drops null and primitive education entries', () => {
     const out = normalizeResumeForSave(
       malformed({ education: [null, { id: 1, institution: 'MIT' }, 'nope'] })


### PR DESCRIPTION
## Summary

Closes #909 items **#3** and **#4** from the code-review remediation cycle — both are the "mechanical, low risk, independently mergeable" follow-ups the maintainer flagged.

### #3 — `get_llm_config()` present-but-null `api_base` bug (backend)

`apps/backend/app/llm.py:486` used `stored.get("api_base", settings.llm_api_base)`. `dict.get(key, default)` returns `None` when the key is **present with a null value** — exactly what an explicit "clear the Base URL" writes. So a cleared Base URL reached LiteLLM as `None` instead of falling back to `LLM_API_BASE`.

`#908` introduced `_effective_api_base()` in `routers/config.py` and routed every site there, but missed the runtime path. Now matches the router:

```python
api_base=stored.get("api_base") or settings.llm_api_base or None,
```

### #4 — Invalid `customSections` entries are guarded but not dropped (frontend)

`apps/frontend/lib/utils/resume-normalization.ts`: `normalizeCustomSection` no longer throws on a null/primitive section value, but returns it unchanged — so those values still reached the backend (failing `CustomSection` validation) and crashed consumers doing `Object.entries(customSections)` → `.sectionType`.

`normalizeResumeForSave` now filters invalid entries out of the dict before building the PATCH payload.

## Tests

- Backend: `tests/unit/test_llm.py` — added 3 `api_base` regression cases; full `tests/unit` suite **341 passed**
- Frontend: `tests/resume-normalization.test.ts` — added a customSections filter case; **17 passed**
- `tsc --noEmit` 0 errors, eslint clean on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two issues from #909: a null `api_base` now falls back correctly, and invalid `customSections` are filtered before saving. The `SectionType`-keyed allowlist is now read-only to prevent mutation and ensure future types aren’t dropped.

- **Bug Fixes**
  - Backend: `get_llm_config()` treats present-but-null `api_base` as unset and falls back to `settings.llm_api_base`, matching router logic.
  - Frontend: `normalizeResumeForSave` drops invalid `customSections` (null/primitive, arrays, or missing/invalid `sectionType`) using a read-only allowlist keyed by `SectionType` for compile-time coverage.

<sup>Written for commit b06f0c17db792fec9c93861fa3227da0b53e5e4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

