### PR TITLE
feat(tracker): add status visibility management

### DIFF
--- a/apps/frontend/components/tracker/kanban-board.tsx
+++ b/apps/frontend/components/tracker/kanban-board.tsx
@@ -15,6 +15,7 @@ import Plus from 'lucide-react/dist/esm/icons/plus';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
 import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left';
 import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right';
+import Settings2 from 'lucide-react/dist/esm/icons/settings-2';
 import { Button } from '@/components/ui/button';
 import { useTranslations } from '@/lib/i18n';
 import {
@@ -31,7 +32,12 @@ import { KanbanColumn } from './kanban-column';
 import { BulkActionBar } from './bulk-action-bar';
 import { CardDetailModal } from './card-detail-modal';
 import { ManualAddApplicationDialog } from './manual-add-application-dialog';
+import { TrackerColumnManagerDialog } from './tracker-column-manager-dialog';
 import { planMove } from './reorder';
+import {
+  loadVisibleTrackerStatuses,
+  saveVisibleTrackerStatuses,
+} from '@/lib/utils/tracker-column-visibility';
 
 function emptyColumns(): ApplicationColumns {
   return APPLICATION_STATUS_ORDER.reduce((acc, status) => {
@@ -53,6 +59,9 @@ export function KanbanBoard() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [openCardId, setOpenCardId] = useState<string | null>(null);
   const [manualAddOpen, setManualAddOpen] = useState(false);
+  const [managerOpen, setManagerOpen] = useState(false);
+  const [visibleStatuses, setVisibleStatuses] =
+    useState<ApplicationStatus[]>(APPLICATION_STATUS_ORDER);
 
   // Horizontal-scroll affordance: the seven stages overflow the canvas, so we
   // track whether more columns sit off-screen and surface controls + a stage
@@ -79,6 +88,12 @@ export function KanbanBoard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Read after mount to preserve SSR hydration; defaults keep every stage
+  // visible until the browser-specific preference is available.
+  useEffect(() => {
+    setVisibleStatuses(loadVisibleTrackerStatuses());
+  }, []);
+
   const allCards: Application[] = useMemo(
     () => APPLICATION_STATUS_ORDER.flatMap((status) => columns[status]),
     [columns]
@@ -96,6 +111,18 @@ export function KanbanBoard() {
   }, [allCards]);
 
   const isEmpty = allCards.length === 0;
+  const allColumnsHidden = visibleStatuses.length === 0;
+
+  const handleVisibilityChange = (status: ApplicationStatus, visible: boolean) => {
+    setVisibleStatuses((current) => {
+      const selected = new Set(current);
+      if (visible) selected.add(status);
+      else selected.delete(status);
+      const next = APPLICATION_STATUS_ORDER.filter((item) => selected.has(item));
+      saveVisibleTrackerStatuses(next);
+      return next;
+    });
+  };
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -113,7 +140,7 @@ export function KanbanBoard() {
       el.removeEventListener('scroll', sync);
       window.removeEventListener('resize', sync);
     };
-  }, [loading, isEmpty]);
+  }, [loading, isEmpty, visibleStatuses.length]);
 
   const scrollByColumn = (direction: 1 | -1) => {
     scrollRef.current?.scrollBy({ left: direction * 320, behavior: 'smooth' });
@@ -181,7 +208,7 @@ export function KanbanBoard() {
     }
   };
 
-  const showScrollControls = !isEmpty && (canScrollLeft || canScrollRight);
+  const showScrollControls = !isEmpty && !allColumnsHidden && (canScrollLeft || canScrollRight);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -196,6 +223,10 @@ export function KanbanBoard() {
           </p>
         </div>
         <div className="flex items-center gap-3">
+          <Button variant="outline" onClick={() => setManagerOpen(true)}>
+            <Settings2 className="h-4 w-4" />
+            {t('tracker.manage.button')}
+          </Button>
           {showScrollControls && (
             <div className="flex items-center">
               <button
@@ -254,6 +285,13 @@ export function KanbanBoard() {
             <p className="font-serif text-lg text-ink">{t('tracker.empty.title')}</p>
             <p className="mt-1 font-mono text-xs text-ink-soft">{t('tracker.empty.description')}</p>
           </div>
+        ) : allColumnsHidden ? (
+          <div className="flex flex-1 flex-col items-center justify-center p-10 text-center">
+            <p className="font-serif text-lg text-ink">{t('tracker.manage.allHiddenTitle')}</p>
+            <p className="mt-1 font-mono text-xs text-ink-soft">
+              {t('tracker.manage.allHiddenDescription')}
+            </p>
+          </div>
         ) : (
           <DndContext
             sensors={sensors}
@@ -261,12 +299,12 @@ export function KanbanBoard() {
             onDragEnd={handleDragEnd}
           >
             <div ref={scrollRef} className="flex min-h-0 flex-1 overflow-x-auto">
-              {APPLICATION_STATUS_ORDER.map((status, index) => (
+              {visibleStatuses.map((status, index) => (
                 <div
                   key={status}
                   data-column={status}
                   className={`flex ${
-                    index < APPLICATION_STATUS_ORDER.length - 1 ? 'border-r border-black' : ''
+                    index < visibleStatuses.length - 1 ? 'border-r border-black' : ''
                   }`}
                 >
                   <KanbanColumn
@@ -286,7 +324,7 @@ export function KanbanBoard() {
 
       {/* Stage rail — an always-visible map of every stage (with counts) so
           off-screen sections are never lost; click a stage to jump to it. */}
-      {!isEmpty && (
+      {!isEmpty && !allColumnsHidden && (
         <div className="flex shrink-0 items-center gap-3 overflow-x-auto border-t border-black bg-paper-tint px-6 py-2 md:px-8">
           {canScrollRight && (
             <span className="flex shrink-0 items-center gap-1 font-mono text-[11px] font-bold uppercase tracking-wide text-primary">
@@ -295,7 +333,7 @@ export function KanbanBoard() {
             </span>
           )}
           <div className="flex items-center gap-2">
-            {APPLICATION_STATUS_ORDER.map((status) => (
+            {visibleStatuses.map((status) => (
               <button
                 key={status}
                 type="button"
@@ -323,6 +361,13 @@ export function KanbanBoard() {
         open={manualAddOpen}
         onOpenChange={setManualAddOpen}
         onCreated={load}
+      />
+
+      <TrackerColumnManagerDialog
+        open={managerOpen}
+        onOpenChange={setManagerOpen}
+        visibleStatuses={visibleStatuses}
+        onVisibilityChange={handleVisibilityChange}
       />
     </div>
   );

--- a/apps/frontend/components/tracker/tracker-column-manager-dialog.tsx
+++ b/apps/frontend/components/tracker/tracker-column-manager-dialog.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ToggleSwitch } from '@/components/ui/toggle-switch';
+import { useTranslations } from '@/lib/i18n';
+import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
+
+interface TrackerColumnManagerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  visibleStatuses: ApplicationStatus[];
+  onVisibilityChange: (status: ApplicationStatus, visible: boolean) => void;
+}
+
+export function TrackerColumnManagerDialog({
+  open,
+  onOpenChange,
+  visibleStatuses,
+  onVisibilityChange,
+}: TrackerColumnManagerDialogProps) {
+  const { t } = useTranslations();
+  const visibleSet = new Set(visibleStatuses);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{t('tracker.manage.title')}</DialogTitle>
+          <DialogDescription>{t('tracker.manage.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          {APPLICATION_STATUS_ORDER.map((status) => (
+            <ToggleSwitch
+              key={status}
+              checked={visibleSet.has(status)}
+              onCheckedChange={(visible) => onVisibilityChange(status, visible)}
+              label={t(`tracker.columns.${status}`)}
+            />
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('tracker.manage.done')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/lib/utils/tracker-column-visibility.ts
+++ b/apps/frontend/lib/utils/tracker-column-visibility.ts
@@ -1,0 +1,44 @@
+import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
+
+export const TRACKER_COLUMN_VISIBILITY_STORAGE_KEY = 'resume-matcher:tracker-column-visibility:v1';
+
+const isApplicationStatus = (value: unknown): value is ApplicationStatus =>
+  typeof value === 'string' && APPLICATION_STATUS_ORDER.includes(value as ApplicationStatus);
+
+/**
+ * Read the user's visible tracker stages without letting unavailable browser
+ * storage or a stale hand-edited value prevent the board from rendering.
+ */
+export function loadVisibleTrackerStatuses(): ApplicationStatus[] {
+  try {
+    const raw = localStorage.getItem(TRACKER_COLUMN_VISIBILITY_STORAGE_KEY);
+    if (!raw) return [...APPLICATION_STATUS_ORDER];
+
+    const parsed = JSON.parse(raw) as { visibleStatuses?: unknown };
+    if (!Array.isArray(parsed.visibleStatuses)) return [...APPLICATION_STATUS_ORDER];
+
+    // An intentionally empty list is valid: the persistent Manage control lets
+    // the user restore stages. Unknown-only data is stale/corrupt, so fall back.
+    const known = parsed.visibleStatuses.filter(isApplicationStatus);
+    if (parsed.visibleStatuses.length > 0 && known.length === 0) {
+      return [...APPLICATION_STATUS_ORDER];
+    }
+
+    const selected = new Set(known);
+    return APPLICATION_STATUS_ORDER.filter((status) => selected.has(status));
+  } catch {
+    return [...APPLICATION_STATUS_ORDER];
+  }
+}
+
+export function saveVisibleTrackerStatuses(statuses: ApplicationStatus[]): void {
+  try {
+    localStorage.setItem(
+      TRACKER_COLUMN_VISIBILITY_STORAGE_KEY,
+      JSON.stringify({ visibleStatuses: statuses })
+    );
+  } catch {
+    // Storage can be blocked by browser or enterprise policy. The preference
+    // still applies for the current page session.
+  }
+}

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -983,6 +983,14 @@
     "title": "Application Tracker",
     "subtitle": "Track where each tailored resume stands in your pipeline.",
     "addApplication": "Add Application",
+    "manage": {
+      "button": "Manage",
+      "title": "Manage stages",
+      "description": "Choose which stages appear on this board. Hidden stages keep their applications.",
+      "done": "Done",
+      "allHiddenTitle": "All stages are hidden",
+      "allHiddenDescription": "Use Manage to show one or more stages."
+    },
     "columns": {
       "saved": "Saved",
       "applied": "Applied",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -983,6 +983,14 @@
     "title": "Seguimiento de candidaturas",
     "subtitle": "Controla en qué punto está cada currículum adaptado de tu proceso.",
     "addApplication": "Añadir candidatura",
+    "manage": {
+      "button": "Gestionar",
+      "title": "Gestionar etapas",
+      "description": "Elige qué etapas aparecen en este tablero. Las etapas ocultas conservan sus candidaturas.",
+      "done": "Listo",
+      "allHiddenTitle": "Todas las etapas están ocultas",
+      "allHiddenDescription": "Usa Gestionar para mostrar una o más etapas."
+    },
     "columns": {
       "saved": "Guardado",
       "applied": "Enviado",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -983,6 +983,14 @@
     "title": "Suivi des candidatures",
     "subtitle": "Suivez l'avancement de chaque CV personnalisé dans votre pipeline.",
     "addApplication": "Ajouter une candidature",
+    "manage": {
+      "button": "Gérer",
+      "title": "Gérer les étapes",
+      "description": "Choisissez les étapes à afficher sur ce tableau. Les étapes masquées conservent leurs candidatures.",
+      "done": "Terminé",
+      "allHiddenTitle": "Toutes les étapes sont masquées",
+      "allHiddenDescription": "Utilisez Gérer pour afficher une ou plusieurs étapes."
+    },
     "columns": {
       "saved": "Enregistré",
       "applied": "Postulé",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -983,6 +983,14 @@
     "title": "応募トラッカー",
     "subtitle": "各カスタマイズ済み履歴書の選考状況を管理します。",
     "addApplication": "応募を追加",
+    "manage": {
+      "button": "管理",
+      "title": "ステージを管理",
+      "description": "このボードに表示するステージを選択します。非表示のステージでも応募データは保持されます。",
+      "done": "完了",
+      "allHiddenTitle": "すべてのステージが非表示です",
+      "allHiddenDescription": "管理を使用して、1 つ以上のステージを表示してください。"
+    },
     "columns": {
       "saved": "保存済み",
       "applied": "応募済み",

--- a/apps/frontend/messages/ko.json
+++ b/apps/frontend/messages/ko.json
@@ -983,6 +983,14 @@
     "title": "지원 현황 트래커",
     "subtitle": "각 맞춤화된 이력서가 지원 파이프라인에서 어느 단계에 있는지 추적하세요.",
     "addApplication": "지원 추가",
+    "manage": {
+      "button": "관리",
+      "title": "단계 관리",
+      "description": "이 보드에 표시할 단계를 선택하세요. 숨긴 단계의 지원 기록은 유지됩니다.",
+      "done": "완료",
+      "allHiddenTitle": "모든 단계가 숨겨져 있습니다",
+      "allHiddenDescription": "관리에서 하나 이상의 단계를 표시하세요."
+    },
     "columns": {
       "saved": "저장됨",
       "applied": "지원 완료",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -983,6 +983,14 @@
     "title": "Acompanhamento de candidaturas",
     "subtitle": "Acompanhe em que etapa está cada currículo personalizado.",
     "addApplication": "Adicionar candidatura",
+    "manage": {
+      "button": "Gerenciar",
+      "title": "Gerenciar etapas",
+      "description": "Escolha quais etapas aparecem neste quadro. As etapas ocultas mantêm suas candidaturas.",
+      "done": "Concluído",
+      "allHiddenTitle": "Todas as etapas estão ocultas",
+      "allHiddenDescription": "Use Gerenciar para mostrar uma ou mais etapas."
+    },
     "columns": {
       "saved": "Salvo",
       "applied": "Enviado",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -983,6 +983,14 @@
     "title": "申请追踪",
     "subtitle": "追踪每份定制简历在求职流程中的进展。",
     "addApplication": "添加申请",
+    "manage": {
+      "button": "管理",
+      "title": "管理状态模块",
+      "description": "选择要在此看板显示的状态模块。隐藏状态会保留其中的申请记录。",
+      "done": "完成",
+      "allHiddenTitle": "所有状态模块均已隐藏",
+      "allHiddenDescription": "使用“管理”显示一个或多个状态模块。"
+    },
     "columns": {
       "saved": "已保存",
       "applied": "已投递",

--- a/apps/frontend/tests/tracker-column-visibility.test.ts
+++ b/apps/frontend/tests/tracker-column-visibility.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { APPLICATION_STATUS_ORDER } from '@/lib/api/tracker';
+import {
+  loadVisibleTrackerStatuses,
+  saveVisibleTrackerStatuses,
+  TRACKER_COLUMN_VISIBILITY_STORAGE_KEY,
+} from '@/lib/utils/tracker-column-visibility';
+
+describe('tracker column visibility storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows every stage by default', () => {
+    expect(loadVisibleTrackerStatuses()).toEqual(APPLICATION_STATUS_ORDER);
+  });
+
+  it('persists the chosen stages in canonical board order', () => {
+    saveVisibleTrackerStatuses(['interview', 'saved']);
+
+    expect(loadVisibleTrackerStatuses()).toEqual(['saved', 'interview']);
+    expect(JSON.parse(localStorage.getItem(TRACKER_COLUMN_VISIBILITY_STORAGE_KEY)!)).toEqual({
+      visibleStatuses: ['interview', 'saved'],
+    });
+  });
+
+  it('keeps an intentional choice to hide every stage', () => {
+    saveVisibleTrackerStatuses([]);
+
+    expect(loadVisibleTrackerStatuses()).toEqual([]);
+  });
+
+  it('falls back to every stage for malformed or unknown-only stored data', () => {
+    localStorage.setItem(TRACKER_COLUMN_VISIBILITY_STORAGE_KEY, '{not json');
+    expect(loadVisibleTrackerStatuses()).toEqual(APPLICATION_STATUS_ORDER);
+
+    localStorage.setItem(
+      TRACKER_COLUMN_VISIBILITY_STORAGE_KEY,
+      JSON.stringify({ visibleStatuses: ['archived'] })
+    );
+    expect(loadVisibleTrackerStatuses()).toEqual(APPLICATION_STATUS_ORDER);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a Manage control to the Application Tracker.
- Let users show or hide individual status columns.
- Persist column visibility preferences in browser local storage.
- Preserve all application records when a status column is hidden.
- Add an all-columns-hidden recovery state.

## Scope

- Frontend-only change.
- No backend API, database, or data-model changes.

## Testing

- `npm test` — 269 tests passed
- `npm run typecheck` — passed
- Prettier check — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Manage control to the Application Tracker so users can show or hide status columns. Visibility preferences persist in browser local storage, hidden columns keep their applications, and a recovery state appears when all columns are hidden.

<sup>Written for commit dabbc4c027124be669c1425f7cd30c45a53ce87d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

