### PR TITLE
fix(frontend): replace SSR sanitizer to avoid Next.js crash

### DIFF
--- a/apps/frontend/components/resume/safe-html.tsx
+++ b/apps/frontend/components/resume/safe-html.tsx
@@ -3,10 +3,10 @@ import { sanitizeHtml } from '@/lib/utils/html-sanitizer';
 import { cn } from '@/lib/utils';
 
 // No 'use client' — this component does no client-only work (no hooks, no
-// event handlers, no browser APIs). Sanitization runs on the server via
-// isomorphic-dompurify. Parent resume templates (resume-single-column,
-// resume-modern, etc.) are also Server Components, so this can render on
-// the server and stays out of the client bundle.
+// event handlers, no browser APIs). Sanitization runs on the server with a
+// strict whitelist parser so the resume templates remain SSR-safe. Parent
+// resume templates (resume-single-column, resume-modern, etc.) are also
+// Server Components, so this stays out of the client bundle.
 
 interface SafeHtmlProps {
   /** HTML content to render (will be sanitized) */
@@ -20,7 +20,7 @@ interface SafeHtmlProps {
 /**
  * Safe HTML Renderer Component
  *
- * Renders HTML content with XSS protection via DOMPurify.
+ * Renders HTML content with XSS protection via a strict whitelist parser.
  * Only allows: <strong>, <em>, <u>, <a> tags.
  *
  * Used in resume templates to render formatted bullet points.

--- a/apps/frontend/lib/utils/html-sanitizer.ts
+++ b/apps/frontend/lib/utils/html-sanitizer.ts
@@ -119,15 +119,20 @@ function isSafeUrl(value: string): boolean {
     return false;
   }
 
-  const normalized = trimmed.toLowerCase();
+  // Decode numeric HTML character references (decimal & hex) before checking scheme
+  let decoded = trimmed.replace(
+    /&#(?:x([0-9a-f]+)|(\d+));?/gi,
+    (_, hex, dec) => String.fromCharCode(parseInt(hex ?? dec, hex ? 16 : 10))
+  );
+
+  // Reject URLs that contain control characters which browsers may ignore inside schemes
+  if (/[\x00-\x1f\x7f]/.test(decoded)) {
+    return false;
+  }
+
+  const normalized = decoded.toLowerCase();
   return !['javascript:', 'data:', 'vbscript:'].some((prefix) => normalized.startsWith(prefix));
 }
-
-function normalizeRel(value: string): string {
-  return value
-    .split(/\s+/)
-    .map((item) => item.trim().toLowerCase())
-    .filter((item) => item && SAFE_REL_VALUES.has(item))
     .join(' ');
 }
 

--- a/apps/frontend/lib/utils/html-sanitizer.ts
+++ b/apps/frontend/lib/utils/html-sanitizer.ts
@@ -1,27 +1,136 @@
-import DOMPurify from 'isomorphic-dompurify';
-
 /**
- * Whitelist of allowed HTML tags for rich text content
+ * Whitelist of allowed HTML tags for rich text content.
  */
-const ALLOWED_TAGS = ['strong', 'em', 'u', 'a'];
+const ALLOWED_TAGS = ['strong', 'em', 'u', 'a'] as const;
 
 /**
- * Whitelist of allowed HTML attributes
+ * Whitelist of allowed HTML attributes.
  */
-const ALLOWED_ATTR = ['href', 'target', 'rel'];
+const ALLOWED_ATTRS = ['href', 'target', 'rel'] as const;
+
+const SAFE_REL_VALUES = new Set(['noopener', 'noreferrer', 'nofollow', 'external', 'ugc', 'sponsored']);
+const BLOCKED_TAGS = new Set(['script', 'style', 'iframe', 'object', 'embed', 'link', 'meta', 'svg', 'math', 'img', 'video', 'audio', 'source', 'track', 'canvas', 'form', 'input', 'button', 'select', 'textarea', 'option', 'noscript']);
 
 /**
- * Sanitizes HTML content using DOMPurify with a strict whitelist.
+ * Sanitizes HTML content with a strict whitelist.
  * Only allows bold, italic, underline, and link formatting.
- * Uses isomorphic-dompurify which works in both browser and Node.js.
  *
  * @param dirty - The unsanitized HTML string
  * @returns Sanitized HTML string safe for rendering
  */
 export function sanitizeHtml(dirty: string): string {
-  return DOMPurify.sanitize(dirty, {
-    ALLOWED_TAGS,
-    ALLOWED_ATTR,
-    FORCE_BODY: true,
+  if (!dirty) {
+    return '';
+  }
+
+  let skipDepth = 0;
+  let currentBlockedTag = '';
+
+  return dirty.replace(/<!--([\s\S]*?)-->|<\/?([a-zA-Z0-9:-]+)([^>]*)>/g, (match, comment, tagName, attributes) => {
+    if (comment !== undefined) {
+      return '';
+    }
+
+    const normalizedTag = tagName.toLowerCase();
+    const isClosingTag = match.startsWith('</');
+
+    if (skipDepth > 0) {
+      if (isClosingTag && normalizedTag === currentBlockedTag) {
+        skipDepth -= 1;
+        currentBlockedTag = skipDepth > 0 ? currentBlockedTag : '';
+      }
+      return '';
+    }
+
+    if (BLOCKED_TAGS.has(normalizedTag)) {
+      if (!isClosingTag) {
+        skipDepth = 1;
+        currentBlockedTag = normalizedTag;
+      }
+      return '';
+    }
+
+    if (!ALLOWED_TAGS.includes(normalizedTag as (typeof ALLOWED_TAGS)[number])) {
+      return '';
+    }
+
+    if (isClosingTag) {
+      return `</${normalizedTag}>`;
+    }
+
+    if (normalizedTag === 'a') {
+      const sanitizedAttrs = sanitizeAttributes(attributes);
+      return sanitizedAttrs ? `<a${sanitizedAttrs}>` : '<a>';
+    }
+
+    return `<${normalizedTag}>`;
   });
+}
+
+function sanitizeAttributes(attributes: string): string {
+  if (!attributes) {
+    return '';
+  }
+
+  const cleaned: string[] = [];
+  const attrPattern = /([a-zA-Z_:][\w:.-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = attrPattern.exec(attributes)) !== null) {
+    const [, rawName, doubleQuoted, singleQuoted, bareValue] = match;
+    const name = rawName.toLowerCase();
+    const value = doubleQuoted ?? singleQuoted ?? bareValue ?? '';
+
+    if (!ALLOWED_ATTRS.includes(name as (typeof ALLOWED_ATTRS)[number])) {
+      continue;
+    }
+
+    if (name === 'href') {
+      if (!isSafeUrl(value)) {
+        continue;
+      }
+
+      cleaned.push(` href="${escapeAttribute(value)}"`);
+      continue;
+    }
+
+    if (name === 'target') {
+      const normalizedTarget = value.trim().toLowerCase();
+      if (['_blank', '_self', '_parent', '_top'].includes(normalizedTarget)) {
+        cleaned.push(` target="${normalizedTarget}"`);
+      }
+      continue;
+    }
+
+    if (name === 'rel') {
+      const normalizedRel = normalizeRel(value);
+      if (normalizedRel) {
+        cleaned.push(` rel="${normalizedRel}"`);
+      }
+    }
+  }
+
+  return cleaned.join('');
+}
+
+function isSafeUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const normalized = trimmed.toLowerCase();
+  return !['javascript:', 'data:', 'vbscript:'].some((prefix) => normalized.startsWith(prefix));
+}
+
+function normalizeRel(value: string): string {
+  return value
+    .split(/\s+/)
+    .map((item) => item.trim().toLowerCase())
+    .filter((item) => item && SAFE_REL_VALUES.has(item))
+    .join(' ');
+}
+
+function escapeAttribute(value: string): string {
+  return value.replace(/"/g, '&quot;');
 }

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -16,7 +16,6 @@
         "@tiptap/react": "^3.20.0",
         "@tiptap/starter-kit": "^3.20.0",
         "clsx": "^2.1.1",
-        "isomorphic-dompurify": "^3.19.0",
         "lucide-react": "^0.575.0",
         "next": "^16.2.12",
         "react": "^19.2.4",
@@ -74,6 +73,7 @@
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
@@ -114,6 +114,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -123,6 +124,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -421,6 +423,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.0"
@@ -433,6 +436,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
       "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -452,6 +456,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
       "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -475,6 +480,7 @@
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
       "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -502,6 +508,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -524,6 +531,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
       "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -548,6 +556,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -797,6 +806,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -3008,13 +3018,6 @@
         "@types/react": "^19.2.0"
       }
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -4144,6 +4147,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -4382,6 +4386,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -4441,6 +4446,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -4526,6 +4532,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -4612,15 +4619,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4668,6 +4666,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -5872,6 +5871,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -6260,6 +6260,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -6420,84 +6421,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isomorphic-dompurify": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.19.0.tgz",
-      "integrity": "sha512-ynZ/6cVv4Trpt1FEd5TkHsHtLs+y/YQGb+ocIIVRdc+DkiYRbxlEL/IiSeSeQXwopQcG5FhoeIUJa1l26IgSpw==",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "^3.4.12",
-        "jsdom": "^29.1.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/jsdom": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
-        "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
-        "css-tree": "^3.2.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
-        "parse5": "^8.0.1",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -7074,6 +6997,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/merge2": {
@@ -7492,6 +7416,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^8.0.0"
@@ -7822,6 +7747,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7949,6 +7875,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8139,6 +8066,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -8628,6 +8556,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -8756,6 +8685,7 @@
       "version": "7.4.9",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
       "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.4.9"
@@ -8768,6 +8698,7 @@
       "version": "7.4.9",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
       "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -8787,6 +8718,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
       "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -8799,6 +8731,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -9013,6 +8946,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -9317,6 +9251,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -9329,6 +9264,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -9338,6 +9274,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -9347,6 +9284,7 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
@@ -9493,6 +9431,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -9502,6 +9441,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yallist": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -20,7 +20,6 @@
     "@tiptap/react": "^3.20.0",
     "@tiptap/starter-kit": "^3.20.0",
     "clsx": "^2.1.1",
-    "isomorphic-dompurify": "^3.19.0",
     "lucide-react": "^0.575.0",
     "next": "^16.2.12",
     "react": "^19.2.4",

--- a/apps/frontend/tests/html-sanitizer.test.ts
+++ b/apps/frontend/tests/html-sanitizer.test.ts
@@ -39,6 +39,12 @@ describe('sanitizeHtml', () => {
     expect(out).toContain('plain text');
   });
 
+  it('drops unsafe javascript links', () => {
+    const out = sanitizeHtml('<a href="javascript:alert(1)">click</a>');
+    expect(out).not.toContain('javascript:');
+    expect(out).toContain('click');
+  });
+
   it('drops dangerous tags like <img onerror>', () => {
     const out = sanitizeHtml('<img src=x onerror="alert(1)">');
     expect(out).not.toContain('img');


### PR DESCRIPTION


## Pull Request Title

fix(frontend): replace SSR sanitizer to prevent Next.js resume rendering crashes

## Related Issue

N/A

## Description

This PR fixes a frontend SSR crash affecting the builder and print resume views. The previous sanitizer implementation relied on a DOMPurify-based dependency path that was incompatible with the current Node runtime and caused Next.js to fail during server-side rendering. The fix replaces it with a lightweight whitelist-based sanitizer that is SSR-safe and preserves the intended formatting behavior for bold, italic, underline, and links.

## Type

- [x] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes

- Replaced the fragile DOMPurify-based SSR sanitizer with a lightweight whitelist sanitizer
- Removed the incompatible dependency from the frontend package setup
- Updated the resume-safe HTML renderer to reflect the new SSR-safe sanitization approach
- Added regression coverage for unsafe link handling in the sanitizer tests

## Screenshots 

<img width="1306" height="605" alt="image" src="https://github.com/user-attachments/assets/2263637b-6c6e-4f40-b6df-aeaf077ddec8" />

## How to Test

1. Start the frontend app with `npm run dev`
2. Open the builder or print resume page
3. Confirm the page renders without the previous SSR crash
4. Optionally test rich text content with bold/italic/underline/links to ensure formatting still renders correctly

## Checklist

- [x] The code compiles successfully without any errors or warnings
- [x] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [x] The changes follow the project's coding guidelines and best practices
- [x] The commit messages are descriptive and follow the project's guidelines
- [x] All tests (if applicable) pass successfully
- [ ] This pull request has been linked to the related issue (if applicable)

## Additional Information

Verified with:
- `npm run typecheck`
- `curl -I http://127.0.0.1:3000` returning `HTTP/1.1 200 OK`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the SSR HTML sanitizer with a lightweight whitelist parser to stop `next` rendering crashes in the resume builder and print views. Keeps bold, italic, underline, and link formatting.

- **Bug Fixes**
  - Implemented server-safe sanitizer that strips blocked tags/comments, removes nested blocked content, validates `href`, `target`, `rel`, and hardens URL checks (decodes char refs, rejects control chars, blocks `javascript:`/`data:`/`vbscript:`).
  - Updated the resume-safe HTML renderer to use the new sanitizer.
  - Added tests for unsafe links and dangerous tags.

- **Dependencies**
  - Removed `isomorphic-dompurify` from the frontend.

<sup>Written for commit da13ed5344ee31d5b3d804a434d08c8640bd9a6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

