### PR TITLE
feat(llm): add OrcaRouter as a named AI provider

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -227,6 +227,7 @@ Abre **<http://localhost:3000>** y configura tu proveedor de IA en Settings.
 | **Anthropic** | Nube | Claude 3.5 Sonnet |
 | **Google Gemini** | Nube | Gemini 1.5 Flash/Pro |
 | **OpenRouter** | Nube | Acceso a múltiples modelos |
+| **[OrcaRouter](https://www.orcarouter.ai)** | Nube | Gateway compatible con OpenAI con seguridad zero-trust para agentes |
 | **DeepSeek** | Nube | DeepSeek Chat |
 
 ### Despliegue con Docker

--- a/README.ja.md
+++ b/README.ja.md
@@ -225,6 +225,7 @@ npm run dev
 | **Anthropic** | クラウド | Claude 3.5 Sonnet |
 | **Google Gemini** | クラウド | Gemini 1.5 Flash/Pro |
 | **OpenRouter** | クラウド | 複数モデルへアクセス |
+| **[OrcaRouter](https://www.orcarouter.ai)** | クラウド | OpenAI互換ゲートウェイ、エージェント向けゼロトラストセキュリティ |
 | **DeepSeek** | クラウド | DeepSeek Chat |
 
 ### Docker デプロイ

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Open **<http://localhost:3000>** and configure your AI provider in Settings.
 | **Anthropic** | Cloud | Claude Haiku 4.5 |
 | **Google Gemini** | Cloud | Gemini 3 Flash |
 | **OpenRouter** | Cloud | Access to multiple models |
+| **[OrcaRouter](https://www.orcarouter.ai)** | Cloud | OpenAI-compatible gateway with zero-trust agent security |
 | **DeepSeek** | Cloud | DeepSeek Chat |
 
 ### Docker Deployment

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -225,6 +225,7 @@ npm run dev
 | **Anthropic** | 云 | Claude 3.5 Sonnet |
 | **Google Gemini** | 云 | Gemini 1.5 Flash/Pro |
 | **OpenRouter** | 云 | 访问多种模型 |
+| **[OrcaRouter](https://www.orcarouter.ai)** | 云 | OpenAI 兼容网关，为 AI 代理提供零信任安全 |
 | **DeepSeek** | 云 | DeepSeek Chat |
 
 ### Docker 部署

--- a/SETUP.es.md
+++ b/SETUP.es.md
@@ -217,6 +217,7 @@ Resume Matcher admite múltiples proveedores de IA. Puedes configurarlo desde la
 | **Anthropic** | `LLM_PROVIDER=anthropic`<br>`LLM_MODEL=claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com/) |
 | **Google Gemini** | `LLM_PROVIDER=gemini`<br>`LLM_MODEL=gemini-3-flash-preview` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | **OpenRouter** | `LLM_PROVIDER=openrouter`<br>`LLM_MODEL=deepseek/deepseek-chat` | [openrouter.ai](https://openrouter.ai/keys) |
+| **OrcaRouter** | `LLM_PROVIDER=orcarouter`<br>`LLM_MODEL=orcarouter/auto`<br>`LLM_API_BASE=https://api.orcarouter.ai/v1` (opcional; valor por defecto) | [orcarouter.ai](https://www.orcarouter.ai) |
 | **DeepSeek** | `LLM_PROVIDER=deepseek`<br>`LLM_MODEL=deepseek-chat` | [platform.deepseek.com](https://platform.deepseek.com/) |
 | **OpenAI-Compatible** | `LLM_PROVIDER=openai_compatible`<br>`LLM_MODEL=llama-3.1-8b`<br>`LLM_API_BASE=http://localhost:8080/v1` | — (local) |
 

--- a/SETUP.ja.md
+++ b/SETUP.ja.md
@@ -217,6 +217,7 @@ Resume Matcher は複数の AI プロバイダに対応しています。アプ�
 | **Anthropic** | `LLM_PROVIDER=anthropic`<br>`LLM_MODEL=claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com/) |
 | **Google Gemini** | `LLM_PROVIDER=gemini`<br>`LLM_MODEL=gemini-3-flash-preview` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | **OpenRouter** | `LLM_PROVIDER=openrouter`<br>`LLM_MODEL=deepseek/deepseek-chat` | [openrouter.ai](https://openrouter.ai/keys) |
+| **OrcaRouter** | `LLM_PROVIDER=orcarouter`<br>`LLM_MODEL=orcarouter/auto`<br>`LLM_API_BASE=https://api.orcarouter.ai/v1` (省略可。デフォルト) | [orcarouter.ai](https://www.orcarouter.ai) |
 | **DeepSeek** | `LLM_PROVIDER=deepseek`<br>`LLM_MODEL=deepseek-chat` | [platform.deepseek.com](https://platform.deepseek.com/) |
 | **OpenAI-Compatible** | `LLM_PROVIDER=openai_compatible`<br>`LLM_MODEL=llama-3.1-8b`<br>`LLM_API_BASE=http://localhost:8080/v1` | — (ローカル) |
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -210,6 +210,7 @@ Resume Matcher supports multiple AI providers. You can configure your provider t
 | **Anthropic** | `LLM_PROVIDER=anthropic`<br>`LLM_MODEL=claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com/) |
 | **Google Gemini** | `LLM_PROVIDER=gemini`<br>`LLM_MODEL=gemini/gemini-3-flash-preview` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | **OpenRouter** | `LLM_PROVIDER=openrouter`<br>`LLM_MODEL=deepseek/deepseek-chat` | [openrouter.ai](https://openrouter.ai/keys) |
+| **OrcaRouter** | `LLM_PROVIDER=orcarouter`<br>`LLM_MODEL=orcarouter/auto`<br>`LLM_API_BASE=https://api.orcarouter.ai/v1` (optional; defaulted) | [orcarouter.ai](https://www.orcarouter.ai) |
 | **DeepSeek** | `LLM_PROVIDER=deepseek`<br>`LLM_MODEL=deepseek-chat` | [platform.deepseek.com](https://platform.deepseek.com/) |
 | **OpenAI-Compatible** | `LLM_PROVIDER=openai_compatible`<br>`LLM_MODEL=llama-3.1-8b`<br>`LLM_API_BASE=http://localhost:8080/v1` | — (local) |
 

--- a/SETUP.zh-CN.md
+++ b/SETUP.zh-CN.md
@@ -217,6 +217,7 @@ Resume Matcher 支持多种 AI 提供商。你可以在应用的 Settings 页面
 | **Anthropic** | `LLM_PROVIDER=anthropic`<br>`LLM_MODEL=claude-haiku-4-5-20251001` | [console.anthropic.com](https://console.anthropic.com/) |
 | **Google Gemini** | `LLM_PROVIDER=gemini`<br>`LLM_MODEL=gemini-3-flash-preview` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | **OpenRouter** | `LLM_PROVIDER=openrouter`<br>`LLM_MODEL=deepseek/deepseek-chat` | [openrouter.ai](https://openrouter.ai/keys) |
+| **OrcaRouter** | `LLM_PROVIDER=orcarouter`<br>`LLM_MODEL=orcarouter/auto`<br>`LLM_API_BASE=https://api.orcarouter.ai/v1`（可选，默认） | [orcarouter.ai](https://www.orcarouter.ai) |
 | **DeepSeek** | `LLM_PROVIDER=deepseek`<br>`LLM_MODEL=deepseek-chat` | [platform.deepseek.com](https://platform.deepseek.com/) |
 | **OpenAI-Compatible** | `LLM_PROVIDER=openai_compatible`<br>`LLM_MODEL=llama-3.1-8b`<br>`LLM_API_BASE=http://localhost:8080/v1` | —（本地） |
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,7 +2,7 @@
 # LLM Provider Configuration
 # ===========================================
 # Supported providers:
-#   openai, openai_compatible, azure_foundry, anthropic, openrouter, gemini, deepseek, groq, ollama
+#   openai, openai_compatible, azure_foundry, anthropic, openrouter, orcarouter, gemini, deepseek, groq, ollama
 # openai_compatible = llama.cpp, vLLM, LM Studio, and any self-hosted server
 # that exposes the OpenAI Chat Completions API. API key is optional for this
 # provider (backend passes a sentinel when blank).
@@ -30,6 +30,12 @@ LLM_API_KEY=sk-your-api-key-here
 # LLM_PROVIDER=openrouter
 # LLM_MODEL=deepseek/deepseek-chat
 # LLM_API_KEY=sk-or-v1-your-key
+
+# For OrcaRouter (OpenAI-compatible gateway)
+# LLM_PROVIDER=orcarouter
+# LLM_MODEL=orcarouter/auto
+# LLM_API_KEY=sk-orca-your-key
+# LLM_API_BASE=https://api.orcarouter.ai/v1  # optional; defaults to this
 
 # For Azure AI Foundry / Azure AI Inference model endpoints
 # LLM_PROVIDER=azure_foundry

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -12,6 +12,13 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 CONFIG_FILE_PATH = Path(__file__).parent.parent / "data" / "config.json"
 ALLOWED_LOG_LEVELS = ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG")
 
+# Default OpenAI-compatible gateway endpoint for the OrcaRouter provider.
+# OrcaRouter is routed through LiteLLM's ``openai`` client (see
+# ``get_model_name`` in app/llm.py), which has no built-in provider base URL,
+# so users who leave the Base URL field blank get this gateway by default.
+ORCAROUTER_DEFAULT_BASE_URL = "https://api.orcarouter.ai/v1"
+ORCAROUTER_DEFAULT_MODEL = "orcarouter/auto"
+
 
 def _read_config_json() -> dict[str, Any]:
     """Raw read of config.json (no key injection)."""
@@ -158,6 +165,7 @@ _LEGACY_PROVIDER_KEY_MAP: dict[str, str] = {
     "anthropic": "anthropic",
     "gemini": "google",
     "openrouter": "openrouter",
+    "orcarouter": "orcarouter",
     "deepseek": "deepseek",
     "groq": "groq",
     "ollama": "ollama",
@@ -187,6 +195,7 @@ def _get_llm_api_key_with_fallback() -> str:
         "anthropic": "anthropic",
         "gemini": "google",
         "openrouter": "openrouter",
+        "orcarouter": "orcarouter",
         "deepseek": "deepseek",
         "groq": "groq",
         "ollama": "ollama",
@@ -212,6 +221,7 @@ class Settings(BaseSettings):
         "azure_foundry",
         "anthropic",
         "openrouter",
+        "orcarouter",
         "gemini",
         "deepseek",
         "groq",

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -12,7 +12,12 @@ from litellm import Router
 from litellm.router import RetryPolicy
 from pydantic import BaseModel
 
-from app.config import load_config_file, save_config_file, settings
+from app.config import (
+    ORCAROUTER_DEFAULT_BASE_URL,
+    load_config_file,
+    save_config_file,
+    settings,
+)
 
 LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
 
@@ -169,7 +174,9 @@ def _normalize_api_base(provider: str, api_base: str | None, model: str | None =
 
     # OpenAI / OpenAI-compatible: preserve the URL as-is. The OpenAI client
     # resolves paths correctly whether the base includes /v1 or not.
-    if provider in ("openai", "openai_compatible"):
+    # OrcaRouter is an OpenAI-compatible gateway routed via LiteLLM's OpenAI
+    # client (see get_model_name), so its base URL must also be preserved.
+    if provider in ("openai", "openai_compatible", "orcarouter"):
         return base or None
 
     # Anthropic handler appends '/v1/messages'. If base already ends with '/v1',
@@ -393,6 +400,7 @@ _PROVIDER_KEY_MAP: dict[str, str] = {
     "anthropic": "anthropic",
     "gemini": "google",
     "openrouter": "openrouter",
+    "orcarouter": "orcarouter",
     "deepseek": "deepseek",
     "groq": "groq",
     "ollama": "ollama",
@@ -479,11 +487,19 @@ def get_llm_config() -> LLMConfig:
     # Normalize empty string to None — user explicitly cleared.
     reasoning_effort = raw_re if raw_re else None
 
+    # OrcaRouter is an OpenAI-compatible gateway routed via LiteLLM's openai
+    # client. It has no built-in provider endpoint, so when the user leaves the
+    # Base URL blank we default to the public gateway endpoint. An explicit
+    # stored/override value always wins.
+    api_base = stored.get("api_base", settings.llm_api_base)
+    if provider == "orcarouter" and not api_base:
+        api_base = ORCAROUTER_DEFAULT_BASE_URL
+
     return LLMConfig(
         provider=provider,
         model=model,
         api_key=api_key,
-        api_base=stored.get("api_base", settings.llm_api_base),
+        api_base=api_base,
         api_version=stored.get("api_version"),
         reasoning_effort=reasoning_effort,
     )
@@ -502,6 +518,10 @@ def get_model_name(config: LLMConfig) -> str:
         # client handles the request; works for llama.cpp, vLLM, LM Studio,
         # and any server exposing the OpenAI Chat Completions API shape.
         "openai_compatible": "openai/",
+        # OrcaRouter is an OpenAI-compatible gateway. Routing via LiteLLM's
+        # openai/ prefix makes the OpenAI client send the gateway alias
+        # (e.g. orcarouter/auto) to https://api.orcarouter.ai/v1.
+        "orcarouter": "openai/",
         "azure_foundry": "azure_ai/",
         "anthropic": "anthropic/",
         "openrouter": "openrouter/",
@@ -534,6 +554,16 @@ def get_model_name(config: LLMConfig) -> str:
         if config.model.startswith("openrouter/"):
             return config.model
         return f"openrouter/{config.model}"
+
+    # OrcaRouter is an OpenAI-compatible gateway. Always route through LiteLLM's
+    # openai client so the model name is forwarded verbatim to the gateway
+    # endpoint — a vendor-qualified id like deepseek/deepseek-v4-pro must NOT be
+    # intercepted by LiteLLM's own deepseek provider. Add openai/ unless already
+    # present (mirrors the OpenRouter special case above).
+    if config.provider == "orcarouter":
+        if config.model.startswith("openai/"):
+            return config.model
+        return f"openai/{config.model}"
 
     # For other providers, don't add prefix if model already has a known prefix
     known_prefixes = [
@@ -1074,6 +1104,7 @@ def _calculate_timeout(
         "anthropic": 1.2,
         "azure_foundry": 1.2,
         "openrouter": 1.5,  # More variable latency
+        "orcarouter": 1.5,  # Gateway: variable latency across upstream models
         "groq": 1.0,
         "ollama": 2.0,  # Local models can be slower
     }

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -475,6 +475,7 @@ SUPPORTED_PROVIDERS = [
     "anthropic",
     "google",
     "openrouter",
+    "orcarouter",
     "deepseek",
     "groq",
     "openai_compatible",
@@ -560,6 +561,13 @@ async def update_api_keys(request: ApiKeysUpdateRequest) -> ApiKeysUpdateRespons
             del stored_keys["openrouter"]
         updated.append("openrouter")
 
+    if request.orcarouter is not None:
+        if request.orcarouter:
+            stored_keys["orcarouter"] = request.orcarouter
+        elif "orcarouter" in stored_keys:
+            del stored_keys["orcarouter"]
+        updated.append("orcarouter")
+
     if request.deepseek is not None:
         if request.deepseek:
             stored_keys["deepseek"] = request.deepseek
@@ -628,7 +636,7 @@ async def delete_api_key(provider: str) -> dict:
     """Delete API key for a specific provider.
 
     Args:
-        provider: The provider name (openai, anthropic, google, openrouter, deepseek)
+        provider: The provider name (openai, anthropic, google, openrouter, orcarouter, deepseek)
 
     Returns:
         Success message

--- a/apps/backend/app/schemas/models.py
+++ b/apps/backend/app/schemas/models.py
@@ -820,6 +820,7 @@ class ApiKeysUpdateRequest(BaseModel):
     anthropic: str | None = None
     google: str | None = None
     openrouter: str | None = None
+    orcarouter: str | None = None
     deepseek: str | None = None
     groq: str | None = None
     # Local/self-hosted providers that may sit behind an auth proxy.

--- a/apps/backend/tests/integration/test_config_api.py
+++ b/apps/backend/tests/integration/test_config_api.py
@@ -445,6 +445,18 @@ class TestEncryptedApiKeys:
         # The gemini LLM provider maps to the google key-store slot.
         assert resolve_api_key(stored, "gemini") == "sk-google-key"
 
+    async def test_orcarouter_key_stored_and_resolved(self, keys_env, client):
+        from app.config import load_config_file
+        from app.llm import resolve_api_key
+
+        async with client:
+            await client.post("/api/v1/config/api-keys", json={"orcarouter": "sk-orca-1234"})
+            status = await client.get("/api/v1/config/api-keys")
+        configured = {p["provider"]: p for p in status.json()["providers"]}
+        assert configured["orcarouter"]["configured"] is True
+        stored = load_config_file()
+        assert resolve_api_key(stored, "orcarouter") == "sk-orca-1234"
+
     async def test_delete_single_provider(self, keys_env, client):
         async with client:
             await client.post("/api/v1/config/api-keys", json={"openai": "a", "anthropic": "b"})
@@ -526,6 +538,23 @@ class TestLegacyKeyMigration:
 
 class TestRequiresBaseUrlValidation:
     """M-05: requiresBaseUrl was a UI-only guard until now."""
+
+    async def test_supported_providers_include_orcarouter(self, client):
+        """The API-key provider list must expose orcarouter end to end."""
+        from app.routers.config import SUPPORTED_PROVIDERS
+
+        assert "orcarouter" in SUPPORTED_PROVIDERS
+
+    async def test_orcarouter_requires_key_but_not_base_url(self, client):
+        """OrcaRouter is a cloud gateway: it needs a key but supplies its own
+        default endpoint, so saving with a blank Base URL must not 422."""
+        async with client:
+            resp = await client.put(
+                "/api/v1/config/llm-api-key",
+                json={"provider": "orcarouter", "model": "orcarouter/auto"},
+            )
+
+        assert resp.status_code == 200
 
     async def test_azure_foundry_without_base_url_is_rejected(self, client):
         async with client:

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -11,6 +11,7 @@ from app.llm import (
     _get_retry_temperature,
     _normalize_api_base,
     _supports_temperature,
+    get_llm_config,
     get_model_name,
     resolve_api_key,
 )
@@ -704,3 +705,47 @@ class TestScrubSecrets:
         assert "sk-abcd1234efgh5678" not in _scrub_secrets("key sk-abcd1234efgh5678 failed")
         assert "AIzaSyABCDEFGHIJ" not in _scrub_secrets("key AIzaSyABCDEFGHIJ failed")
         assert "tok_secret" not in _scrub_secrets("Authorization: Bearer tok_secret")
+
+
+# ---------------------------------------------------------------------------
+# get_llm_config — OrcaRouter default base URL
+# ---------------------------------------------------------------------------
+
+
+class TestOrcaRouterConfig:
+    """OrcaRouter is an OpenAI-compatible gateway routed via LiteLLM's openai
+    client. When the user leaves the Base URL blank, get_llm_config() fills in
+    the public gateway endpoint so a named OrcaRouter config works out of the box.
+    """
+
+    @patch("app.llm.load_config_file")
+    def test_orcarouter_defaults_to_gateway_base_url(self, mock_load):
+        mock_load.return_value = {"provider": "orcarouter", "model": "orcarouter/auto"}
+
+        config = get_llm_config()
+
+        assert config.provider == "orcarouter"
+        assert config.api_base == "https://api.orcarouter.ai/v1"
+
+    @patch("app.llm.load_config_file")
+    def test_orcarouter_explicit_base_url_wins(self, mock_load):
+        mock_load.return_value = {
+            "provider": "orcarouter",
+            "model": "orcarouter/auto",
+            "api_base": "https://gateway.example.com/v1",
+        }
+
+        config = get_llm_config()
+
+        assert config.api_base == "https://gateway.example.com/v1"
+
+    @patch("app.llm.load_config_file")
+    def test_other_providers_unaffected(self, mock_load):
+        # The default-base-url injection is scoped to orcarouter; other
+        # providers keep their None (empty) api_base untouched.
+        mock_load.return_value = {"provider": "openai", "model": "gpt-4o"}
+
+        config = get_llm_config()
+
+        assert config.provider == "openai"
+        assert config.api_base is None

--- a/apps/backend/tests/unit/test_llm_providers.py
+++ b/apps/backend/tests/unit/test_llm_providers.py
@@ -60,6 +60,19 @@ class TestGetModelName:
             == "openrouter/anthropic/claude-3.5-sonnet"
         )
 
+    def test_orcarouter_routes_via_openai_prefix(self):
+        # OrcaRouter is an OpenAI-compatible gateway; LiteLLM's openai/ prefix
+        # sends the model name verbatim to https://api.orcarouter.ai/v1.
+        assert get_model_name(_cfg("orcarouter", "orcarouter/auto")) == "openai/orcarouter/auto"
+        assert (
+            get_model_name(_cfg("orcarouter", "deepseek/deepseek-v4-pro"))
+            == "openai/deepseek/deepseek-v4-pro"
+        )
+        assert (
+            get_model_name(_cfg("orcarouter", "openai/gpt-4o"))
+            == "openai/gpt-4o"  # no double prefix
+        )
+
     def test_anthropic_prefix(self):
         assert get_model_name(_cfg("anthropic", "claude-3-opus")) == "anthropic/claude-3-opus"
 
@@ -95,6 +108,19 @@ class TestNormalizeApiBase:
         assert (
             _normalize_api_base("openai_compatible", "http://localhost:8080/v1")
             == "http://localhost:8080/v1"
+        )
+
+    def test_orcarouter_preserves_v1_as_is(self):
+        # OrcaRouter is routed through the OpenAI client, which handles /v1
+        # correctly — preserve the pasted base URL so api.orcarouter.ai/v1
+        # round-trips intact (mirrors the openai/openai_compatible rule).
+        assert (
+            _normalize_api_base("orcarouter", "https://api.orcarouter.ai/v1")
+            == "https://api.orcarouter.ai/v1"
+        )
+        assert (
+            _normalize_api_base("orcarouter", "https://api.orcarouter.ai/v1/")
+            == "https://api.orcarouter.ai/v1"
         )
 
     def test_openai_strips_only_trailing_slash(self):
@@ -151,6 +177,11 @@ class TestResolveApiKey:
     def test_cloud_provider_does_inherit_env_key(self, monkeypatch):
         monkeypatch.setattr("app.llm.settings.llm_api_key", "sk-paid-secret")
         assert resolve_api_key({}, "openai") == "sk-paid-secret"
+
+    def test_orcarouter_key_from_provider_store(self):
+        # OrcaRouter keys live in their own encrypted store slot.
+        stored = {"api_keys": {"orcarouter": "sk-orca-1234"}}
+        assert resolve_api_key(stored, "orcarouter") == "sk-orca-1234"
 
 
 # ---------------------------------------------------------------------------

--- a/apps/frontend/app/(default)/settings/page.tsx
+++ b/apps/frontend/app/(default)/settings/page.tsx
@@ -74,6 +74,7 @@ const PROVIDERS: LLMProvider[] = [
   'azure_foundry',
   'anthropic',
   'openrouter',
+  'orcarouter',
   'gemini',
   'deepseek',
   'groq',

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -7,6 +7,7 @@ export type LLMProvider =
   | 'azure_foundry'
   | 'anthropic'
   | 'openrouter'
+  | 'orcarouter'
   | 'gemini'
   | 'deepseek'
   | 'groq'
@@ -193,6 +194,12 @@ export const PROVIDER_INFO: Record<
     name: 'OpenRouter',
     defaultModel: 'deepseek/deepseek-chat',
     requiresKey: true,
+  },
+  orcarouter: {
+    name: 'OrcaRouter',
+    defaultModel: 'orcarouter/auto',
+    requiresKey: true,
+    defaultBaseUrl: 'https://api.orcarouter.ai/v1',
   },
   gemini: { name: 'Google Gemini', defaultModel: 'gemini-3-flash-preview', requiresKey: true },
   deepseek: { name: 'DeepSeek', defaultModel: 'deepseek-chat', requiresKey: true },
@@ -421,6 +428,7 @@ export type ApiKeyProvider =
   | 'anthropic'
   | 'google'
   | 'openrouter'
+  | 'orcarouter'
   | 'deepseek'
   | 'groq'
   | 'openai_compatible'
@@ -450,6 +458,7 @@ export interface ApiKeysUpdateRequest {
   anthropic?: string;
   google?: string;
   openrouter?: string;
+  orcarouter?: string;
   deepseek?: string;
   groq?: string;
   openai_compatible?: string;
@@ -469,6 +478,10 @@ export const API_KEY_PROVIDER_INFO: Record<ApiKeyProvider, { name: string; descr
     anthropic: { name: 'Anthropic', description: 'Claude 3.5, Claude 4, etc.' },
     google: { name: 'Google', description: 'Gemini 1.5, Gemini 2, etc.' },
     openrouter: { name: 'OpenRouter', description: 'Access multiple providers' },
+    orcarouter: {
+      name: 'OrcaRouter',
+      description: 'OpenAI-compatible gateway with zero-trust agent security',
+    },
     deepseek: { name: 'DeepSeek', description: 'DeepSeek chat models' },
     groq: { name: 'Groq', description: 'Llama, Mixtral, Gemma on Groq' },
     openai_compatible: { name: 'OpenAI-Compatible', description: 'Self-hosted / proxy endpoints' },

--- a/apps/frontend/tests/api-config.test.ts
+++ b/apps/frontend/tests/api-config.test.ts
@@ -20,6 +20,7 @@ const ALL_PROVIDERS: LLMProvider[] = [
   'openai_compatible',
   'anthropic',
   'openrouter',
+  'orcarouter',
   'gemini',
   'deepseek',
   'groq',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - LOG_LLM=${LOG_LLM:-WARNING}
       #- LOG_LLM_FILE=${LOG_LLM_FILE:-}
       # LLM Configuration - configure via Settings UI or set env vars for explicit overrides
-      # Supported providers: openai, anthropic, openrouter, gemini, deepseek, ollama
+      # Supported providers: openai, anthropic, openrouter, orcarouter, gemini, deepseek, ollama
       # Defaults are defined in apps/backend/app/config.py
       - LLM_PROVIDER=${LLM_PROVIDER:-openai}
       - LLM_MODEL=${LLM_MODEL:-}

--- a/docs/agent/llm-integration.md
+++ b/docs/agent/llm-integration.md
@@ -14,6 +14,7 @@ Backend uses LiteLLM to support multiple providers through a unified API:
 | **Anthropic** | Cloud | Claude Haiku 4.5 |
 | **Google Gemini** | Cloud | Gemini 3 Flash |
 | **OpenRouter** | Cloud | Access to multiple models |
+| **[OrcaRouter](https://www.orcarouter.ai)** | Cloud | OpenAI-compatible gateway with zero-trust agent security |
 | **DeepSeek** | Cloud | DeepSeek Chat |
 
 ## API Key Handling


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class, named model provider in the LiteLLM layer, mirroring how OpenRouter / DeepSeek / Groq are wired.

OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `apps/backend/app/llm.py`: route `orcarouter` via LiteLLM's `openai/` prefix so model names are forwarded verbatim to the gateway (gateway aliases like `orcarouter/auto` and vendor-qualified ids like `deepseek/deepseek-v4-pro`); preserve `/v1` in `_normalize_api_base`; default the base URL to `https://api.orcarouter.ai/v1` when blank; add a latency factor.
- `apps/backend/app/config.py`: register `orcarouter` in the provider key maps, extend the `llm_provider` Literal, add default base URL/model constants.
- `apps/backend/app/routers/config.py` + `apps/backend/app/schemas/models.py`: expose `orcarouter` in `SUPPORTED_PROVIDERS` and the per-provider encrypted key store (`ORCAROUTER_API_KEY`, `sk-orca-` prefix).
- `apps/frontend/lib/api/config.ts` + `apps/frontend/app/(default)/settings/page.tsx`: add OrcaRouter to the provider unions, `PROVIDER_INFO` (name / default model `orcarouter/auto` / base URL), `API_KEY_PROVIDER_INFO`, and the Settings provider picker.
- Docs: `.env.example`, `docker-compose.yml` comment, `README` (EN/ES/JA/ZH), `SETUP` (EN/ES/JA/ZH), `docs/agent/llm-integration.md` provider tables.
- Tests: unit tests for `get_model_name` / `_normalize_api_base` / `resolve_api_key` / `get_llm_config` default base URL; integration contract tests for the key store and `SUPPORTED_PROVIDERS`; frontend `PROVIDER_INFO` completeness.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how OpenRouter is wired in this repo: a named provider entry keeps the Settings picker, per-provider API key store and docs consistent for users, instead of relying on the free-text `openai_compatible` base-URL field.

## How to use it

1. In **Settings → LLM Configuration**, select **OrcaRouter**.
2. Enter an API key from [orcarouter.ai](https://www.orcarouter.ai) (`sk-orca-...`).
3. Model defaults to `orcarouter/auto` (adaptive routing); base URL defaults to `https://api.orcarouter.ai/v1`.
4. Click **Test Connection** to verify.

Or via env:

```env
LLM_PROVIDER=orcarouter
LLM_MODEL=orcarouter/auto
LLM_API_KEY=sk-orca-your-key
# LLM_API_BASE=https://api.orcarouter.ai/v1  # optional; defaulted
```

## How to test

- Backend: `uv run pytest tests/unit/test_llm.py tests/unit/test_llm_providers.py` (all pass); config key-store contract tests added.
- Frontend: `npm run test` (265 passed), `npm run lint`, `npm run build` all green.
- Verified live against `https://api.orcarouter.ai/v1/chat/completions` with a real key through the production wiring (`get_model_name` → `openai/orcarouter/auto`, base `https://api.orcarouter.ai/v1`) — HTTP 200, `ORCA-OK`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `orcarouter` as a first-class provider routed via `LiteLLM`’s `openai/` client, replacing the prior “use `openai_compatible` + custom base URL” workaround. This enables one-click selection in Settings, a default base URL, and a dedicated encrypted key slot.

- Routes `orcarouter` through `openai/` in `get_model_name` so model ids pass through verbatim (e.g., `orcarouter/auto`, `deepseek/deepseek-v4-pro`); avoids double prefixing when already `openai/…`.
- Preserves `/v1` for `orcarouter` in `_normalize_api_base` and defaults the Base URL to `https://api.orcarouter.ai/v1` when blank; adds a provider-specific latency factor.
- Exposes `orcarouter` across backend (`SUPPORTED_PROVIDERS`, provider literals, API keys schema) and frontend (`LLMProvider`/`ApiKeyProvider` unions, `PROVIDER_INFO` with default model and base URL, Settings picker).
- Updates docs and examples; adds unit and integration tests for routing, base URL behavior, key storage, and provider lists.

Bolded rollout or migration details:
- No breaking changes. Existing provider configs continue to work.
- Optional: If you previously used OrcaRouter via `openai_compatible`, switch provider to `orcarouter` in Settings; leave Base URL blank to use `https://api.orcarouter.ai/v1` and provide a `sk-orca-…` API key.

<sup>Written for commit eeba337fa17c995e9a4c7f8563cfeaa4446c052b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

