### PR TITLE
add Claude Code CLI as a local LLM provider

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,10 +2,13 @@
 # LLM Provider Configuration
 # ===========================================
 # Supported providers:
-#   openai, openai_compatible, azure_foundry, anthropic, openrouter, gemini, deepseek, groq, ollama
+#   openai, openai_compatible, azure_foundry, anthropic, openrouter, gemini,
+#   deepseek, groq, ollama, claude_cli
 # openai_compatible = llama.cpp, vLLM, LM Studio, and any self-hosted server
 # that exposes the OpenAI Chat Completions API. API key is optional for this
 # provider (backend passes a sentinel when blank).
+# claude_cli = local Claude Code CLI (`claude -p`), uses your Claude login —
+# no Anthropic API key. Requires `claude` on PATH (or CLAUDE_CLI_PATH).
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-5-nano-2025-08-07
 LLM_API_KEY=sk-your-api-key-here
@@ -47,6 +50,12 @@ LLM_API_KEY=sk-your-api-key-here
 # LLM_PROVIDER=anthropic
 # LLM_MODEL=claude-haiku-4-5-20251001
 # LLM_API_KEY=sk-ant-your-key
+
+# For Claude Code CLI (local; Multica-style — uses `claude auth login`, no API key)
+# LLM_PROVIDER=claude_cli
+# LLM_MODEL=sonnet
+# LLM_API_KEY=
+# Optional: CLAUDE_CLI_PATH=/full/path/to/claude
 
 # For Google Gemini
 # LLM_PROVIDER=gemini

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -216,6 +216,7 @@ class Settings(BaseSettings):
         "deepseek",
         "groq",
         "ollama",
+        "claude_cli",
     ] = "openai"
     llm_model: str = "gpt-5-nano-2025-08-07"
     llm_api_key: str = ""

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -13,6 +13,11 @@ from litellm.router import RetryPolicy
 from pydantic import BaseModel
 
 from app.config import load_config_file, save_config_file, settings
+from app.providers.claude_cli import (
+    ClaudeCLIError,
+    check_claude_cli_health,
+    complete_claude_cli,
+)
 
 LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
 
@@ -399,13 +404,16 @@ _PROVIDER_KEY_MAP: dict[str, str] = {
 }
 
 
-# Providers where the user commonly runs a local server without auth. For
+# Providers where the user commonly runs a local server / CLI without auth. For
 # these, we MUST NOT fall back to ``settings.llm_api_key`` (the env-level
 # default), because the env var may hold a real paid-API key that would then
 # leak to a local/compatible endpoint the user set up expecting no auth.
+#
+# Also exported as LOCAL_NO_KEY_PROVIDERS for health/status/eval gates.
 _PROVIDERS_WITHOUT_ENV_KEY_FALLBACK: frozenset[str] = frozenset(
-    {"openai_compatible", "ollama"}
+    {"openai_compatible", "ollama", "claude_cli"}
 )
+LOCAL_NO_KEY_PROVIDERS: frozenset[str] = _PROVIDERS_WITHOUT_ENV_KEY_FALLBACK
 
 
 def resolve_api_key(stored: dict, provider: str) -> str:
@@ -413,9 +421,9 @@ def resolve_api_key(stored: dict, provider: str) -> str:
 
     Priority: top-level ``api_key`` > ``api_keys[provider]`` > env/settings
     default — EXCEPT for providers in ``_PROVIDERS_WITHOUT_ENV_KEY_FALLBACK``
-    (``openai_compatible`` / ``ollama``), where the env-level default is
-    skipped so a paid OpenAI key in ``LLM_API_KEY`` cannot leak to a local
-    self-hosted server when the user leaves the provider key blank.
+    (``openai_compatible`` / ``ollama`` / ``claude_cli``), where the env-level
+    default is skipped so a paid OpenAI key in ``LLM_API_KEY`` cannot leak to a
+    local self-hosted server / CLI when the user leaves the provider key blank.
 
     This is the single source of truth for key resolution. Every code path
     that needs an API key (runtime, config display, health check, test
@@ -646,17 +654,40 @@ async def check_llm_health(
     if config is None:
         config = get_llm_config()
 
-    # Check if API key is configured. Ollama and openai_compatible local
-    # servers often run without auth, so a blank key is acceptable for those
-    # providers — a sentinel is passed downstream (see _effective_api_key)
-    # to satisfy the OpenAI client's non-empty-string validation.
-    if config.provider not in ("ollama", "openai_compatible") and not config.api_key:
+    # Check if API key is configured. Local providers (Ollama, openai_compatible,
+    # Claude CLI) run without a paid API key — a blank key is acceptable.
+    # For openai_compatible a sentinel is passed downstream (see
+    # _effective_api_key) to satisfy the OpenAI client's non-empty-string check.
+    if config.provider not in LOCAL_NO_KEY_PROVIDERS and not config.api_key:
         return {
             "healthy": False,
             "provider": config.provider,
             "model": config.model,
             "error_code": "api_key_missing",
         }
+
+    # Claude Code CLI path — Multica-style local ``claude -p``, no LiteLLM.
+    if config.provider == "claude_cli":
+        cli_result = await check_claude_cli_health(
+            model=config.model or "sonnet",
+            test_prompt=test_prompt,
+            timeout=float(LLM_TIMEOUT_HEALTH_CHECK),
+        )
+        result: dict[str, Any] = {
+            "healthy": bool(cli_result.get("healthy")),
+            "provider": "claude_cli",
+            "model": config.model,
+            "response_model": cli_result.get("response_model"),
+        }
+        if not result["healthy"]:
+            result["error_code"] = cli_result.get("error_code", "cli_error")
+            result["message"] = cli_result.get("message", "Claude CLI unhealthy")
+        if include_details:
+            result["test_prompt"] = _to_code_block(test_prompt or "Reply with exactly: OK")
+            result["model_output"] = _to_code_block(cli_result.get("content"))
+            if not result["healthy"] and cli_result.get("message"):
+                result["error_detail"] = _to_code_block(str(cli_result["message"]))
+        return result
 
     model_name = get_model_name(config)
 
@@ -772,6 +803,31 @@ async def complete(
 
     Transport retries (429, 500, timeout) are handled by the Router.
     """
+    if config is None:
+        config = get_llm_config()
+
+    if config.provider == "claude_cli":
+        try:
+            content = await complete_claude_cli(
+                prompt,
+                system_prompt=system_prompt,
+                model=config.model or "sonnet",
+                timeout=float(
+                    _calculate_timeout("completion", max_tokens, config.provider)
+                ),
+            )
+        except ClaudeCLIError as e:
+            logging.error("Claude CLI completion failed: %s", e)
+            raise ValueError(
+                "LLM completion failed. Please check your Claude CLI setup "
+                "(`claude auth login`) and try again."
+            ) from e
+        if "<think>" in content:
+            content = _strip_thinking_tags(content)
+            if not content:
+                raise ValueError("Response contained only thinking content, no output")
+        return content
+
     router, config = get_router(config)
     model_name = get_model_name(config)
 
@@ -1076,6 +1132,7 @@ def _calculate_timeout(
         "openrouter": 1.5,  # More variable latency
         "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower
+        "claude_cli": 2.0,  # Local CLI spawn + subscription latency
     }
     provider_factor = provider_factors.get(provider, 1.0)
 
@@ -1181,6 +1238,112 @@ def _extract_json(content: str, _depth: int = 0) -> str:
     raise ValueError(f"No JSON found in response: {original[:200]}")
 
 
+def _truncation_retry_hint(schema_type: str) -> str:
+    """Prompt suffix used when parsed JSON looks truncated."""
+    if schema_type == "resume":
+        return (
+            "\n\nIMPORTANT: Output the COMPLETE JSON object with ALL sections. "
+            "Do not truncate."
+        )
+    if schema_type == "enrichment":
+        return (
+            "\n\nIMPORTANT: Output the COMPLETE JSON object with ALL keys: "
+            "items_to_enrich, questions, analysis_summary. Do not truncate."
+        )
+    if schema_type == "interview_prep":
+        return (
+            "\n\nIMPORTANT: Output the COMPLETE JSON object with ALL keys: "
+            "role_fit_analysis, resume_questions, project_follow_ups, "
+            "skill_gaps, talking_points. Do not truncate."
+        )
+    return (
+        "\n\nIMPORTANT: Output ONLY a valid JSON object. Start with { and end with }."
+    )
+
+
+async def _complete_json_via_claude_cli(
+    *,
+    prompt: str,
+    json_system: str,
+    config: LLMConfig,
+    max_tokens: int,
+    retries: int,
+    schema_type: str,
+) -> dict[str, Any]:
+    """JSON completion path for the local Claude Code CLI provider."""
+    user_prompt = prompt
+    timeout = float(_calculate_timeout("json", max_tokens, config.provider))
+
+    for attempt in range(retries + 1):
+        try:
+            content = await complete_claude_cli(
+                user_prompt,
+                system_prompt=json_system,
+                model=config.model or "sonnet",
+                timeout=timeout,
+            )
+            if "<think>" in content:
+                content = _strip_thinking_tags(content)
+            if not content:
+                raise ValueError("Empty response from LLM")
+
+            logging.debug(
+                "Claude CLI JSON response (attempt %d): %s",
+                attempt + 1,
+                content[:300],
+            )
+
+            json_str = _extract_json(content)
+            result = json.loads(json_str)
+
+            if isinstance(result, dict) and _appears_truncated(result, schema_type):
+                if attempt < retries:
+                    logging.warning(
+                        "Claude CLI JSON appears truncated (attempt %d/%d), retrying",
+                        attempt + 1,
+                        retries + 1,
+                    )
+                    user_prompt = prompt + _truncation_retry_hint(schema_type)
+                    continue
+                logging.warning(
+                    "Claude CLI JSON appears truncated on final attempt, "
+                    "proceeding with result"
+                )
+            return result
+
+        except json.JSONDecodeError as e:
+            logging.warning("Claude CLI JSON parse failed (attempt %d): %s", attempt + 1, e)
+            if attempt < retries:
+                user_prompt = (
+                    prompt
+                    + "\n\nIMPORTANT: Output ONLY a valid JSON object. "
+                    "Start with { and end with }."
+                )
+                continue
+            raise ValueError(
+                f"Failed to parse JSON after {retries + 1} attempts: {e}"
+            ) from e
+
+        except ClaudeCLIError as e:
+            logging.error("Claude CLI JSON completion failed: %s", e)
+            raise ValueError(
+                "LLM completion failed. Please check your Claude CLI setup "
+                "(`claude auth login`) and try again."
+            ) from e
+
+        except ValueError as e:
+            logging.warning(
+                "Claude CLI content extraction failed (attempt %d): %s",
+                attempt + 1,
+                e,
+            )
+            if attempt < retries:
+                continue
+            raise
+
+    raise ValueError(f"Failed after {retries + 1} attempts")
+
+
 async def complete_json(
     prompt: str,
     system_prompt: str | None = None,
@@ -1200,8 +1363,8 @@ async def complete_json(
             "keywords", or "interview_prep". Passed to _appears_truncated for
             context-aware truncation detection and used to tailor retry hints.
     """
-    router, config = get_router(config)
-    model_name = get_model_name(config)
+    if config is None:
+        config = get_llm_config()
 
     # Build messages
     json_system = (
@@ -1211,6 +1374,20 @@ async def complete_json(
         {"role": "system", "content": json_system},
         {"role": "user", "content": prompt},
     ]
+
+    # Claude Code CLI — no LiteLLM JSON mode; prompt-only + same retry loop.
+    if config.provider == "claude_cli":
+        return await _complete_json_via_claude_cli(
+            prompt=prompt,
+            json_system=json_system,
+            config=config,
+            max_tokens=max_tokens,
+            retries=retries,
+            schema_type=schema_type,
+        )
+
+    router, config = get_router(config)
+    model_name = get_model_name(config)
 
     # Check if we can use JSON mode
     use_json_mode = _supports_json_mode(model_name)

--- a/apps/backend/app/providers/__init__.py
+++ b/apps/backend/app/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Non-LiteLLM LLM backends (local CLIs, etc.)."""

--- a/apps/backend/app/providers/claude_cli.py
+++ b/apps/backend/app/providers/claude_cli.py
@@ -1,0 +1,234 @@
+"""Claude Code CLI backend — Multica-style local ``claude -p`` invocations.
+
+Uses the signed-in Claude Code CLI on PATH (or ``CLAUDE_CLI_PATH``) instead of
+an Anthropic API key. Tools are disabled so Claude answers as a plain LLM
+(resume JSON, keywords, etc.) rather than acting as a coding agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default model alias understood by Claude Code (``--model``).
+DEFAULT_CLAUDE_CLI_MODEL = "sonnet"
+
+# Hard ceiling for a single CLI process; callers pass their own timeout too.
+_MAX_CLI_TIMEOUT_SECONDS = 1800
+
+
+class ClaudeCLIError(RuntimeError):
+    """Raised when the local Claude Code CLI cannot complete a request."""
+
+
+def resolve_claude_binary() -> str:
+    """Return the Claude Code binary path or raise ``ClaudeCLIError``."""
+    override = (os.environ.get("CLAUDE_CLI_PATH") or "").strip()
+    if override:
+        if os.path.isfile(override) and os.access(override, os.X_OK):
+            return override
+        raise ClaudeCLIError(
+            f"CLAUDE_CLI_PATH is set but not an executable file: {override}"
+        )
+    binary = shutil.which("claude")
+    if not binary:
+        raise ClaudeCLIError(
+            "Claude Code CLI not found on PATH. Install it "
+            "(https://docs.anthropic.com/en/docs/claude-code) and run "
+            "`claude auth login`, or set CLAUDE_CLI_PATH."
+        )
+    return binary
+
+
+# Keep --system-prompt on argv only when short; large resume/JD payloads go
+# through stdin so we stay under OS ARG_MAX limits.
+_MAX_SYSTEM_PROMPT_ARGV_CHARS = 4000
+
+
+def build_claude_cli_args(
+    *,
+    system_prompt: str | None,
+    model: str,
+) -> tuple[list[str], str | None]:
+    """Build ``claude -p`` argv and the optional system prompt for argv.
+
+    Returns ``(args, system_prompt_for_argv)``. When the system prompt is too
+    large for argv, ``system_prompt_for_argv`` is ``None`` and the caller must
+    fold it into the stdin payload.
+    """
+    # NOTE: Do NOT pass ``--bare``. That mode refuses OAuth/keychain auth and
+    # only accepts ANTHROPIC_API_KEY — which defeats the whole point of this
+    # provider (use the signed-in Claude Code subscription).
+    # ``--safe-mode`` skips project CLAUDE.md/hooks/plugins but keeps auth.
+    args: list[str] = [
+        "-p",
+        "--safe-mode",
+        "--tools",
+        "",
+        "--output-format",
+        "text",
+        "--permission-mode",
+        "dontAsk",
+        "--model",
+        model or DEFAULT_CLAUDE_CLI_MODEL,
+    ]
+    system_for_argv: str | None = None
+    if system_prompt:
+        if len(system_prompt) <= _MAX_SYSTEM_PROMPT_ARGV_CHARS:
+            system_for_argv = system_prompt
+            args.extend(["--system-prompt", system_prompt])
+    # User prompt is always sent on stdin (not argv) — see complete_claude_cli.
+    return args, system_for_argv
+
+
+def _stdin_payload(prompt: str, system_prompt: str | None, system_on_argv: bool) -> str:
+    """Build the stdin body. Fold system text in when it did not fit on argv."""
+    if system_prompt and not system_on_argv:
+        return f"[System]\n{system_prompt}\n\n[User]\n{prompt}"
+    return prompt
+
+
+async def complete_claude_cli(
+    prompt: str,
+    system_prompt: str | None = None,
+    *,
+    model: str = DEFAULT_CLAUDE_CLI_MODEL,
+    timeout: float = 180,
+) -> str:
+    """Run a single non-interactive Claude Code completion.
+
+    Equivalent in spirit to Multica's daemon path: spawn ``claude -p``, use the
+    local login, return stdout text. Does not use the Anthropic HTTP API.
+
+    The user prompt is written to stdin (not argv) so large resume/JD payloads
+    do not hit OS argument-length limits.
+    """
+    binary = resolve_claude_binary()
+    args, system_on_argv = build_claude_cli_args(
+        system_prompt=system_prompt, model=model
+    )
+    stdin_text = _stdin_payload(
+        prompt, system_prompt, system_on_argv=system_on_argv is not None
+    )
+    timeout = max(1.0, min(float(timeout), float(_MAX_CLI_TIMEOUT_SECONDS)))
+
+    logger.debug(
+        "Invoking Claude CLI",
+        extra={"binary": binary, "model": model, "timeout": timeout},
+    )
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            binary,
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            # Avoid inheriting a cwd that loads project CLAUDE.md unexpectedly;
+            # --bare already skips CLAUDE.md discovery, but keep cwd stable.
+            cwd=os.path.expanduser("~"),
+            env=os.environ.copy(),
+        )
+    except FileNotFoundError as e:
+        raise ClaudeCLIError(
+            "Failed to start Claude Code CLI. Is `claude` installed?"
+        ) from e
+
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(
+            proc.communicate(input=stdin_text.encode("utf-8")),
+            timeout=timeout,
+        )
+    except TimeoutError as e:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.communicate()
+        raise ClaudeCLIError(
+            f"Claude CLI timed out after {int(timeout)}s. "
+            "Try a faster model alias (haiku) or raise REQUEST_TIMEOUT_SECONDS."
+        ) from e
+
+    stdout = stdout_b.decode("utf-8", errors="replace").strip()
+    stderr = stderr_b.decode("utf-8", errors="replace").strip()
+
+    if proc.returncode != 0:
+        detail = stderr or stdout or f"exit code {proc.returncode}"
+        # Keep client messages short; full detail is logged.
+        logger.error("Claude CLI failed (code %s): %s", proc.returncode, detail[:2000])
+        raise ClaudeCLIError(
+            "Claude CLI request failed. Ensure `claude auth login` succeeded "
+            f"and the CLI can run (`claude -p \"hi\"`). Detail: {_short(detail)}"
+        )
+
+    if not stdout:
+        logger.error("Claude CLI returned empty stdout; stderr=%s", stderr[:1000])
+        raise ClaudeCLIError("Claude CLI returned an empty response.")
+
+    return stdout
+
+
+async def check_claude_cli_health(
+    *,
+    model: str = DEFAULT_CLAUDE_CLI_MODEL,
+    test_prompt: str | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    """Minimal smoke test: binary present + one tiny completion."""
+    prompt = test_prompt or "Reply with exactly: OK"
+    try:
+        # Cheap existence check first so missing binary is a clear error_code.
+        resolve_claude_binary()
+        content = await complete_claude_cli(
+            prompt,
+            system_prompt="You are a health-check probe. Reply with a short OK.",
+            model=model,
+            timeout=timeout,
+        )
+    except ClaudeCLIError as e:
+        message = str(e)
+        error_code = "cli_missing" if "not found" in message.lower() else "cli_error"
+        return {
+            "healthy": False,
+            "provider": "claude_cli",
+            "model": model,
+            "error_code": error_code,
+            "message": message,
+        }
+    except Exception as e:
+        logger.exception("Unexpected Claude CLI health failure")
+        return {
+            "healthy": False,
+            "provider": "claude_cli",
+            "model": model,
+            "error_code": "cli_error",
+            "message": f"Claude CLI health check failed: {e}",
+        }
+
+    if not content.strip():
+        return {
+            "healthy": False,
+            "provider": "claude_cli",
+            "model": model,
+            "error_code": "empty_content",
+            "message": "Claude CLI returned empty response",
+        }
+
+    return {
+        "healthy": True,
+        "provider": "claude_cli",
+        "model": model,
+        "response_model": model,
+        "content": content,
+    }
+
+
+def _short(text: str, limit: int = 240) -> str:
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"

--- a/apps/backend/app/routers/health.py
+++ b/apps/backend/app/routers/health.py
@@ -5,7 +5,7 @@ import logging
 from fastapi import APIRouter
 
 from app.database import db
-from app.llm import check_llm_health, get_llm_config
+from app.llm import LOCAL_NO_KEY_PROVIDERS, check_llm_health, get_llm_config
 from app.schemas import HealthResponse, StatusResponse
 
 logger = logging.getLogger(__name__)
@@ -43,8 +43,8 @@ async def get_status() -> StatusResponse:
     llm_healthy = False
     try:
         config = get_llm_config()
-        # ollama / openai_compatible run without a key, matching check_llm_health.
-        llm_configured = bool(config.api_key) or config.provider in ("ollama", "openai_compatible")
+        # Local providers run without a key, matching check_llm_health.
+        llm_configured = bool(config.api_key) or config.provider in LOCAL_NO_KEY_PROVIDERS
         llm_status = await check_llm_health(config)
         llm_healthy = bool(llm_status.get("healthy"))
     except Exception:

--- a/apps/backend/e2e_monitor/gate.py
+++ b/apps/backend/e2e_monitor/gate.py
@@ -17,12 +17,12 @@ class MonitorDisabled(RuntimeError):
 def _key_is_configured() -> bool:
     """True when a usable key/provider is set (mirrors the eval ``_needs_key``)."""
     try:
-        from app.llm import get_llm_config
+        from app.llm import LOCAL_NO_KEY_PROVIDERS, get_llm_config
 
         cfg = get_llm_config()
     except Exception:
         return False
-    return bool(cfg.api_key) or cfg.provider in ("ollama", "openai_compatible")
+    return bool(cfg.api_key) or cfg.provider in LOCAL_NO_KEY_PROVIDERS
 
 
 def ensure_enabled(*, require_key: bool = True) -> None:

--- a/apps/backend/tests/evals/test_tailoring_eval.py
+++ b/apps/backend/tests/evals/test_tailoring_eval.py
@@ -24,7 +24,7 @@ import json
 
 import pytest
 
-from app.llm import complete_json, get_llm_config
+from app.llm import LOCAL_NO_KEY_PROVIDERS, complete_json, get_llm_config
 from tests.evals.golden.cases import GOLDEN_CASES
 
 
@@ -33,14 +33,14 @@ def _needs_key() -> None:
 
     A key is considered "absent" only when there is no api_key AND the provider
     is not one of the local/self-hosted providers that legitimately run without
-    one (``ollama``, ``openai_compatible``). This mirrors the gate used
-    throughout the backend.
+    one (``ollama``, ``openai_compatible``, ``claude_cli``). This mirrors the
+    gate used throughout the backend.
     """
     try:
         cfg = get_llm_config()
     except Exception as exc:  # corrupt/unreadable config.json — skip, don't hard-fail
         pytest.skip(f"could not read LLM config ({exc}); skipping LLM-judge eval")
-    if not cfg.api_key and cfg.provider not in ("ollama", "openai_compatible"):
+    if not cfg.api_key and cfg.provider not in LOCAL_NO_KEY_PROVIDERS:
         pytest.skip("no LLM key configured; set one to run LLM-judge evals")
 
 

--- a/apps/backend/tests/unit/test_claude_cli.py
+++ b/apps/backend/tests/unit/test_claude_cli.py
@@ -1,0 +1,85 @@
+"""Unit tests for the local Claude Code CLI provider."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.llm import LOCAL_NO_KEY_PROVIDERS, LLMConfig, complete, resolve_api_key
+from app.providers.claude_cli import (
+    ClaudeCLIError,
+    _stdin_payload,
+    build_claude_cli_args,
+    resolve_claude_binary,
+)
+
+
+class TestBuildClaudeCliArgs:
+    def test_includes_print_bare_and_no_tools(self):
+        args, system_on_argv = build_claude_cli_args(
+            system_prompt="sys",
+            model="sonnet",
+        )
+        assert args[0] == "-p"
+        assert "--bare" not in args
+        assert "--safe-mode" in args
+        assert args[args.index("--tools") + 1] == ""
+        assert args[args.index("--output-format") + 1] == "text"
+        assert args[args.index("--model") + 1] == "sonnet"
+        assert args[args.index("--system-prompt") + 1] == "sys"
+        assert system_on_argv == "sys"
+        # Prompt goes on stdin, never argv.
+        assert "hello" not in args
+
+    def test_omits_system_prompt_when_absent(self):
+        args, system_on_argv = build_claude_cli_args(system_prompt=None, model="haiku")
+        assert "--system-prompt" not in args
+        assert system_on_argv is None
+
+    def test_folds_large_system_prompt_into_stdin(self):
+        huge = "x" * 5000
+        args, system_on_argv = build_claude_cli_args(system_prompt=huge, model="sonnet")
+        assert "--system-prompt" not in args
+        assert system_on_argv is None
+        payload = _stdin_payload("user-text", huge, system_on_argv=False)
+        assert payload.startswith("[System]\n")
+        assert "user-text" in payload
+
+
+class TestResolveClaudeBinary:
+    def test_uses_path_override(self, monkeypatch, tmp_path):
+        binary = tmp_path / "claude"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        monkeypatch.setenv("CLAUDE_CLI_PATH", str(binary))
+        assert resolve_claude_binary() == str(binary)
+
+    def test_missing_override_raises(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLAUDE_CLI_PATH", str(tmp_path / "missing"))
+        with pytest.raises(ClaudeCLIError, match="CLAUDE_CLI_PATH"):
+            resolve_claude_binary()
+
+
+class TestLocalNoKeyProviders:
+    def test_claude_cli_is_keyless(self):
+        assert "claude_cli" in LOCAL_NO_KEY_PROVIDERS
+
+    def test_claude_cli_does_not_inherit_env_key(self, monkeypatch):
+        monkeypatch.setattr("app.llm.settings.llm_api_key", "sk-paid-secret")
+        assert resolve_api_key({}, "claude_cli") == ""
+
+
+@pytest.mark.asyncio
+async def test_complete_routes_to_claude_cli():
+    cfg = LLMConfig(provider="claude_cli", model="sonnet", api_key="")
+    with patch(
+        "app.llm.complete_claude_cli",
+        new=AsyncMock(return_value='{"ok": true}'),
+    ) as mock_cli:
+        out = await complete("prompt", system_prompt="sys", config=cfg)
+    assert out == '{"ok": true}'
+    mock_cli.assert_awaited_once()
+    kwargs = mock_cli.await_args.kwargs
+    assert kwargs["model"] == "sonnet"
+    assert kwargs["system_prompt"] == "sys"

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -78,6 +78,7 @@ const PROVIDERS: LLMProvider[] = [
   'deepseek',
   'groq',
   'ollama',
+  'claude_cli',
 ];
 
 const SEGMENTED_BUTTON_BASE =
@@ -305,7 +306,9 @@ export default function SettingsPage() {
           // Whether THIS provider already has an encrypted key (per-provider,
           // not the legacy shared slot) drives the "leave blank to keep" hint.
           const keyProvider = llmProviderToKeyProvider(safeProvider);
-          setHasStoredApiKey(statuses.some((s) => s.provider === keyProvider && s.configured));
+          setHasStoredApiKey(
+            keyProvider != null && statuses.some((s) => s.provider === keyProvider && s.configured)
+          );
           setApiKey('');
           setApiBase(llmConfig.api_base || '');
           setReasoningEffort((llmConfig.reasoning_effort as ReasoningEffort | null) ?? 'auto');
@@ -352,6 +355,7 @@ export default function SettingsPage() {
   // Whether a given key-store provider currently has a saved key.
   const providerHasStoredKey = (p: LLMProvider): boolean => {
     const keyProvider = llmProviderToKeyProvider(p);
+    if (keyProvider == null) return false;
     return apiKeyStatuses.some((s) => s.provider === keyProvider && s.configured);
   };
 
@@ -433,7 +437,9 @@ export default function SettingsPage() {
       // shared config slot, so saving one provider never wipes another's key.
       if (trimmedKey) {
         const keyProvider = llmProviderToKeyProvider(provider);
-        await updateApiKeys({ [keyProvider]: trimmedKey } as Record<ApiKeyProvider, string>);
+        if (keyProvider != null) {
+          await updateApiKeys({ [keyProvider]: trimmedKey } as Record<ApiKeyProvider, string>);
+        }
       }
 
       // (2) Persist non-secret LLM config — WITHOUT api_key.
@@ -450,8 +456,10 @@ export default function SettingsPage() {
       // Refresh the per-provider key status + cached system status after save.
       const statuses = await refreshApiKeyStatus();
       setApiKey('');
+      const savedKeyProvider = llmProviderToKeyProvider(provider);
       setHasStoredApiKey(
-        statuses.some((s) => s.provider === llmProviderToKeyProvider(provider) && s.configured)
+        savedKeyProvider != null &&
+          statuses.some((s) => s.provider === savedKeyProvider && s.configured)
       );
       await refreshStatus();
 

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -10,7 +10,8 @@ export type LLMProvider =
   | 'gemini'
   | 'deepseek'
   | 'groq'
-  | 'ollama';
+  | 'ollama'
+  | 'claude_cli';
 
 // Reasoning-effort levels supported by LiteLLM. `null` (or absent) means
 // "do not send the parameter" — the default for max compatibility.
@@ -202,6 +203,13 @@ export const PROVIDER_INFO: Record<
     defaultModel: 'gemma3:4b',
     requiresKey: false,
     defaultBaseUrl: 'http://localhost:11434',
+  },
+  // Claude Code CLI: Multica-style local `claude -p`. Uses your Claude
+  // Pro/Max login — no Anthropic API key. Requires `claude` on PATH.
+  claude_cli: {
+    name: 'Claude CLI (Local)',
+    defaultModel: 'sonnet',
+    requiresKey: false,
   },
 };
 
@@ -429,7 +437,9 @@ export type ApiKeyProvider =
 // Map an LLM provider (the active-provider axis) to its key-store provider
 // name. Mirrors the backend `_PROVIDER_KEY_MAP` (gemini → google; the local
 // providers pass through). Keys are persisted under the key-store name.
-export function llmProviderToKeyProvider(provider: LLMProvider): ApiKeyProvider {
+export function llmProviderToKeyProvider(provider: LLMProvider): ApiKeyProvider | null {
+  // Claude CLI has no key-store slot (auth is the local `claude` login).
+  if (provider === 'claude_cli') return null;
   if (provider === 'gemini') return 'google';
   return provider as ApiKeyProvider;
 }

--- a/apps/frontend/tests/api-config.test.ts
+++ b/apps/frontend/tests/api-config.test.ts
@@ -18,12 +18,14 @@ import {
 const ALL_PROVIDERS: LLMProvider[] = [
   'openai',
   'openai_compatible',
+  'azure_foundry',
   'anthropic',
   'openrouter',
   'gemini',
   'deepseek',
   'groq',
   'ollama',
+  'claude_cli',
 ];
 
 describe('PROVIDER_INFO', () => {
@@ -40,6 +42,7 @@ describe('PROVIDER_INFO', () => {
   it('marks only local providers as not requiring a key', () => {
     expect(PROVIDER_INFO.ollama.requiresKey).toBe(false);
     expect(PROVIDER_INFO.openai_compatible.requiresKey).toBe(false);
+    expect(PROVIDER_INFO.claude_cli.requiresKey).toBe(false);
     expect(PROVIDER_INFO.openai.requiresKey).toBe(true);
     expect(PROVIDER_INFO.anthropic.requiresKey).toBe(true);
   });

--- a/apps/frontend/tests/api-tracker.test.ts
+++ b/apps/frontend/tests/api-tracker.test.ts
@@ -21,6 +21,7 @@ describe('llmProviderToKeyProvider', () => {
     expect(llmProviderToKeyProvider('anthropic')).toBe('anthropic');
     expect(llmProviderToKeyProvider('openai_compatible')).toBe('openai_compatible');
     expect(llmProviderToKeyProvider('ollama')).toBe('ollama');
+    expect(llmProviderToKeyProvider('claude_cli')).toBeNull();
   });
 });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
       - LOG_LLM=${LOG_LLM:-WARNING}
       #- LOG_LLM_FILE=${LOG_LLM_FILE:-}
       # LLM Configuration - configure via Settings UI or set env vars for explicit overrides
-      # Supported providers: openai, anthropic, openrouter, gemini, deepseek, ollama
+      # Supported providers: openai, openai_compatible, azure_foundry, anthropic,
+      # openrouter, gemini, deepseek, groq, ollama, claude_cli
       # Defaults are defined in apps/backend/app/config.py
       - LLM_PROVIDER=${LLM_PROVIDER:-openai}
       - LLM_MODEL=${LLM_MODEL:-}

--- a/docs/agent/llm-integration.md
+++ b/docs/agent/llm-integration.md
@@ -9,12 +9,15 @@ Backend uses LiteLLM to support multiple providers through a unified API:
 | Provider | Type | Notes |
 |----------|------|-------|
 | **Ollama** | Local | Free, runs on your machine |
+| **Claude CLI** | Local | Claude Code CLI (`claude -p`); uses your Claude login — no API key |
 | **OpenAI** | Cloud | GPT-5 Nano, GPT-4o |
+| **OpenAI-Compatible** | Local/self-hosted | llama.cpp, vLLM, LM Studio |
 | **Azure AI Foundry** | Cloud | Azure AI Inference / Foundry model endpoints |
-| **Anthropic** | Cloud | Claude Haiku 4.5 |
+| **Anthropic** | Cloud | Claude Haiku 4.5 (API key) |
 | **Google Gemini** | Cloud | Gemini 3 Flash |
 | **OpenRouter** | Cloud | Access to multiple models |
 | **DeepSeek** | Cloud | DeepSeek Chat |
+| **Groq** | Cloud | Fast inference |
 
 ## API Key Handling
 


### PR DESCRIPTION
## Summary
- Adds a `claude_cli` LLM provider that runs local Claude Code (`claude -p`) so parse/tailor can use a Claude Pro/Max login without an Anthropic API key.
- Available in Settings as **Claude CLI (Local)** (no API key field).

## How it works
Frontend → backend → spawns `claude -p --safe-mode --tools ""` → uses your local Claude login → returns text/JSON for the resume pipeline.

## Test plan
- [ ] `claude auth login` (Claude Code installed and on PATH)
- [ ] Settings → Claude CLI (Local) → Save → Test connection
- [ ] Upload a resume (parse succeeds)
- [ ] Tailor against a job description

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `claude_cli` local LLM provider that runs Claude Code CLI (`claude -p`) so users can parse/tailor with their Claude Pro/Max login without an Anthropic API key. Updates backend, settings UI, tests, and docs to support a keyless local flow safely.

- New Features
  - Added `claude_cli` provider that spawns `claude -p --safe-mode --tools ""` using your local login; no API key.
  - Health/status now support keyless local providers via `LOCAL_NO_KEY_PROVIDERS`, plus a dedicated CLI health check.
  - Backend completion paths handle CLI for text and JSON (timeout tuning, truncation retry, `<think>` stripping).
  - Settings adds “Claude CLI (Local)” (no key field); key-store mapping returns null for this provider; docs and examples updated.

- Migration
  - Install the Claude Code CLI and ensure `claude` is on PATH (or set `CLAUDE_CLI_PATH`).
  - Run `claude auth login`.
  - In Settings, pick “Claude CLI (Local)”, Save, then Test connection (no API key needed).

<sup>Written for commit 8f66b793d78b066eb7792ef556af6e3a86faf3bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

