### PR TITLE
feat: add tracker status visibility management

### DIFF
--- a/apps/frontend/components/tracker/kanban-board.tsx
+++ b/apps/frontend/components/tracker/kanban-board.tsx
@@ -12,6 +12,7 @@ import {
 } from '@dnd-kit/core';
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import Plus from 'lucide-react/dist/esm/icons/plus';
+import Settings from 'lucide-react/dist/esm/icons/settings';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
 import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left';
 import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right';
@@ -32,6 +33,11 @@ import { BulkActionBar } from './bulk-action-bar';
 import { CardDetailModal } from './card-detail-modal';
 import { ManualAddApplicationDialog } from './manual-add-application-dialog';
 import { planMove } from './reorder';
+import { ManageColumnsDialog } from './manage-columns-dialog';
+import {
+  readHiddenStatuses,
+  writeHiddenStatuses,
+} from '@/lib/utils/tracker-column-visibility';
 
 function emptyColumns(): ApplicationColumns {
   return APPLICATION_STATUS_ORDER.reduce((acc, status) => {
@@ -53,6 +59,14 @@ export function KanbanBoard() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [openCardId, setOpenCardId] = useState<string | null>(null);
   const [manualAddOpen, setManualAddOpen] = useState(false);
+  const [manageOpen, setManageOpen] = useState(false);
+  const [hiddenStatuses, setHiddenStatuses] = useState<Set<ApplicationStatus>>(
+    () => readHiddenStatuses()
+  );
+
+  useEffect(() => {
+    writeHiddenStatuses(hiddenStatuses);
+  }, [hiddenStatuses]);
 
   // Horizontal-scroll affordance: the seven stages overflow the canvas, so we
   // track whether more columns sit off-screen and surface controls + a stage
@@ -82,6 +96,11 @@ export function KanbanBoard() {
   const allCards: Application[] = useMemo(
     () => APPLICATION_STATUS_ORDER.flatMap((status) => columns[status]),
     [columns]
+  );
+
+  const visibleStatuses = useMemo(
+    () => APPLICATION_STATUS_ORDER.filter((status) => !hiddenStatuses.has(status)),
+    [hiddenStatuses]
   );
 
   // Master resume ids that back more than one card → "shared resume" badge.
@@ -196,6 +215,10 @@ export function KanbanBoard() {
           </p>
         </div>
         <div className="flex items-center gap-3">
+          <Button variant="outline" onClick={() => setManageOpen(true)}>
+            <Settings className="h-4 w-4" />
+            {t('tracker.manage')}
+          </Button>
           {showScrollControls && (
             <div className="flex items-center">
               <button
@@ -261,12 +284,12 @@ export function KanbanBoard() {
             onDragEnd={handleDragEnd}
           >
             <div ref={scrollRef} className="flex min-h-0 flex-1 overflow-x-auto">
-              {APPLICATION_STATUS_ORDER.map((status, index) => (
+              {visibleStatuses.map((status, index) => (
                 <div
                   key={status}
                   data-column={status}
                   className={`flex ${
-                    index < APPLICATION_STATUS_ORDER.length - 1 ? 'border-r border-black' : ''
+                    index < visibleStatuses.length - 1 ? 'border-r border-black' : ''
                   }`}
                 >
                   <KanbanColumn
@@ -295,7 +318,7 @@ export function KanbanBoard() {
             </span>
           )}
           <div className="flex items-center gap-2">
-            {APPLICATION_STATUS_ORDER.map((status) => (
+            {visibleStatuses.map((status) => (
               <button
                 key={status}
                 type="button"
@@ -323,6 +346,23 @@ export function KanbanBoard() {
         open={manualAddOpen}
         onOpenChange={setManualAddOpen}
         onCreated={load}
+      />
+
+      <ManageColumnsDialog
+        open={manageOpen}
+        onOpenChange={setManageOpen}
+        hiddenStatuses={hiddenStatuses}
+        onToggle={(status) =>
+          setHiddenStatuses((prev) => {
+            const next = new Set(prev);
+            if (next.has(status)) {
+              next.delete(status);
+            } else {
+              next.add(status);
+            }
+            return next;
+          })
+        }
       />
     </div>
   );

--- a/apps/frontend/components/tracker/manage-columns-dialog.tsx
+++ b/apps/frontend/components/tracker/manage-columns-dialog.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React from 'react';
+import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
+import { useTranslations } from '@/lib/i18n';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ToggleSwitch } from '@/components/ui/toggle-switch';
+
+interface ManageColumnsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hiddenStatuses: Set<ApplicationStatus>;
+  onToggle: (status: ApplicationStatus) => void;
+}
+
+export function ManageColumnsDialog({
+  open,
+  onOpenChange,
+  hiddenStatuses,
+  onToggle,
+}: ManageColumnsDialogProps) {
+  const { t } = useTranslations();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md p-6">
+        <DialogHeader>
+          <DialogTitle>{t('tracker.manageDialog.title')}</DialogTitle>
+          <DialogDescription>{t('tracker.manageDialog.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] space-y-3 overflow-y-auto py-4">
+          {APPLICATION_STATUS_ORDER.map((status) => {
+            const hidden = hiddenStatuses.has(status);
+            return (
+              <ToggleSwitch
+                key={status}
+                checked={!hidden}
+                onCheckedChange={() => onToggle(status)}
+                label={t(`tracker.columns.${status}`)}
+                description={hidden ? t('tracker.manageDialog.hide') : t('tracker.manageDialog.show')}
+              />
+            );
+          })}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>{t('tracker.manageDialog.close')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/lib/utils/tracker-column-visibility.ts
+++ b/apps/frontend/lib/utils/tracker-column-visibility.ts
@@ -1,0 +1,30 @@
+import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
+import { safeStorage } from '@/lib/utils/resume-draft-storage';
+
+export const TRACKER_HIDDEN_STATUSES_KEY = 'tracker_hidden_statuses';
+
+export function readHiddenStatuses(): Set<ApplicationStatus> {
+  const raw = safeStorage.get(TRACKER_HIDDEN_STATUSES_KEY);
+  if (!raw) return new Set();
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+
+    const validStatuses = new Set<ApplicationStatus>(APPLICATION_STATUS_ORDER);
+    const hidden = new Set<ApplicationStatus>();
+    for (const value of parsed) {
+      if (typeof value === 'string' && validStatuses.has(value as ApplicationStatus)) {
+        hidden.add(value as ApplicationStatus);
+      }
+    }
+    return hidden;
+  } catch {
+    return new Set();
+  }
+}
+
+export function writeHiddenStatuses(hidden: Set<ApplicationStatus>): boolean {
+  const ordered = APPLICATION_STATUS_ORDER.filter((status) => hidden.has(status));
+  return safeStorage.set(TRACKER_HIDDEN_STATUSES_KEY, JSON.stringify(ordered));
+}

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "Scroll left",
       "next": "Scroll right",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "Desplazar a la izquierda",
       "next": "Desplazar a la derecha",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "Faire défiler à gauche",
       "next": "Faire défiler à droite",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "左へスクロール",
       "next": "右へスクロール",

--- a/apps/frontend/messages/ko.json
+++ b/apps/frontend/messages/ko.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "왼쪽으로 스크롤",
       "next": "오른쪽으로 스크롤",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "Rolar para a esquerda",
       "next": "Rolar para a direita",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "管理",
+    "manageDialog": {
+      "title": "管理状态模块",
+      "description": "选择看板中显示的状态模块。",
+      "show": "显示",
+      "hide": "隐藏",
+      "close": "完成"
+    },
     "scroll": {
       "prev": "向左滚动",
       "next": "向右滚动",

--- a/apps/frontend/tests/manage-columns-dialog.test.tsx
+++ b/apps/frontend/tests/manage-columns-dialog.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ManageColumnsDialog } from '@/components/tracker/manage-columns-dialog';
+
+vi.mock('@/lib/i18n', () => ({
+  useTranslations: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('ManageColumnsDialog', () => {
+  it('renders one switch per tracker status', () => {
+    render(
+      <ManageColumnsDialog
+        open
+        onOpenChange={vi.fn()}
+        hiddenStatuses={new Set(['interview'])}
+        onToggle={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('switch')).toHaveLength(7);
+  });
+
+  it('reports toggles with the status key', () => {
+    const onToggle = vi.fn();
+    render(
+      <ManageColumnsDialog
+        open
+        onOpenChange={vi.fn()}
+        hiddenStatuses={new Set(['interview'])}
+        onToggle={onToggle}
+      />
+    );
+
+    const interviewSwitch = screen.getByRole('switch', { name: 'tracker.columns.interview' });
+    expect(interviewSwitch).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(interviewSwitch);
+    expect(onToggle).toHaveBeenCalledWith('interview');
+  });
+});

--- a/apps/frontend/tests/tracker-column-visibility.test.ts
+++ b/apps/frontend/tests/tracker-column-visibility.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
+import {
+  readHiddenStatuses,
+  TRACKER_HIDDEN_STATUSES_KEY,
+  writeHiddenStatuses,
+} from '@/lib/utils/tracker-column-visibility';
+
+describe('tracker column visibility storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to all statuses visible', () => {
+    expect(readHiddenStatuses().size).toBe(0);
+  });
+
+  it('persists and reloads hidden statuses', () => {
+    const hidden = new Set<ApplicationStatus>(['interview', 'rejected']);
+
+    expect(writeHiddenStatuses(hidden)).toBe(true);
+
+    const loaded = readHiddenStatuses();
+    expect(loaded.has('interview')).toBe(true);
+    expect(loaded.has('rejected')).toBe(true);
+    expect(loaded.has('applied')).toBe(false);
+  });
+
+  it('ignores corrupt JSON', () => {
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, '{broken');
+    expect(readHiddenStatuses().size).toBe(0);
+  });
+
+  it('ignores unknown statuses', () => {
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, JSON.stringify(['interview', 'unknown']));
+    expect(Array.from(readHiddenStatuses())).toEqual(['interview']);
+  });
+
+  it('ignores non-array payloads', () => {
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, JSON.stringify({ saved: true }));
+    expect(readHiddenStatuses().size).toBe(0);
+  });
+
+  it('writes statuses in the canonical order', () => {
+    writeHiddenStatuses(new Set<ApplicationStatus>(['rejected', 'saved']));
+    expect(JSON.parse(localStorage.getItem(TRACKER_HIDDEN_STATUSES_KEY) ?? '[]')).toEqual([
+      APPLICATION_STATUS_ORDER[0],
+      APPLICATION_STATUS_ORDER[APPLICATION_STATUS_ORDER.length - 1],
+    ]);
+  });
+});


### PR DESCRIPTION
# Pull Request Title
<!-- Provide a concise and descriptive title for the pull request -->

## Related Issue
<!-- If this pull request is related to an issue, please link it here using the "#" symbol followed by the issue number (e.g., #123) -->

## Description
<!-- Describe the changes made in this pull request. What problem does it solve or what feature does it add/modify? -->
copilot:summary

## Type
<!-- Check the relevant options by putting an "x" in the brackets -->

- [ ] Bug Fix
- [ ] Feature Enhancement
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Other (please specify):

## Proposed Changes
<!-- List the specific changes made in this pull request -->

-
-
-

## Screenshots / Code Snippets (if applicable)
<!-- Include any relevant screenshots or code snippets that help visualize the changes made -->

## How to Test
<!-- Provide step-by-step instructions or a checklist for testing the changes in this pull request -->

1.
2.
3.

## Checklist
<!-- Put an "x" in the brackets for the items that apply to this pull request -->

- [ ] The code compiles successfully without any errors or warnings
- [ ] The changes have been tested and verified
- [ ] The documentation has been updated (if applicable)
- [ ] The changes follow the project's coding guidelines and best practices
- [ ] The commit messages are descriptive and follow the project's guidelines
- [ ] All tests (if applicable) pass successfully
- [ ] This pull request has been linked to the related issue (if applicable)

## Additional Information
<!-- Add any other information about the pull request that you think might be helpful -->
copilot:walkthrough


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add column visibility management to the Tracker board so users can hide status columns and persist their choice per browser. Previously all statuses always rendered; now only visible statuses render, and hidden statuses do not accept drops but retain their cards and reappear when unhidden.

- Introduces Manage Columns dialog in `KanbanBoard` with a Settings button; toggles one switch per status.
- Filters rendered columns and quick-nav chips using a computed visible status list; ordering remains unchanged.
- Persists hidden statuses via `safeStorage` under key `tracker_hidden_statuses`, stored in canonical order and resilient to corrupt/unknown data.
- Adds i18n keys for manage dialog in all locales.
- Includes unit tests for dialog behavior and storage read/write.
- No backend or API changes; no migration required.

<sup>Written for commit 150817bffdcb0ffcd4e500e87ea7954ece744eba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

