### PR TITLE
fix: preserve structured resume output for compatible LLMs (#924) + review follow-ups

### DIFF
--- a/apps/backend/app/database.py
+++ b/apps/backend/app/database.py
@@ -45,6 +45,21 @@ APPLICATION_STATUSES: tuple[str, ...] = (
 )
 
 
+class ResumeNotFoundError(ValueError):
+    """Raised when a write targets a resume ID that no longer exists.
+
+    Subclasses ``ValueError`` deliberately: every pre-existing
+    ``except ValueError`` handler around resume writes keeps working unchanged,
+    while callers that need to distinguish "the row is gone" from any other
+    bad-argument error can catch this type instead of string-matching the
+    message (the message is not an API).
+    """
+
+    def __init__(self, resume_id: str) -> None:
+        self.resume_id = resume_id
+        super().__init__(f"Resume not found: {resume_id}")
+
+
 def _now() -> str:
     """Current UTC time as an ISO-8601 string (TinyDB-era format)."""
     return datetime.now(timezone.utc).isoformat()
@@ -310,12 +325,14 @@ class Database:
         """Update resume by ID.
 
         Raises:
-            ValueError: If resume not found.
+            ResumeNotFoundError: If resume not found. It subclasses
+                ``ValueError``, so existing ``except ValueError`` callers are
+                unaffected.
         """
         async with self._session() as session:
             row = await session.get(Resume, resume_id)
             if row is None:
-                raise ValueError(f"Resume not found: {resume_id}")
+                raise ResumeNotFoundError(resume_id)
             for key, value in updates.items():
                 if hasattr(row, key):
                     setattr(row, key, value)

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -51,6 +51,42 @@ MAX_JSON_CONTENT_SIZE = 1024 * 1024  # 1MB
 # automatically clamped to the model's actual capacity.
 DEFAULT_JSON_MAX_TOKENS = 8192
 
+# ---------------------------------------------------------------------------
+# OpenAI-compatible endpoint allowlists
+#
+# Why this exists: custom OpenAI-compatible servers expose no capability
+# discovery API, so there is no way to ask an endpoint at runtime whether it
+# accepts OpenAI JSON mode (``response_format={"type": "json_object"}``).
+# Sending it optimistically to an unverified server can turn a prompt-only JSON
+# request that previously worked into a hard 400, so support is opt-in: an
+# endpoint gets JSON mode only when it appears below.
+#
+# Bar for adding an entry: the endpoint must be *verified to support OpenAI JSON
+# mode* - a real request against the live endpoint that came back with a
+# parseable JSON body. A vendor doc claiming OpenAI compatibility is not enough.
+#
+# Which constant to edit when adding a provider:
+#   * A server that accepts plain OpenAI JSON mode -> add its lowercase
+#     hostname to ``JSON_MODE_VERIFIED_HOSTS``. Hosts are compared against the
+#     exact parsed hostname of ``api_base``, so lookalike domains such as
+#     ``evil-opencode.ai`` never match.
+#   * A new OpenCode Zen HY3 model alias -> add it (lowercased) to
+#     ``OPENCODE_ZEN_HY3_MODELS``. The Zen route is separate from the plain host
+#     allowlist because it also drives a vendor-specific ``no_think`` reasoning
+#     switch, and must stay scoped to the exact gateway/model pair.
+# ---------------------------------------------------------------------------
+
+#: Exact hostname of the OpenCode Zen gateway.
+OPENCODE_ZEN_HOST: str = "opencode.ai"
+#: Path prefix identifying the Zen gateway on that host (``/zen``, ``/zen/v1``, ...).
+OPENCODE_ZEN_PATH_PREFIX: str = "/zen"
+#: Lowercased model names served by Zen's HY3-compatible route.
+OPENCODE_ZEN_HY3_MODELS: frozenset[str] = frozenset({"hy3", "hy3-free"})
+
+#: Hostnames verified to accept OpenAI JSON mode over an ``openai_compatible``
+#: endpoint. See the comment block above before adding to this set.
+JSON_MODE_VERIFIED_HOSTS: frozenset[str] = frozenset({"api.stepfun.com"})
+
 
 class LLMConfig(BaseModel):
     """LLM configuration model."""
@@ -220,19 +256,24 @@ def _uses_opencode_zen_hy3(config: LLMConfig) -> bool:
 
     HY3 is a reasoning model.  Zen exposes its supported switch as top-level
     ``reasoning_effort: \"no_think\"``.  Scope this workaround to the exact
-    gateway/model pair so an unrelated OpenAI-compatible server never receives
-    a vendor-specific parameter.
+    gateway/model pair - ``OPENCODE_ZEN_HOST`` + ``OPENCODE_ZEN_PATH_PREFIX`` +
+    ``OPENCODE_ZEN_HY3_MODELS`` - so an unrelated OpenAI-compatible server never
+    receives a vendor-specific parameter.
     """
     if config.provider != "openai_compatible" or not isinstance(config.model, str):
         return False
-    if config.model.strip().lower() not in {"hy3", "hy3-free"}:
+    if config.model.strip().lower() not in OPENCODE_ZEN_HY3_MODELS:
         return False
     if not isinstance(config.api_base, str):
         return False
     parsed = urlsplit(config.api_base.strip())
+    if (parsed.hostname or "").lower() != OPENCODE_ZEN_HOST:
+        return False
+    # ``/zen``, ``/zen/`` and ``/zen/<segment>`` are all the Zen gateway; a
+    # merely prefixed path such as ``/zenith`` is a different service.
     path = parsed.path.rstrip("/")
-    return (parsed.hostname or "").lower() == "opencode.ai" and (
-        path == "/zen" or path.startswith("/zen/")
+    return path == OPENCODE_ZEN_PATH_PREFIX or path.startswith(
+        f"{OPENCODE_ZEN_PATH_PREFIX}/"
     )
 
 
@@ -241,13 +282,15 @@ def _openai_compatible_supports_json_mode(config: LLMConfig) -> bool:
 
     Custom OpenAI-compatible servers have no uniform capability-discovery API.
     Sending ``response_format`` to every one of them can turn a prompt-only
-    JSON request that previously worked into a 400. Keep this allowlist limited
-    to endpoints that have been verified to support OpenAI JSON mode.
+    JSON request that previously worked into a 400, so this stays an allowlist:
+    an endpoint qualifies only when its host is in ``JSON_MODE_VERIFIED_HOSTS``
+    or it is the OpenCode Zen HY3 route. Read the allowlist comment block above
+    those constants before adding an entry.
     """
     if config.provider != "openai_compatible" or not isinstance(config.api_base, str):
         return False
     host = (urlsplit(config.api_base.strip()).hostname or "").lower()
-    return _uses_opencode_zen_hy3(config) or host == "api.stepfun.com"
+    return _uses_opencode_zen_hy3(config) or host in JSON_MODE_VERIFIED_HOSTS
 
 
 def _extract_text_parts(

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -250,11 +250,19 @@ def _openai_compatible_supports_json_mode(config: LLMConfig) -> bool:
     return _uses_opencode_zen_hy3(config) or host == "api.stepfun.com"
 
 
-def _extract_text_parts(value: Any, depth: int = 0, max_depth: int = 10) -> list[str]:
+def _extract_text_parts(
+    value: Any,
+    depth: int = 0,
+    max_depth: int = 10,
+    *,
+    exclude_reasoning: bool = False,
+) -> list[str]:
     """Recursively extract text segments from nested response structures.
 
     Handles strings, lists, dicts with 'text'/'content'/'value' keys, and objects
-    with text/content attributes. Limits recursion depth to avoid cycles.
+    with text/content attributes. Limits recursion depth to avoid cycles.  Set
+    ``exclude_reasoning`` for structured output, where typed reasoning blocks
+    must not be joined with a model's final answer.
 
     Args:
         value: Input value that may contain text in strings, lists, dicts, or objects.
@@ -277,64 +285,75 @@ def _extract_text_parts(value: Any, depth: int = 0, max_depth: int = 10) -> list
         parts: list[str] = []
         next_depth = depth + 1
         for item in value:
-            parts.extend(_extract_text_parts(item, next_depth, max_depth))
+            parts.extend(
+                _extract_text_parts(
+                    item,
+                    next_depth,
+                    max_depth,
+                    exclude_reasoning=exclude_reasoning,
+                )
+            )
         return parts
 
     if isinstance(value, dict):
+        block_type = value.get("type")
+        if (
+            exclude_reasoning
+            and isinstance(block_type, str)
+            and block_type.lower() in _REASONING_BLOCK_TYPES
+        ):
+            return []
         next_depth = depth + 1
         if "text" in value:
-            return _extract_text_parts(value.get("text"), next_depth, max_depth)
+            return _extract_text_parts(
+                value.get("text"),
+                next_depth,
+                max_depth,
+                exclude_reasoning=exclude_reasoning,
+            )
         if "content" in value:
-            return _extract_text_parts(value.get("content"), next_depth, max_depth)
+            return _extract_text_parts(
+                value.get("content"),
+                next_depth,
+                max_depth,
+                exclude_reasoning=exclude_reasoning,
+            )
         if "value" in value:
-            return _extract_text_parts(value.get("value"), next_depth, max_depth)
+            return _extract_text_parts(
+                value.get("value"),
+                next_depth,
+                max_depth,
+                exclude_reasoning=exclude_reasoning,
+            )
         return []
 
+    block_type = getattr(value, "type", None)
+    if (
+        exclude_reasoning
+        and isinstance(block_type, str)
+        and block_type.lower() in _REASONING_BLOCK_TYPES
+    ):
+        return []
     next_depth = depth + 1
     if hasattr(value, "text"):
-        return _extract_text_parts(getattr(value, "text"), next_depth, max_depth)
+        return _extract_text_parts(
+            getattr(value, "text"),
+            next_depth,
+            max_depth,
+            exclude_reasoning=exclude_reasoning,
+        )
     if hasattr(value, "content"):
-        return _extract_text_parts(getattr(value, "content"), next_depth, max_depth)
+        return _extract_text_parts(
+            getattr(value, "content"),
+            next_depth,
+            max_depth,
+            exclude_reasoning=exclude_reasoning,
+        )
 
     return []
 
 
 _REASONING_BLOCK_TYPES = frozenset({"analysis", "reasoning", "reasoning_content", "thinking"})
-
-
-def _extract_final_text_parts(value: Any, depth: int = 0, max_depth: int = 10) -> list[str]:
-    """Extract final-answer text while excluding typed reasoning blocks.
-
-    Some compatible APIs put both the hidden reasoning and the final answer in
-    ``message.content`` as a list of typed blocks. JSON parsing must not join a
-    reasoning block into the final answer in that representation.
-    """
-    if depth >= max_depth or value is None:
-        return []
-    if isinstance(value, str):
-        return [value]
-    if isinstance(value, list):
-        return [
-            text
-            for item in value
-            for text in _extract_final_text_parts(item, depth + 1, max_depth)
-        ]
-    if isinstance(value, dict):
-        block_type = value.get("type")
-        if isinstance(block_type, str) and block_type.lower() in _REASONING_BLOCK_TYPES:
-            return []
-        for key in ("text", "content", "value"):
-            if key in value:
-                return _extract_final_text_parts(value[key], depth + 1, max_depth)
-        return []
-
-    block_type = getattr(value, "type", None)
-    if isinstance(block_type, str) and block_type.lower() in _REASONING_BLOCK_TYPES:
-        return []
-    for attribute in ("text", "content", "value"):
-        if hasattr(value, attribute):
-            return _extract_final_text_parts(getattr(value, attribute), depth + 1, max_depth)
-    return []
 
 
 def _join_text_parts(parts: list[str]) -> str | None:
@@ -425,14 +444,18 @@ def _extract_choice_primary_text(choice: Any) -> str | None:
     respond.
     """
     message = _safe_get(choice, "message")
-    content = _join_text_parts(_extract_final_text_parts(_safe_get(message, "content")))
+    content = _join_text_parts(
+        _extract_text_parts(_safe_get(message, "content"), exclude_reasoning=True)
+    )
     if content:
         return content
 
     for field in ("text", "delta"):
         value = _safe_get(choice, field)
         if value is not None:
-            extracted = _join_text_parts(_extract_final_text_parts(value))
+            extracted = _join_text_parts(
+                _extract_text_parts(value, exclude_reasoning=True)
+            )
             if extracted:
                 return extracted
 

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -230,7 +230,24 @@ def _uses_opencode_zen_hy3(config: LLMConfig) -> bool:
     if not isinstance(config.api_base, str):
         return False
     parsed = urlsplit(config.api_base.strip())
-    return (parsed.hostname or "").lower() == "opencode.ai" and parsed.path.startswith("/zen/")
+    path = parsed.path.rstrip("/")
+    return (parsed.hostname or "").lower() == "opencode.ai" and (
+        path == "/zen" or path.startswith("/zen/")
+    )
+
+
+def _openai_compatible_supports_json_mode(config: LLMConfig) -> bool:
+    """Return whether a compatible endpoint is known to accept JSON mode.
+
+    Custom OpenAI-compatible servers have no uniform capability-discovery API.
+    Sending ``response_format`` to every one of them can turn a prompt-only
+    JSON request that previously worked into a 400. Keep this allowlist limited
+    to endpoints that have been verified to support OpenAI JSON mode.
+    """
+    if config.provider != "openai_compatible" or not isinstance(config.api_base, str):
+        return False
+    host = (urlsplit(config.api_base.strip()).hostname or "").lower()
+    return _uses_opencode_zen_hy3(config) or host == "api.stepfun.com"
 
 
 def _extract_text_parts(value: Any, depth: int = 0, max_depth: int = 10) -> list[str]:
@@ -279,6 +296,44 @@ def _extract_text_parts(value: Any, depth: int = 0, max_depth: int = 10) -> list
     if hasattr(value, "content"):
         return _extract_text_parts(getattr(value, "content"), next_depth, max_depth)
 
+    return []
+
+
+_REASONING_BLOCK_TYPES = frozenset({"analysis", "reasoning", "reasoning_content", "thinking"})
+
+
+def _extract_final_text_parts(value: Any, depth: int = 0, max_depth: int = 10) -> list[str]:
+    """Extract final-answer text while excluding typed reasoning blocks.
+
+    Some compatible APIs put both the hidden reasoning and the final answer in
+    ``message.content`` as a list of typed blocks. JSON parsing must not join a
+    reasoning block into the final answer in that representation.
+    """
+    if depth >= max_depth or value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [
+            text
+            for item in value
+            for text in _extract_final_text_parts(item, depth + 1, max_depth)
+        ]
+    if isinstance(value, dict):
+        block_type = value.get("type")
+        if isinstance(block_type, str) and block_type.lower() in _REASONING_BLOCK_TYPES:
+            return []
+        for key in ("text", "content", "value"):
+            if key in value:
+                return _extract_final_text_parts(value[key], depth + 1, max_depth)
+        return []
+
+    block_type = getattr(value, "type", None)
+    if isinstance(block_type, str) and block_type.lower() in _REASONING_BLOCK_TYPES:
+        return []
+    for attribute in ("text", "content", "value"):
+        if hasattr(value, attribute):
+            return _extract_final_text_parts(getattr(value, attribute), depth + 1, max_depth)
     return []
 
 
@@ -370,14 +425,14 @@ def _extract_choice_primary_text(choice: Any) -> str | None:
     respond.
     """
     message = _safe_get(choice, "message")
-    content = _join_text_parts(_extract_text_parts(_safe_get(message, "content")))
+    content = _join_text_parts(_extract_final_text_parts(_safe_get(message, "content")))
     if content:
         return content
 
     for field in ("text", "delta"):
         value = _safe_get(choice, field)
         if value is not None:
-            extracted = _join_text_parts(_extract_text_parts(value))
+            extracted = _join_text_parts(_extract_final_text_parts(value))
             if extracted:
                 return extracted
 
@@ -914,15 +969,13 @@ def _is_response_format_unsupported(error: Exception) -> bool:
     return any(cue in msg for cue in rejection_cues)
 
 
-# Unknown OpenAI-compatible models are common (self-hosted deployments and
-# aggregators do not appear in LiteLLM's registry).  A complete resume JSON
-# frequently needs more than 4096 tokens once a reasoning model has spent part
-# of the shared budget on thinking, so keep the documented 8192 default rather
-# than silently shrinking it.  Providers with a lower hard limit return a
-# clear validation error instead of a deceptively incomplete "success".
-FALLBACK_MAX_TOKENS = DEFAULT_JSON_MAX_TOKENS
+FALLBACK_MAX_TOKENS = 4096
 
-def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKENS) -> int:
+def get_safe_max_tokens(
+    model_name: str,
+    requested: int = DEFAULT_JSON_MAX_TOKENS,
+    config: LLMConfig | None = None,
+) -> int:
     """Return a token count safe for the given model, clamped to its output limit.
 
     Queries LiteLLM's model registry for ``max_output_tokens`` and returns
@@ -930,11 +983,14 @@ def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKEN
     what the backend actually supports.
 
     If the model is not in the registry (e.g. custom Ollama models), it falls
-    back to the structured-output default (FALLBACK_MAX_TOKENS).
+    back to a conservative limit. The verified OpenCode Zen HY3 route is an
+    exception because JSON extraction disables reasoning for that model and
+    needs the full structured-output budget.
 
     Args:
         model_name: LiteLLM-formatted model name (from get_model_name).
         requested: Desired token budget; defaults to DEFAULT_JSON_MAX_TOKENS.
+        config: Optional provider configuration for scoped compatibility rules.
 
     Returns:
         Safe token count, clamped correctly and always >= 1.
@@ -957,7 +1013,12 @@ def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKEN
     except Exception:
         pass  # Model not in registry, drop down to fallback logic
 
-    safe = min(safe_requested, FALLBACK_MAX_TOKENS)
+    fallback_limit = (
+        DEFAULT_JSON_MAX_TOKENS
+        if config is not None and _uses_opencode_zen_hy3(config)
+        else FALLBACK_MAX_TOKENS
+    )
+    safe = min(safe_requested, fallback_limit)
     logging.debug(
         "Model %s not in LiteLLM registry, using fallback max_tokens %d",
         model_name,
@@ -1265,12 +1326,10 @@ async def complete_json(
         {"role": "user", "content": prompt},
     ]
 
-    # Check if we can use JSON mode.  OpenAI-compatible endpoints are often
-    # custom models which LiteLLM does not know about, so the registry cannot
-    # reliably report their ``response_format`` capability.  Prefer JSON mode
-    # for those endpoints and retain the existing BadRequest fallback below for
-    # servers that reject it (for example older local servers).
-    use_json_mode = _supports_json_mode(model_name) or config.provider == "openai_compatible"
+    # Unknown compatible servers may reject response_format. Use JSON mode
+    # when LiteLLM advertises it or when the endpoint is explicitly known to
+    # support it; prompt-only JSON remains the portable default.
+    use_json_mode = _supports_json_mode(model_name) or _openai_compatible_supports_json_mode(config)
     json_mode_failed = False
 
     for attempt in range(retries + 1):

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -349,6 +349,13 @@ def _extract_text_parts(
             max_depth,
             exclude_reasoning=exclude_reasoning,
         )
+    if hasattr(value, "value"):
+        return _extract_text_parts(
+            getattr(value, "value"),
+            next_depth,
+            max_depth,
+            exclude_reasoning=exclude_reasoning,
+        )
 
     return []
 

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -215,6 +215,24 @@ def _effective_api_key(provider: str, api_key: str) -> str:
     return api_key
 
 
+def _uses_opencode_zen_hy3(config: LLMConfig) -> bool:
+    """Return whether a request targets OpenCode Zen's HY3-compatible route.
+
+    HY3 is a reasoning model.  Zen exposes its supported switch as top-level
+    ``reasoning_effort: \"no_think\"``.  Scope this workaround to the exact
+    gateway/model pair so an unrelated OpenAI-compatible server never receives
+    a vendor-specific parameter.
+    """
+    if config.provider != "openai_compatible" or not isinstance(config.model, str):
+        return False
+    if config.model.strip().lower() not in {"hy3", "hy3-free"}:
+        return False
+    if not isinstance(config.api_base, str):
+        return False
+    parsed = urlsplit(config.api_base.strip())
+    return (parsed.hostname or "").lower() == "opencode.ai" and parsed.path.startswith("/zen/")
+
+
 def _extract_text_parts(value: Any, depth: int = 0, max_depth: int = 10) -> list[str]:
     """Recursively extract text segments from nested response structures.
 
@@ -327,6 +345,32 @@ def _extract_choice_text(choice: Any) -> str | None:
     object attributes and dict keys.
     """
     content = _extract_message_text(_safe_get(choice, "message"))
+    if content:
+        return content
+
+    for field in ("text", "delta"):
+        value = _safe_get(choice, field)
+        if value is not None:
+            extracted = _join_text_parts(_extract_text_parts(value))
+            if extracted:
+                return extracted
+
+    return None
+
+
+def _extract_choice_primary_text(choice: Any) -> str | None:
+    """Extract only a model's final answer, never its reasoning trace.
+
+    Reasoning models commonly return their chain-of-thought in
+    ``reasoning_content`` before (or, when the output budget is exhausted,
+    instead of) the user-facing ``content``.  That trace is not an answer and
+    must never be fed into the JSON parser.  The broader
+    :func:`_extract_choice_text` intentionally retains its reasoning fallback
+    for the health-check UI, where it is useful evidence that a provider can
+    respond.
+    """
+    message = _safe_get(choice, "message")
+    content = _join_text_parts(_extract_text_parts(_safe_get(message, "content")))
     if content:
         return content
 
@@ -870,7 +914,13 @@ def _is_response_format_unsupported(error: Exception) -> bool:
     return any(cue in msg for cue in rejection_cues)
 
 
-FALLBACK_MAX_TOKENS = 4096
+# Unknown OpenAI-compatible models are common (self-hosted deployments and
+# aggregators do not appear in LiteLLM's registry).  A complete resume JSON
+# frequently needs more than 4096 tokens once a reasoning model has spent part
+# of the shared budget on thinking, so keep the documented 8192 default rather
+# than silently shrinking it.  Providers with a lower hard limit return a
+# clear validation error instead of a deceptively incomplete "success".
+FALLBACK_MAX_TOKENS = DEFAULT_JSON_MAX_TOKENS
 
 def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKENS) -> int:
     """Return a token count safe for the given model, clamped to its output limit.
@@ -880,7 +930,7 @@ def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKEN
     what the backend actually supports.
 
     If the model is not in the registry (e.g. custom Ollama models), it falls
-    back to a safe conservative limit (FALLBACK_MAX_TOKENS).
+    back to the structured-output default (FALLBACK_MAX_TOKENS).
 
     Args:
         model_name: LiteLLM-formatted model name (from get_model_name).
@@ -909,9 +959,8 @@ def get_safe_max_tokens(model_name: str, requested: int = DEFAULT_JSON_MAX_TOKEN
 
     safe = min(safe_requested, FALLBACK_MAX_TOKENS)
     logging.debug(
-        "Model %s not in LiteLLM registry, clamping requested max_tokens %d → %d constraint",
+        "Model %s not in LiteLLM registry, using fallback max_tokens %d",
         model_name,
-        safe_requested,
         safe,
     )
     return safe
@@ -1174,11 +1223,15 @@ def _extract_json(content: str, _depth: int = 0) -> str:
         return _extract_json(content[start_idx:], _depth + 1)
 
     # LLM-007: Log unrecognized format for debugging
+    # Model output can include a user's full resume or job description.  Keep
+    # diagnostics useful without writing that personal content to server logs.
     logging.error(
-        "Could not extract JSON from response format. Content preview: %s",
-        content[:200] if content else "<empty>",
+        "Could not extract JSON from response format (response length: %d)",
+        len(content) if content else 0,
     )
-    raise ValueError(f"No JSON found in response: {original[:200]}")
+    # Do not include model output in the exception either: callers log this
+    # exception and model output can contain a user's resume or job details.
+    raise ValueError(f"No JSON found in response (response length: {len(original)})")
 
 
 async def complete_json(
@@ -1212,8 +1265,12 @@ async def complete_json(
         {"role": "user", "content": prompt},
     ]
 
-    # Check if we can use JSON mode
-    use_json_mode = _supports_json_mode(model_name)
+    # Check if we can use JSON mode.  OpenAI-compatible endpoints are often
+    # custom models which LiteLLM does not know about, so the registry cannot
+    # reliably report their ``response_format`` capability.  Prefer JSON mode
+    # for those endpoints and retain the existing BadRequest fallback below for
+    # servers that reject it (for example older local servers).
+    use_json_mode = _supports_json_mode(model_name) or config.provider == "openai_compatible"
     json_mode_failed = False
 
     for attempt in range(retries + 1):
@@ -1247,7 +1304,14 @@ async def complete_json(
                 and reasoning_effort in ("low", "medium", "high")
             ):
                 reasoning_effort = "minimal"
-            if reasoning_effort:
+            # HY3-Free on OpenCode Zen otherwise spends much of its output
+            # allocation in ``reasoning_content`` and truncates large resume
+            # JSON. LiteLLM filters unknown top-level parameters, so use its
+            # OpenAI-compatible ``extra_body`` passthrough for the HY3-native
+            # no_think setting. Scope it to structured-output requests only.
+            if _uses_opencode_zen_hy3(config):
+                kwargs["extra_body"] = {"reasoning_effort": "no_think"}
+            elif reasoning_effort:
                 kwargs["reasoning_effort"] = reasoning_effort
 
             # JSON-012: Fallback to prompt-only JSON mode after JSON-mode failure.
@@ -1257,13 +1321,21 @@ async def complete_json(
                 kwargs["response_format"] = {"type": "json_object"}
 
             response = await router.acompletion(**kwargs)
-            content = _extract_choice_text(response.choices[0])
+            # Never parse ``reasoning_content`` as JSON.  If the model has
+            # consumed its budget on reasoning but produced no final answer,
+            # treat it as an empty completion and retry with the full budget.
+            content = _extract_choice_primary_text(response.choices[0])
 
             if not content:
                 raise ValueError("Empty response from LLM")
 
+            # Do not log response bodies: they frequently contain a resume or
+            # a job description and are therefore user-provided personal data.
             logging.debug(
-                f"LLM response (attempt {attempt + 1}): {content[:300]}")
+                "Received LLM JSON response (attempt %d, length: %d)",
+                attempt + 1,
+                len(content),
+            )
 
             # Extract and parse JSON
             json_str = _extract_json(content)

--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -46,7 +46,12 @@ from app.schemas import (
     UpdateTitleRequest,
     normalize_resume_data,
 )
-from app.services.parser import parse_document, parse_resume_to_json, restore_dates_from_markdown
+from app.services.parser import (
+    has_meaningful_resume_content,
+    parse_document,
+    parse_resume_to_json,
+    restore_dates_from_markdown,
+)
 from app.services.improver import (
     MONTH_PATTERN,
     apply_diffs,
@@ -1680,16 +1685,21 @@ async def retry_processing(resume_id: str) -> ResumeUploadResponse:
     """Retry AI processing for a failed or stuck resume.
 
     Re-runs parse_resume_to_json() on the stored markdown content.
-    Works for resumes with processing_status == "failed" or "processing".
+    Works for failed/in-progress resumes and legacy ``ready`` records whose
+    structured data is empty due to an earlier parser false positive.
     """
     resume = await db.get_resume(resume_id)
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
-    if resume.get("processing_status") not in ("failed", "processing"):
+    status = resume.get("processing_status")
+    can_retry_legacy_empty_ready = status == "ready" and not has_meaningful_resume_content(
+        resume.get("processed_data") or {}
+    )
+    if status not in ("failed", "processing") and not can_retry_legacy_empty_ready:
         raise HTTPException(
             status_code=400,
-            detail="Only resumes with 'failed' or 'processing' status can be retried.",
+            detail="Only failed, processing, or empty legacy resumes can be retried.",
         )
 
     markdown_content = resume.get("content", "")
@@ -1717,7 +1727,14 @@ async def retry_processing(resume_id: str) -> ResumeUploadResponse:
         )
     except Exception as e:
         logger.warning(f"Retry processing failed for resume {resume_id}: {e}")
-        await db.update_resume(resume_id, {"processing_status": "failed"})
+        try:
+            await db.update_resume(resume_id, {"processing_status": "failed"})
+        except ValueError as update_error:
+            # The user can delete a resume while a long LLM retry is in
+            # progress.  Do not turn that benign race into a server traceback.
+            if "Resume not found" in str(update_error):
+                raise HTTPException(status_code=404, detail="Resume was deleted during retry.") from e
+            raise
         return ResumeUploadResponse(
             message="Retry processing failed",
             request_id=str(uuid4()),

--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -16,7 +16,7 @@ from fastapi.responses import Response
 from pydantic import ValidationError
 
 from app.config_cache import get_content_language, load_config as _load_config
-from app.database import db
+from app.database import ResumeNotFoundError, db
 from app.pdf import render_resume_pdf, PDFRenderError
 from app.config import settings
 
@@ -1729,12 +1729,13 @@ async def retry_processing(resume_id: str) -> ResumeUploadResponse:
         logger.warning(f"Retry processing failed for resume {resume_id}: {e}")
         try:
             await db.update_resume(resume_id, {"processing_status": "failed"})
-        except ValueError as update_error:
+        except ResumeNotFoundError:
             # The user can delete a resume while a long LLM retry is in
             # progress.  Do not turn that benign race into a server traceback.
-            if "Resume not found" in str(update_error):
-                raise HTTPException(status_code=404, detail="Resume was deleted during retry.") from e
-            raise
+            # Keyed on the exception type, never on its message text.
+            raise HTTPException(
+                status_code=404, detail="Resume was deleted during retry."
+            ) from e
         return ResumeUploadResponse(
             message="Retry processing failed",
             request_id=str(uuid4()),

--- a/apps/backend/app/services/interview_prep.py
+++ b/apps/backend/app/services/interview_prep.py
@@ -113,7 +113,11 @@ async def generate_interview_prep(
         output_language=get_language_name(language),
     )
     config = get_llm_config()
-    max_tokens = get_safe_max_tokens(get_model_name(config), requested=8192)
+    max_tokens = get_safe_max_tokens(
+        get_model_name(config),
+        requested=8192,
+        config=config,
+    )
 
     result = await complete_json(
         prompt=prompt,

--- a/apps/backend/app/services/parser.py
+++ b/apps/backend/app/services/parser.py
@@ -116,6 +116,45 @@ def restore_dates_from_markdown(
     return parsed_data
 
 
+def has_meaningful_resume_content(resume_data: Any) -> bool:
+    """Return whether parsed resume data contains any user-facing content.
+
+    ``ResumeData`` intentionally defaults most fields to empty strings/lists.
+    That is useful for the builder, but it also means an LLM response such as
+    ``{}`` validates successfully.  Treating that response as a parsed resume
+    produces a blank PDF and makes every downstream tailoring request operate
+    on empty data.
+    """
+
+    if not isinstance(resume_data, dict):
+        return False
+
+    personal_info = resume_data.get("personalInfo")
+    if isinstance(personal_info, dict) and any(
+        isinstance(value, str) and value.strip() for value in personal_info.values()
+    ):
+        return True
+
+    if isinstance(resume_data.get("summary"), str) and resume_data["summary"].strip():
+        return True
+
+    for section in ("workExperience", "education", "personalProjects"):
+        entries = resume_data.get(section)
+        if isinstance(entries, list) and any(isinstance(entry, dict) and entry for entry in entries):
+            return True
+
+    additional = resume_data.get("additional")
+    if isinstance(additional, dict):
+        for values in additional.values():
+            if isinstance(values, list) and any(
+                isinstance(value, str) and value.strip() for value in values
+            ):
+                return True
+
+    custom_sections = resume_data.get("customSections")
+    return isinstance(custom_sections, dict) and bool(custom_sections)
+
+
 async def parse_document(content: bytes, filename: str) -> str:
     """Convert PDF/DOCX to Markdown using markitdown.
 
@@ -176,4 +215,7 @@ async def parse_resume_to_json(markdown_text: str) -> dict[str, Any]:
 
     # Validate against schema
     validated = ResumeData.model_validate(result)
-    return validated.model_dump()
+    parsed_data = validated.model_dump()
+    if not has_meaningful_resume_content(parsed_data):
+        raise ValueError("LLM returned an empty structured resume.")
+    return parsed_data

--- a/apps/backend/app/services/parser.py
+++ b/apps/backend/app/services/parser.py
@@ -119,6 +119,22 @@ def restore_dates_from_markdown(
 _NON_CONTENT_RESUME_KEYS = frozenset(
     {"id", "sectionType", "descriptionStyles", "isDefault", "isVisible", "order", "key", "displayName"}
 )
+# Depth guard against self-referential or pathological LLM output.  Recursion
+# starts at depth 0 on a *top-level section value*, so the deepest user-visible
+# value the real ``ResumeData`` schema can produce sits at depth 5:
+#
+#   customSections(0) -> CustomSection(1) -> items(2) -> CustomSectionItem(3)
+#       -> description(4) -> bullet string(5)
+#
+# Every other content section is shallower: workExperience / personalProjects
+# bottom out at depth 3 (list -> Experience -> description -> bullet),
+# education and additional at depth 2, personalInfo at depth 1, summary at
+# depth 0.  Values are still inspected at depth 9 (the cut-off is ``>= 10``),
+# so the limit leaves four full levels of headroom over the schema maximum.
+# Nothing that validates as ``ResumeData`` can be misjudged empty here;
+# anything deeper is malformed LLM output rather than a resume.  Raise this
+# only if the schema itself grows deeper -- see the boundary tests in
+# tests/unit/test_parser.py::TestMeaningfulResumeContent.
 _MAX_RESUME_CONTENT_RECURSION = 10
 
 

--- a/apps/backend/app/services/parser.py
+++ b/apps/backend/app/services/parser.py
@@ -116,6 +116,25 @@ def restore_dates_from_markdown(
     return parsed_data
 
 
+_NON_CONTENT_RESUME_KEYS = frozenset(
+    {"id", "sectionType", "descriptionStyles", "isDefault", "isVisible", "order", "key", "displayName"}
+)
+
+
+def _has_meaningful_resume_value(value: Any) -> bool:
+    """Return whether a value contains non-structural, user-visible text."""
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_has_meaningful_resume_value(item) for item in value)
+    if isinstance(value, dict):
+        return any(
+            key not in _NON_CONTENT_RESUME_KEYS and _has_meaningful_resume_value(item)
+            for key, item in value.items()
+        )
+    return False
+
+
 def has_meaningful_resume_content(resume_data: Any) -> bool:
     """Return whether parsed resume data contains any user-facing content.
 
@@ -129,30 +148,19 @@ def has_meaningful_resume_content(resume_data: Any) -> bool:
     if not isinstance(resume_data, dict):
         return False
 
-    personal_info = resume_data.get("personalInfo")
-    if isinstance(personal_info, dict) and any(
-        isinstance(value, str) and value.strip() for value in personal_info.values()
-    ):
-        return True
-
-    if isinstance(resume_data.get("summary"), str) and resume_data["summary"].strip():
-        return True
-
-    for section in ("workExperience", "education", "personalProjects"):
-        entries = resume_data.get(section)
-        if isinstance(entries, list) and any(isinstance(entry, dict) and entry for entry in entries):
-            return True
-
-    additional = resume_data.get("additional")
-    if isinstance(additional, dict):
-        for values in additional.values():
-            if isinstance(values, list) and any(
-                isinstance(value, str) and value.strip() for value in values
-            ):
-                return True
-
-    custom_sections = resume_data.get("customSections")
-    return isinstance(custom_sections, dict) and bool(custom_sections)
+    content_sections = (
+        "personalInfo",
+        "summary",
+        "workExperience",
+        "education",
+        "personalProjects",
+        "additional",
+        "customSections",
+    )
+    return any(
+        _has_meaningful_resume_value(resume_data.get(section))
+        for section in content_sections
+    )
 
 
 async def parse_document(content: bytes, filename: str) -> str:
@@ -206,7 +214,7 @@ async def parse_resume_to_json(markdown_text: str) -> dict[str, Any]:
     result = await complete_json(
         prompt=prompt,
         system_prompt="You are a JSON extraction engine. Output only valid JSON, no explanations.",
-        max_tokens=get_safe_max_tokens(model_name),
+        max_tokens=get_safe_max_tokens(model_name, config=config),
         retries=3,
     )
 

--- a/apps/backend/app/services/parser.py
+++ b/apps/backend/app/services/parser.py
@@ -119,17 +119,34 @@ def restore_dates_from_markdown(
 _NON_CONTENT_RESUME_KEYS = frozenset(
     {"id", "sectionType", "descriptionStyles", "isDefault", "isVisible", "order", "key", "displayName"}
 )
+_MAX_RESUME_CONTENT_RECURSION = 10
 
 
-def _has_meaningful_resume_value(value: Any) -> bool:
-    """Return whether a value contains non-structural, user-visible text."""
+def _has_meaningful_resume_value(
+    value: Any,
+    *,
+    depth: int = 0,
+    filter_structural_keys: bool = True,
+) -> bool:
+    """Return whether a value contains non-structural, user-visible text.
+
+    Custom-section identifiers are dictionary keys rather than schema fields,
+    so their values are checked without filtering the identifier itself.  Once
+    inside a section, normal structural-key filtering resumes.
+    """
+    if depth >= _MAX_RESUME_CONTENT_RECURSION:
+        return False
     if isinstance(value, str):
         return bool(value.strip())
     if isinstance(value, list):
-        return any(_has_meaningful_resume_value(item) for item in value)
+        return any(
+            _has_meaningful_resume_value(item, depth=depth + 1)
+            for item in value
+        )
     if isinstance(value, dict):
         return any(
-            key not in _NON_CONTENT_RESUME_KEYS and _has_meaningful_resume_value(item)
+            (not filter_structural_keys or key not in _NON_CONTENT_RESUME_KEYS)
+            and _has_meaningful_resume_value(item, depth=depth + 1)
             for key, item in value.items()
         )
     return False
@@ -158,7 +175,10 @@ def has_meaningful_resume_content(resume_data: Any) -> bool:
         "customSections",
     )
     return any(
-        _has_meaningful_resume_value(resume_data.get(section))
+        _has_meaningful_resume_value(
+            resume_data.get(section),
+            filter_structural_keys=section != "customSections",
+        )
         for section in content_sections
     )
 

--- a/apps/backend/tests/integration/test_resume_api.py
+++ b/apps/backend/tests/integration/test_resume_api.py
@@ -324,6 +324,41 @@ class TestRetryProcessing:
         assert resp.status_code == 200
         mock_parse.assert_awaited_once_with(empty_ready_record["content"])
 
+    @patch("app.routers.resumes.parse_resume_to_json", new_callable=AsyncMock)
+    @patch("app.routers.resumes.db", new_callable=AsyncMock)
+    async def test_retry_legacy_ready_resume_with_schema_defaults(
+        self, mock_db, mock_parse, client, mock_resume_record, sample_resume
+    ):
+        legacy_default_record = {
+            **mock_resume_record,
+            "processing_status": "ready",
+            "processed_data": {
+                "workExperience": [
+                    {
+                        "id": 0,
+                        "title": "",
+                        "company": "",
+                        "description": [],
+                        "descriptionStyles": [],
+                    }
+                ],
+                "customSections": {
+                    "empty": {
+                        "sectionType": "itemList",
+                        "items": [{"id": 0, "title": "", "description": []}],
+                    }
+                },
+            },
+        }
+        mock_db.get_resume.return_value = legacy_default_record
+        mock_parse.return_value = sample_resume
+
+        async with client:
+            resp = await client.post("/api/v1/resumes/res-123/retry-processing")
+
+        assert resp.status_code == 200
+        mock_parse.assert_awaited_once_with(legacy_default_record["content"])
+
 
 class TestUploadResume:
     """POST /api/v1/resumes/upload"""

--- a/apps/backend/tests/integration/test_resume_api.py
+++ b/apps/backend/tests/integration/test_resume_api.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.database import ResumeNotFoundError
 from app.main import app
 from app.schemas import InterviewPrepData
 
@@ -366,6 +367,83 @@ class TestRetryProcessing:
                 "processing_status": "ready",
             },
         )
+
+
+    @patch("app.routers.resumes.parse_resume_to_json", new_callable=AsyncMock)
+    @patch("app.routers.resumes.db", new_callable=AsyncMock)
+    async def test_retry_returns_404_when_resume_deleted_mid_retry(
+        self, mock_db, mock_parse, client, mock_resume_record
+    ):
+        """A resume deleted during a long retry yields 404, not a traceback.
+
+        The 404 is keyed on the ResumeNotFoundError *type*. The message here is
+        deliberately reworded to contain no "Resume not found" substring, so
+        this test still passes if someone rewrites database.py's error text --
+        and fails if the router goes back to string-matching.
+        """
+        mock_db.get_resume.return_value = {
+            **mock_resume_record,
+            "processing_status": "failed",
+        }
+        mock_parse.side_effect = RuntimeError("llm exploded")
+        deleted = ResumeNotFoundError("res-123")
+        deleted.args = ("row vanished; totally different wording",)
+        mock_db.update_resume.side_effect = deleted
+
+        async with client:
+            resp = await client.post("/api/v1/resumes/res-123/retry-processing")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Resume was deleted during retry."
+
+    @patch("app.routers.resumes.parse_resume_to_json", new_callable=AsyncMock)
+    @patch("app.routers.resumes.db", new_callable=AsyncMock)
+    async def test_retry_does_not_swallow_unrelated_value_errors(
+        self, mock_db, mock_parse, client, mock_resume_record
+    ):
+        """Only ResumeNotFoundError becomes a 404; other ValueErrors propagate."""
+        mock_db.get_resume.return_value = {
+            **mock_resume_record,
+            "processing_status": "failed",
+        }
+        mock_parse.side_effect = RuntimeError("llm exploded")
+        mock_db.update_resume.side_effect = ValueError("Resume not found: res-123")
+
+        with pytest.raises(ValueError, match="Resume not found"):
+            async with client:
+                await client.post("/api/v1/resumes/res-123/retry-processing")
+
+
+class TestResumeNotFoundError:
+    """app.database.ResumeNotFoundError backward compatibility."""
+
+    def test_is_a_value_error(self):
+        """Subclassing ValueError keeps every pre-existing handler working."""
+        assert issubclass(ResumeNotFoundError, ValueError)
+
+        caught = False
+        try:
+            raise ResumeNotFoundError("res-123")
+        except ValueError as exc:
+            caught = True
+            assert isinstance(exc, ResumeNotFoundError)
+        assert caught
+
+    def test_carries_the_resume_id(self):
+        error = ResumeNotFoundError("res-123")
+        assert error.resume_id == "res-123"
+        assert "res-123" in str(error)
+
+    async def test_real_update_resume_raises_the_typed_error(self, tmp_path):
+        """The real Database.update_resume raises the typed error, not bare ValueError."""
+        from app.database import Database
+
+        database = Database(db_path=tmp_path / "typed_error.db")
+        try:
+            with pytest.raises(ResumeNotFoundError):
+                await database.update_resume("does-not-exist", {"title": "X"})
+        finally:
+            await database.close()
 
 
 class TestUploadResume:

--- a/apps/backend/tests/integration/test_resume_api.py
+++ b/apps/backend/tests/integration/test_resume_api.py
@@ -357,7 +357,15 @@ class TestRetryProcessing:
             resp = await client.post("/api/v1/resumes/res-123/retry-processing")
 
         assert resp.status_code == 200
+        assert resp.json()["processing_status"] == "ready"
         mock_parse.assert_awaited_once_with(legacy_default_record["content"])
+        mock_db.update_resume.assert_awaited_once_with(
+            "res-123",
+            {
+                "processed_data": sample_resume,
+                "processing_status": "ready",
+            },
+        )
 
 
 class TestUploadResume:

--- a/apps/backend/tests/integration/test_resume_api.py
+++ b/apps/backend/tests/integration/test_resume_api.py
@@ -309,6 +309,21 @@ class TestRetryProcessing:
             resp = await client.post("/api/v1/resumes/res-123/retry-processing")
         assert resp.status_code == 400
 
+    @patch("app.routers.resumes.parse_resume_to_json", new_callable=AsyncMock)
+    @patch("app.routers.resumes.db", new_callable=AsyncMock)
+    async def test_retry_empty_legacy_ready_resume(self, mock_db, mock_parse, client, mock_resume_record, sample_resume):
+        empty_ready_record = {
+            **mock_resume_record,
+            "processing_status": "ready",
+            "processed_data": {},
+        }
+        mock_db.get_resume.return_value = empty_ready_record
+        mock_parse.return_value = sample_resume
+        async with client:
+            resp = await client.post("/api/v1/resumes/res-123/retry-processing")
+        assert resp.status_code == 200
+        mock_parse.assert_awaited_once_with(empty_ready_record["content"])
+
 
 class TestUploadResume:
     """POST /api/v1/resumes/upload"""

--- a/apps/backend/tests/unit/test_interview_prep_service.py
+++ b/apps/backend/tests/unit/test_interview_prep_service.py
@@ -73,6 +73,7 @@ async def test_generate_interview_prep_validates_successful_json():
     mock_get_safe_max_tokens.assert_called_once_with(
         "openai/small-output-model",
         requested=8192,
+        config=mock_get_llm_config.return_value,
     )
     assert mock_complete.await_args.kwargs["max_tokens"] == 4096
     assert mock_complete.await_args.kwargs["schema_type"] == "interview_prep"

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -11,6 +11,7 @@ from app.llm import (
     _get_retry_temperature,
     _normalize_api_base,
     _supports_temperature,
+    _uses_opencode_zen_hy3,
     get_model_name,
     resolve_api_key,
 )
@@ -115,6 +116,24 @@ class TestProviderConfiguration:
         stored = {"api_keys": {"azure_foundry": "foundry-key"}}
 
         assert resolve_api_key(stored, "azure_foundry") == "foundry-key"
+
+    def test_recognizes_only_opencode_zen_hy3(self):
+        assert _uses_opencode_zen_hy3(
+            LLMConfig(
+                provider="openai_compatible",
+                model="hy3-free",
+                api_key="",
+                api_base="https://opencode.ai/zen/v1",
+            )
+        )
+        assert not _uses_opencode_zen_hy3(
+            LLMConfig(
+                provider="openai_compatible",
+                model="hy3-free",
+                api_key="",
+                api_base="https://example.com/v1",
+            )
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +377,99 @@ class TestAppearsTruncated:
 
 class TestCompleteJsonFallback:
     """Tests for JSON mode fallback in complete_json()."""
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
+    async def test_openai_compatible_uses_json_mode_for_unknown_model(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """Custom compatible models should not depend on LiteLLM's registry."""
+        mock_supports_json.return_value = False
+        mock_get_name.return_value = "openai/custom-compatible-model"
+
+        choice = MagicMock()
+        choice.message.content = '{"required_skills": ["Python"]}'
+        response = MagicMock()
+        response.choices = [choice]
+        router = MagicMock()
+        router.acompletion = AsyncMock(return_value=response)
+        config = MagicMock()
+        config.provider = "openai_compatible"
+        config.reasoning_effort = None
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json(prompt="Extract keywords", schema_type="keywords")
+
+        assert result == {"required_skills": ["Python"]}
+        assert router.acompletion.call_args.kwargs["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
+    async def test_reasoning_only_response_is_not_parsed_as_json(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        """A reasoning trace without final content must retry, not be parsed."""
+        mock_supports_json.return_value = False
+        mock_get_name.return_value = "openai/reasoning-model"
+
+        reasoning_only = MagicMock()
+        reasoning_only.message.content = None
+        reasoning_only.message.reasoning_content = "I should construct JSON next."
+        completed = MagicMock()
+        completed.message.content = '{"required_skills": ["Python"]}'
+        router = MagicMock()
+        router.acompletion = AsyncMock(
+            side_effect=[
+                MagicMock(choices=[reasoning_only]),
+                MagicMock(choices=[completed]),
+            ]
+        )
+        config = MagicMock()
+        config.provider = "openai_compatible"
+        config.reasoning_effort = None
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json("Extract keywords", retries=1, schema_type="keywords")
+
+        assert result == {"required_skills": ["Python"]}
+        assert router.acompletion.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
+    async def test_opencode_hy3_json_request_disables_reasoning(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        mock_supports_json.return_value = False
+        mock_get_name.return_value = "openai/hy3-free"
+        choice = MagicMock()
+        choice.message.content = '{"required_skills": ["Python"]}'
+        router = MagicMock()
+        router.acompletion = AsyncMock(return_value=MagicMock(choices=[choice]))
+        config = LLMConfig(
+            provider="openai_compatible",
+            model="hy3-free",
+            api_key="",
+            api_base="https://opencode.ai/zen/v1",
+        )
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        await complete_json("Extract keywords", schema_type="keywords")
+
+        assert router.acompletion.call_args.kwargs["extra_body"] == {
+            "reasoning_effort": "no_think"
+        }
 
     @pytest.mark.asyncio
     @patch("app.llm.get_router")

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.llm import (
+    JSON_MODE_VERIFIED_HOSTS,
+    OPENCODE_ZEN_HY3_MODELS,
     LLMConfig,
     _appears_truncated,
     _azure_foundry_api_version,
@@ -892,3 +894,156 @@ class TestScrubSecrets:
         assert "sk-abcd1234efgh5678" not in _scrub_secrets("key sk-abcd1234efgh5678 failed")
         assert "AIzaSyABCDEFGHIJ" not in _scrub_secrets("key AIzaSyABCDEFGHIJ failed")
         assert "tok_secret" not in _scrub_secrets("Authorization: Bearer tok_secret")
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible endpoint allowlists
+# ---------------------------------------------------------------------------
+
+
+def _compatible(model: str = "hy3-free", api_base: str | None = "https://opencode.ai/zen/v1"):
+    """Build an ``openai_compatible`` config for allowlist assertions."""
+    return LLMConfig(
+        provider="openai_compatible",
+        model=model,
+        api_key="",
+        api_base=api_base,
+    )
+
+
+class TestOpenCodeZenHy3Route:
+    """The Zen HY3 route must match its gateway exactly and nothing else."""
+
+    @pytest.mark.parametrize("model", sorted(OPENCODE_ZEN_HY3_MODELS))
+    def test_every_allowlisted_model_matches(self, model):
+        assert _uses_opencode_zen_hy3(_compatible(model=model))
+
+    @pytest.mark.parametrize("model", ["HY3-Free", "  hy3  ", "Hy3"])
+    def test_model_matching_ignores_case_and_surrounding_space(self, model):
+        assert _uses_opencode_zen_hy3(_compatible(model=model))
+
+    @pytest.mark.parametrize(
+        "api_base",
+        [
+            "https://opencode.ai/zen",
+            "https://opencode.ai/zen/",
+            "https://opencode.ai/zen/v1",
+            "https://opencode.ai/zen/v1/",
+            "  https://opencode.ai/zen/v1  ",
+            "https://OpenCode.AI/zen/v1",
+        ],
+    )
+    def test_gateway_path_forms_match(self, api_base):
+        assert _uses_opencode_zen_hy3(_compatible(api_base=api_base))
+
+    def test_bare_zen_path_without_trailing_segment_matches(self):
+        """Regression: ``/zen`` with no trailing segment is the Zen gateway.
+
+        A review note claimed this form was mishandled. ``path.rstrip("/")``
+        normalises ``/zen`` and ``/zen/`` to ``/zen``, which the equality arm
+        accepts, so both the HY3 workaround and JSON mode engage.
+        """
+        config = _compatible(api_base="https://opencode.ai/zen")
+        assert _uses_opencode_zen_hy3(config)
+        assert _openai_compatible_supports_json_mode(config)
+
+    @pytest.mark.parametrize(
+        "api_base",
+        [
+            "https://evil-opencode.ai/zen/v1",  # lookalike registrable domain
+            "https://opencode.ai.evil.com/zen/v1",  # host as a left-hand label
+            "https://zen.opencode.ai/zen/v1",  # subdomain, not the exact host
+            "https://opencode.ai/zenith/v1",  # prefixed but different path
+            "https://opencode.ai/v1",  # right host, not the Zen gateway
+            "https://opencode.ai",  # right host, no path at all
+            "https://example.com/zen/v1",  # unrelated host
+        ],
+    )
+    def test_lookalike_hosts_and_paths_do_not_match(self, api_base):
+        config = _compatible(api_base=api_base)
+        assert not _uses_opencode_zen_hy3(config)
+        assert not _openai_compatible_supports_json_mode(config)
+
+    @pytest.mark.parametrize("model", ["gpt-4o", "hy3-turbo", "qwen2.5"])
+    def test_other_models_on_the_zen_gateway_do_not_match(self, model):
+        config = _compatible(model=model)
+        assert not _uses_opencode_zen_hy3(config)
+        # opencode.ai is not itself a JSON-mode-verified host: only the HY3
+        # route on it is allowlisted.
+        assert not _openai_compatible_supports_json_mode(config)
+
+    def test_other_providers_never_match(self):
+        assert not _uses_opencode_zen_hy3(
+            LLMConfig(
+                provider="openai",
+                model="hy3-free",
+                api_key="k",
+                api_base="https://opencode.ai/zen/v1",
+            )
+        )
+
+    def test_missing_api_base_does_not_match(self):
+        assert not _uses_opencode_zen_hy3(_compatible(api_base=None))
+
+    def test_route_reads_the_model_allowlist_constant(self):
+        """Matching must come from the constant, not an inlined literal."""
+        with patch("app.llm.OPENCODE_ZEN_HY3_MODELS", frozenset({"hy4"})):
+            assert not _uses_opencode_zen_hy3(_compatible(model="hy3-free"))
+            assert _uses_opencode_zen_hy3(_compatible(model="hy4"))
+
+    def test_route_reads_the_host_constant(self):
+        with patch("app.llm.OPENCODE_ZEN_HOST", "zen.example.com"):
+            assert not _uses_opencode_zen_hy3(_compatible())
+            assert _uses_opencode_zen_hy3(
+                _compatible(api_base="https://zen.example.com/zen/v1")
+            )
+
+
+class TestJsonModeVerifiedHosts:
+    """JSON mode is opt-in: only verified hosts (and Zen HY3) get it."""
+
+    @pytest.mark.parametrize("host", sorted(JSON_MODE_VERIFIED_HOSTS))
+    def test_every_verified_host_gets_json_mode(self, host):
+        assert _openai_compatible_supports_json_mode(
+            _compatible(model="step-2", api_base=f"https://{host}/v1")
+        )
+
+    def test_stepfun_gets_json_mode(self):
+        assert _openai_compatible_supports_json_mode(
+            _compatible(model="step-2-16k", api_base="https://api.stepfun.com/v1")
+        )
+
+    @pytest.mark.parametrize(
+        "api_base",
+        [
+            "https://llm.internal.example.com/v1",
+            "http://localhost:11434/v1",
+            "https://api.stepfun.com.evil.com/v1",  # verified host as a prefix label
+            "https://not-api.stepfun.com/v1",  # lookalike registrable domain
+            None,
+        ],
+    )
+    def test_unknown_endpoints_do_not_get_json_mode(self, api_base):
+        assert not _openai_compatible_supports_json_mode(
+            _compatible(model="some-model", api_base=api_base)
+        )
+
+    def test_non_compatible_providers_do_not_use_the_allowlist(self):
+        assert not _openai_compatible_supports_json_mode(
+            LLMConfig(
+                provider="openai",
+                model="gpt-4o",
+                api_key="k",
+                api_base="https://api.stepfun.com/v1",
+            )
+        )
+
+    def test_json_mode_reads_the_verified_hosts_constant(self):
+        """Matching must come from the constant, not an inlined literal."""
+        with patch("app.llm.JSON_MODE_VERIFIED_HOSTS", frozenset({"api.example.com"})):
+            assert not _openai_compatible_supports_json_mode(
+                _compatible(model="step-2", api_base="https://api.stepfun.com/v1")
+            )
+            assert _openai_compatible_supports_json_mode(
+                _compatible(model="step-2", api_base="https://api.example.com/v1")
+            )

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -1,5 +1,6 @@
 """Unit tests for LLM capability helpers in app.llm."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from app.llm import (
     LLMConfig,
     _appears_truncated,
     _azure_foundry_api_version,
+    _extract_choice_primary_text,
     _get_retry_temperature,
     _normalize_api_base,
     _openai_compatible_supports_json_mode,
@@ -160,6 +162,21 @@ class TestProviderConfiguration:
             api_base="https://opencode.ai/zen/v1",
         )
         assert get_safe_max_tokens("openai/hy3-free", config=config) == 8192
+
+
+def test_primary_text_reads_typed_block_value_attribute():
+    choice = SimpleNamespace(
+        message=SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="output_text",
+                    value='{"required_skills": ["Python"]}',
+                )
+            ]
+        )
+    )
+
+    assert _extract_choice_primary_text(choice) == '{"required_skills": ["Python"]}'
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -10,8 +10,10 @@ from app.llm import (
     _azure_foundry_api_version,
     _get_retry_temperature,
     _normalize_api_base,
+    _openai_compatible_supports_json_mode,
     _supports_temperature,
     _uses_opencode_zen_hy3,
+    get_safe_max_tokens,
     get_model_name,
     resolve_api_key,
 )
@@ -134,6 +136,30 @@ class TestProviderConfiguration:
                 api_base="https://example.com/v1",
             )
         )
+
+    def test_recognizes_opencode_zen_without_a_trailing_path_segment(self):
+        config = LLMConfig(
+            provider="openai_compatible",
+            model="hy3-free",
+            api_key="",
+            api_base="https://opencode.ai/zen",
+        )
+        assert _uses_opencode_zen_hy3(config)
+        assert _openai_compatible_supports_json_mode(config)
+
+    @patch("app.llm.litellm.get_model_info", side_effect=Exception("unknown model"))
+    def test_unknown_models_keep_conservative_token_fallback(self, _mock_model_info):
+        assert get_safe_max_tokens("openai/custom-model") == 4096
+
+    @patch("app.llm.litellm.get_model_info", side_effect=Exception("unknown model"))
+    def test_opencode_hy3_gets_full_json_budget_when_unknown(self, _mock_model_info):
+        config = LLMConfig(
+            provider="openai_compatible",
+            model="hy3-free",
+            api_key="",
+            api_base="https://opencode.ai/zen/v1",
+        )
+        assert get_safe_max_tokens("openai/hy3-free", config=config) == 8192
 
 
 # ---------------------------------------------------------------------------
@@ -382,12 +408,12 @@ class TestCompleteJsonFallback:
     @patch("app.llm.get_router")
     @patch("app.llm.get_model_name")
     @patch("app.llm._supports_json_mode")
-    async def test_openai_compatible_uses_json_mode_for_unknown_model(
+    async def test_known_compatible_endpoint_uses_json_mode(
         self, mock_supports_json, mock_get_name, mock_get_router
     ):
-        """Custom compatible models should not depend on LiteLLM's registry."""
+        """Verified compatible endpoints can opt into JSON mode."""
         mock_supports_json.return_value = False
-        mock_get_name.return_value = "openai/custom-compatible-model"
+        mock_get_name.return_value = "openai/hy3-free"
 
         choice = MagicMock()
         choice.message.content = '{"required_skills": ["Python"]}'
@@ -395,9 +421,12 @@ class TestCompleteJsonFallback:
         response.choices = [choice]
         router = MagicMock()
         router.acompletion = AsyncMock(return_value=response)
-        config = MagicMock()
-        config.provider = "openai_compatible"
-        config.reasoning_effort = None
+        config = LLMConfig(
+            provider="openai_compatible",
+            model="hy3-free",
+            api_key="",
+            api_base="https://opencode.ai/zen/v1",
+        )
         mock_get_router.return_value = (router, config)
 
         from app.llm import complete_json
@@ -420,7 +449,7 @@ class TestCompleteJsonFallback:
 
         reasoning_only = MagicMock()
         reasoning_only.message.content = None
-        reasoning_only.message.reasoning_content = "I should construct JSON next."
+        reasoning_only.message.reasoning_content = '{"required_skills": ["incorrect"]}'
         completed = MagicMock()
         completed.message.content = '{"required_skills": ["Python"]}'
         router = MagicMock()
@@ -441,6 +470,36 @@ class TestCompleteJsonFallback:
 
         assert result == {"required_skills": ["Python"]}
         assert router.acompletion.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("app.llm.get_router")
+    @patch("app.llm.get_model_name")
+    @patch("app.llm._supports_json_mode")
+    async def test_typed_reasoning_block_is_excluded_from_final_json(
+        self, mock_supports_json, mock_get_name, mock_get_router
+    ):
+        mock_supports_json.return_value = False
+        mock_get_name.return_value = "openai/hy3-free"
+        choice = MagicMock()
+        choice.message.content = [
+            {"type": "reasoning", "text": '{"required_skills": ["incorrect"]}'},
+            {"type": "output_text", "text": '{"required_skills": ["Python"]}'},
+        ]
+        router = MagicMock()
+        router.acompletion = AsyncMock(return_value=MagicMock(choices=[choice]))
+        config = LLMConfig(
+            provider="openai_compatible",
+            model="hy3-free",
+            api_key="",
+            api_base="https://opencode.ai/zen/v1",
+        )
+        mock_get_router.return_value = (router, config)
+
+        from app.llm import complete_json
+
+        result = await complete_json("Extract keywords", schema_type="keywords")
+
+        assert result == {"required_skills": ["Python"]}
 
     @pytest.mark.asyncio
     @patch("app.llm.get_router")

--- a/apps/backend/tests/unit/test_parser.py
+++ b/apps/backend/tests/unit/test_parser.py
@@ -10,11 +10,23 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 from app.services.parser import (
+    _MAX_RESUME_CONTENT_RECURSION,
     _extract_markdown_dates,
     has_meaningful_resume_content,
     parse_resume_to_json,
     restore_dates_from_markdown,
 )
+
+
+def _wrap(value: object, levels: int) -> object:
+    """Nest ``value`` inside ``levels`` plain dicts.
+
+    ``has_meaningful_resume_content`` starts the recursion at depth 0 on the
+    section value, so ``levels`` wrappers put the string at depth ``levels``.
+    """
+    for _ in range(levels):
+        value = {"value": value}
+    return value
 
 
 class TestExtractMarkdownDates:
@@ -148,6 +160,49 @@ class TestMeaningfulResumeContent:
             deeply_nested = {"value": deeply_nested}
 
         assert has_meaningful_resume_content({"summary": deeply_nested}) is False
+
+    def test_finds_content_at_the_last_allowed_depth(self):
+        """Boundary: a value at depth ``limit - 1`` is still inspected."""
+        nested = _wrap("Resume content", _MAX_RESUME_CONTENT_RECURSION - 1)
+
+        assert has_meaningful_resume_content({"summary": nested}) is True
+
+    def test_rejects_content_one_level_past_the_limit(self):
+        """Boundary: a value at exactly ``limit`` is cut off (declared empty).
+
+        This is the documented, accepted false negative. It is unreachable for
+        schema-valid resumes -- see test_deepest_real_schema_content_is_found
+        and the comment on _MAX_RESUME_CONTENT_RECURSION.
+        """
+        nested = _wrap("Resume content", _MAX_RESUME_CONTENT_RECURSION)
+
+        assert has_meaningful_resume_content({"summary": nested}) is False
+
+    def test_deepest_real_schema_content_is_found(self):
+        """The deepest path ResumeData allows (depth 5) stays well inside 10.
+
+        customSections(0) -> CustomSection(1) -> items(2) -> item(3)
+        -> description(4) -> bullet(5).
+        """
+        assert has_meaningful_resume_content(
+            {
+                "customSections": {
+                    "publications": {
+                        "sectionType": "itemList",
+                        "items": [
+                            {
+                                "id": 0,
+                                "title": "",
+                                "subtitle": None,
+                                "years": "",
+                                "description": ["A paper nobody should lose"],
+                                "descriptionStyles": [],
+                            }
+                        ],
+                    }
+                }
+            }
+        ) is True
 
     @pytest.mark.asyncio
     @patch("app.services.parser.complete_json", new_callable=AsyncMock)

--- a/apps/backend/tests/unit/test_parser.py
+++ b/apps/backend/tests/unit/test_parser.py
@@ -107,9 +107,46 @@ class TestMeaningfulResumeContent:
             {"personalInfo": {}, "workExperience": [{"title": "Engineer"}]}
         ) is True
 
+    def test_rejects_default_only_section_entries(self):
+        assert has_meaningful_resume_content(
+            {
+                "workExperience": [
+                    {
+                        "id": 0,
+                        "title": "",
+                        "company": "",
+                        "years": "",
+                        "description": [],
+                        "descriptionStyles": [],
+                    }
+                ],
+                "customSections": {
+                    "empty": {
+                        "sectionType": "itemList",
+                        "items": [{"id": 0, "title": "", "description": []}],
+                    }
+                },
+            }
+        ) is False
+
+    def test_accepts_additional_and_custom_section_text(self):
+        assert has_meaningful_resume_content(
+            {"additional": {"technicalSkills": ["Python"]}}
+        ) is True
+        assert has_meaningful_resume_content(
+            {"customSections": {"publications": {"sectionType": "text", "text": "Paper"}}}
+        ) is True
+
     @pytest.mark.asyncio
     @patch("app.services.parser.complete_json", new_callable=AsyncMock)
     async def test_parse_rejects_empty_llm_json(self, mock_complete_json):
         mock_complete_json.return_value = {}
+        with pytest.raises(ValueError, match="empty structured resume"):
+            await parse_resume_to_json("Jane Doe")
+
+    @pytest.mark.asyncio
+    @patch("app.services.parser.complete_json", new_callable=AsyncMock)
+    async def test_parse_rejects_default_only_llm_entries(self, mock_complete_json):
+        mock_complete_json.return_value = {"workExperience": [{}]}
         with pytest.raises(ValueError, match="empty structured resume"):
             await parse_resume_to_json("Jane Doe")

--- a/apps/backend/tests/unit/test_parser.py
+++ b/apps/backend/tests/unit/test_parser.py
@@ -137,6 +137,18 @@ class TestMeaningfulResumeContent:
             {"customSections": {"publications": {"sectionType": "text", "text": "Paper"}}}
         ) is True
 
+    def test_accepts_custom_section_with_a_reserved_identifier(self):
+        assert has_meaningful_resume_content(
+            {"customSections": {"key": {"sectionType": "text", "text": "Paper"}}}
+        ) is True
+
+    def test_rejects_content_beyond_the_recursion_limit(self):
+        deeply_nested: object = "Resume content"
+        for _ in range(11):
+            deeply_nested = {"value": deeply_nested}
+
+        assert has_meaningful_resume_content({"summary": deeply_nested}) is False
+
     @pytest.mark.asyncio
     @patch("app.services.parser.complete_json", new_callable=AsyncMock)
     async def test_parse_rejects_empty_llm_json(self, mock_complete_json):

--- a/apps/backend/tests/unit/test_parser.py
+++ b/apps/backend/tests/unit/test_parser.py
@@ -6,7 +6,15 @@ markdown. This is pure, deterministic logic — the parser module was at ~20%
 coverage with none of it exercised.
 """
 
-from app.services.parser import _extract_markdown_dates, restore_dates_from_markdown
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.services.parser import (
+    _extract_markdown_dates,
+    has_meaningful_resume_content,
+    parse_resume_to_json,
+    restore_dates_from_markdown,
+)
 
 
 class TestExtractMarkdownDates:
@@ -78,3 +86,30 @@ class TestRestoreDatesFromMarkdown:
         markdown = "Jun 2020 - Aug 2021"
         result = restore_dates_from_markdown(parsed, markdown)
         assert result["workExperience"][1]["years"] == "Jun 2020 - Aug 2021"
+
+
+class TestMeaningfulResumeContent:
+    def test_rejects_schema_defaults_only(self):
+        assert has_meaningful_resume_content(
+            {
+                "personalInfo": {},
+                "summary": "",
+                "workExperience": [],
+                "education": [],
+                "personalProjects": [],
+                "additional": {"technicalSkills": []},
+                "customSections": {},
+            }
+        ) is False
+
+    def test_accepts_experience_without_contact_details(self):
+        assert has_meaningful_resume_content(
+            {"personalInfo": {}, "workExperience": [{"title": "Engineer"}]}
+        ) is True
+
+    @pytest.mark.asyncio
+    @patch("app.services.parser.complete_json", new_callable=AsyncMock)
+    async def test_parse_rejects_empty_llm_json(self, mock_complete_json):
+        mock_complete_json.return_value = {}
+        with pytest.raises(ValueError, match="empty structured resume"):
+            await parse_resume_to_json("Jane Doe")

--- a/apps/frontend/app/(default)/dashboard/page.tsx
+++ b/apps/frontend/app/(default)/dashboard/page.tsx
@@ -31,22 +31,38 @@ import { useStatusCache } from '@/lib/context/status-cache';
 
 type ProcessingStatus = 'pending' | 'processing' | 'ready' | 'failed' | 'loading';
 
+const nonContentResumeKeys = new Set([
+  'id',
+  'sectionType',
+  'descriptionStyles',
+  'isDefault',
+  'isVisible',
+  'order',
+  'key',
+  'displayName',
+]);
+
+const hasMeaningfulResumeValue = (value: unknown): boolean => {
+  if (typeof value === 'string') return Boolean(value.trim());
+  if (Array.isArray(value)) return value.some(hasMeaningfulResumeValue);
+  if (!value || typeof value !== 'object') return false;
+  return Object.entries(value as Record<string, unknown>).some(
+    ([key, item]) => !nonContentResumeKeys.has(key) && hasMeaningfulResumeValue(item)
+  );
+};
+
 const hasMeaningfulResumeContent = (value: unknown): boolean => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const resume = value as Record<string, unknown>;
-  const personalInfo = resume.personalInfo;
-  if (
-    personalInfo &&
-    typeof personalInfo === 'object' &&
-    !Array.isArray(personalInfo) &&
-    Object.values(personalInfo).some((field) => typeof field === 'string' && field.trim())
-  ) {
-    return true;
-  }
-  if (typeof resume.summary === 'string' && resume.summary.trim()) return true;
-  return ['workExperience', 'education', 'personalProjects'].some(
-    (section) => Array.isArray(resume[section]) && resume[section].length > 0
-  );
+  return [
+    'personalInfo',
+    'summary',
+    'workExperience',
+    'education',
+    'personalProjects',
+    'additional',
+    'customSections',
+  ].some((section) => hasMeaningfulResumeValue(resume[section]));
 };
 
 export default function DashboardPage() {

--- a/apps/frontend/app/(default)/dashboard/page.tsx
+++ b/apps/frontend/app/(default)/dashboard/page.tsx
@@ -41,13 +41,23 @@ const nonContentResumeKeys = new Set([
   'key',
   'displayName',
 ]);
+const maxResumeContentRecursion = 10;
 
-const hasMeaningfulResumeValue = (value: unknown): boolean => {
+const hasMeaningfulResumeValue = (
+  value: unknown,
+  depth = 0,
+  filterStructuralKeys = true
+): boolean => {
+  if (depth >= maxResumeContentRecursion) return false;
   if (typeof value === 'string') return Boolean(value.trim());
-  if (Array.isArray(value)) return value.some(hasMeaningfulResumeValue);
+  if (Array.isArray(value)) {
+    return value.some((item) => hasMeaningfulResumeValue(item, depth + 1));
+  }
   if (!value || typeof value !== 'object') return false;
   return Object.entries(value as Record<string, unknown>).some(
-    ([key, item]) => !nonContentResumeKeys.has(key) && hasMeaningfulResumeValue(item)
+    ([key, item]) =>
+      (!filterStructuralKeys || !nonContentResumeKeys.has(key)) &&
+      hasMeaningfulResumeValue(item, depth + 1)
   );
 };
 
@@ -62,7 +72,7 @@ const hasMeaningfulResumeContent = (value: unknown): boolean => {
     'personalProjects',
     'additional',
     'customSections',
-  ].some((section) => hasMeaningfulResumeValue(resume[section]));
+  ].some((section) => hasMeaningfulResumeValue(resume[section], 0, section !== 'customSections'));
 };
 
 export default function DashboardPage() {

--- a/apps/frontend/app/(default)/dashboard/page.tsx
+++ b/apps/frontend/app/(default)/dashboard/page.tsx
@@ -28,52 +28,9 @@ import {
   type ResumeListItem,
 } from '@/lib/api/resume';
 import { useStatusCache } from '@/lib/context/status-cache';
+import { hasMeaningfulResumeContent } from '@/lib/utils/resume-content';
 
 type ProcessingStatus = 'pending' | 'processing' | 'ready' | 'failed' | 'loading';
-
-const nonContentResumeKeys = new Set([
-  'id',
-  'sectionType',
-  'descriptionStyles',
-  'isDefault',
-  'isVisible',
-  'order',
-  'key',
-  'displayName',
-]);
-const maxResumeContentRecursion = 10;
-
-const hasMeaningfulResumeValue = (
-  value: unknown,
-  depth = 0,
-  filterStructuralKeys = true
-): boolean => {
-  if (depth >= maxResumeContentRecursion) return false;
-  if (typeof value === 'string') return Boolean(value.trim());
-  if (Array.isArray(value)) {
-    return value.some((item) => hasMeaningfulResumeValue(item, depth + 1));
-  }
-  if (!value || typeof value !== 'object') return false;
-  return Object.entries(value as Record<string, unknown>).some(
-    ([key, item]) =>
-      (!filterStructuralKeys || !nonContentResumeKeys.has(key)) &&
-      hasMeaningfulResumeValue(item, depth + 1)
-  );
-};
-
-const hasMeaningfulResumeContent = (value: unknown): boolean => {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const resume = value as Record<string, unknown>;
-  return [
-    'personalInfo',
-    'summary',
-    'workExperience',
-    'education',
-    'personalProjects',
-    'additional',
-    'customSections',
-  ].some((section) => hasMeaningfulResumeValue(resume[section], 0, section !== 'customSections'));
-};
 
 export default function DashboardPage() {
   const { t, locale } = useTranslations();

--- a/apps/frontend/app/(default)/dashboard/page.tsx
+++ b/apps/frontend/app/(default)/dashboard/page.tsx
@@ -31,6 +31,24 @@ import { useStatusCache } from '@/lib/context/status-cache';
 
 type ProcessingStatus = 'pending' | 'processing' | 'ready' | 'failed' | 'loading';
 
+const hasMeaningfulResumeContent = (value: unknown): boolean => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const resume = value as Record<string, unknown>;
+  const personalInfo = resume.personalInfo;
+  if (
+    personalInfo &&
+    typeof personalInfo === 'object' &&
+    !Array.isArray(personalInfo) &&
+    Object.values(personalInfo).some((field) => typeof field === 'string' && field.trim())
+  ) {
+    return true;
+  }
+  if (typeof resume.summary === 'string' && resume.summary.trim()) return true;
+  return ['workExperience', 'education', 'personalProjects'].some(
+    (section) => Array.isArray(resume[section]) && resume[section].length > 0
+  );
+};
+
 export default function DashboardPage() {
   const { t, locale } = useTranslations();
   const [masterResumeId, setMasterResumeId] = useState<string | null>(null);
@@ -80,7 +98,13 @@ export default function DashboardPage() {
     try {
       setProcessingStatus('loading');
       const data = await fetchResume(resumeId);
-      const status = data.raw_resume?.processing_status || 'pending';
+      const savedStatus = data.raw_resume?.processing_status || 'pending';
+      // Older backend versions accepted `{}` as a valid ResumeData object.
+      // Surface that legacy state as failed so users can retry it safely.
+      const status =
+        savedStatus === 'ready' && !hasMeaningfulResumeContent(data.processed_resume)
+          ? 'failed'
+          : savedStatus;
       setProcessingStatus(status as ProcessingStatus);
     } catch (err: unknown) {
       console.error('Failed to check resume status:', err);

--- a/apps/frontend/lib/utils/resume-content.ts
+++ b/apps/frontend/lib/utils/resume-content.ts
@@ -1,0 +1,85 @@
+/**
+ * Mirror of `apps/backend/app/services/parser.py::has_meaningful_resume_content`
+ * (and its `_has_meaningful_resume_value` helper), which is the authoritative
+ * implementation. The backend rejects an LLM parse whose result carries no
+ * user-visible content; the dashboard uses the same predicate to surface a
+ * legacy `ready` resume that stored `{}` as `failed` instead of a blank PDF.
+ *
+ * THE TWO COPIES MUST BE CHANGED TOGETHER. The constant names, values and the
+ * seven section names below are kept aligned with the Python so the two files
+ * can be diffed by eye:
+ *
+ *   nonContentResumeKeys      <-> _NON_CONTENT_RESUME_KEYS
+ *   maxResumeContentRecursion <-> _MAX_RESUME_CONTENT_RECURSION
+ *   hasMeaningfulResumeValue  <-> _has_meaningful_resume_value
+ *   hasMeaningfulResumeContent<-> has_meaningful_resume_content
+ */
+
+/** @internal Exported for tests/resume-content-parity.test.ts. */
+export const nonContentResumeKeys = new Set([
+  'id',
+  'sectionType',
+  'descriptionStyles',
+  'isDefault',
+  'isVisible',
+  'order',
+  'key',
+  'displayName',
+]);
+
+/** @internal Exported for tests/resume-content-parity.test.ts. */
+export const maxResumeContentRecursion = 10;
+
+/**
+ * Content-bearing sections, mirroring ``content_sections`` in the Python.
+ * @internal Exported for tests/resume-content-parity.test.ts.
+ */
+export const resumeContentSections = [
+  'personalInfo',
+  'summary',
+  'workExperience',
+  'education',
+  'personalProjects',
+  'additional',
+  'customSections',
+] as const;
+
+/**
+ * Return whether a value contains non-structural, user-visible text.
+ *
+ * Custom-section identifiers are dictionary keys rather than schema fields, so
+ * their values are checked without filtering the identifier itself. Once inside
+ * a section, normal structural-key filtering resumes.
+ */
+const hasMeaningfulResumeValue = (
+  value: unknown,
+  depth = 0,
+  filterStructuralKeys = true
+): boolean => {
+  if (depth >= maxResumeContentRecursion) return false;
+  if (typeof value === 'string') return Boolean(value.trim());
+  if (Array.isArray(value)) {
+    return value.some((item) => hasMeaningfulResumeValue(item, depth + 1));
+  }
+  if (!value || typeof value !== 'object') return false;
+  return Object.entries(value as Record<string, unknown>).some(
+    ([key, item]) =>
+      (!filterStructuralKeys || !nonContentResumeKeys.has(key)) &&
+      hasMeaningfulResumeValue(item, depth + 1)
+  );
+};
+
+/**
+ * Return whether parsed resume data contains any user-facing content.
+ *
+ * `ResumeData` intentionally defaults most fields to empty strings/lists. That
+ * is useful for the builder, but it also means an LLM response such as `{}`
+ * validates successfully — which would render a blank resume.
+ */
+export const hasMeaningfulResumeContent = (value: unknown): boolean => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const resume = value as Record<string, unknown>;
+  return resumeContentSections.some((section) =>
+    hasMeaningfulResumeValue(resume[section], 0, section !== 'customSections')
+  );
+};

--- a/apps/frontend/tests/resume-content-parity.test.ts
+++ b/apps/frontend/tests/resume-content-parity.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  maxResumeContentRecursion,
+  nonContentResumeKeys,
+  resumeContentSections,
+} from '@/lib/utils/resume-content';
+
+/**
+ * `lib/utils/resume-content.ts` is a hand-maintained TypeScript mirror of
+ * `has_meaningful_resume_content` in apps/backend/app/services/parser.py. The
+ * backend uses it to reject an empty LLM parse; the dashboard uses it to show
+ * a legacy empty-but-`ready` resume as failed. If the two drift, the dashboard
+ * starts disagreeing with the backend about whether a resume is usable.
+ *
+ * A comment asking the next person to keep them in sync is not a guarantee, so
+ * this reads the Python source and asserts the shared constants still match —
+ * the same tactic as i18n-locale-parity.test.ts.
+ */
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const parserPy = readFileSync(resolve(repoRoot, 'apps/backend/app/services/parser.py'), 'utf-8');
+
+/** Pull the double-quoted strings out of a named Python block. */
+function pyStrings(source: string, pattern: RegExp, label: string): string[] {
+  const match = source.match(pattern);
+  if (!match) {
+    throw new Error(
+      `Could not find ${label} in parser.py — the parity guard needs updating, ` +
+        'not deleting: it is the only thing keeping the two copies aligned.'
+    );
+  }
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+describe('resume-content parity with the Python original', () => {
+  it('has the same structural (non-content) keys', () => {
+    const pythonKeys = pyStrings(
+      parserPy,
+      /_NON_CONTENT_RESUME_KEYS\s*=\s*frozenset\(\s*\{([\s\S]*?)\}\s*\)/,
+      '_NON_CONTENT_RESUME_KEYS'
+    );
+
+    expect(pythonKeys.length).toBeGreaterThan(0);
+    expect([...nonContentResumeKeys].sort()).toEqual(pythonKeys.sort());
+  });
+
+  it('has the same content sections, in the same order', () => {
+    const pythonSections = pyStrings(
+      parserPy,
+      /content_sections\s*=\s*\(([\s\S]*?)\)/,
+      'content_sections'
+    );
+
+    // Order matters less than membership, but keeping it identical is what
+    // lets a reader diff the two files by eye.
+    expect([...resumeContentSections]).toEqual(pythonSections);
+  });
+
+  it('has the same recursion depth cap', () => {
+    const match = parserPy.match(/^_MAX_RESUME_CONTENT_RECURSION\s*=\s*(\d+)/m);
+    if (!match) throw new Error('Could not find _MAX_RESUME_CONTENT_RECURSION in parser.py');
+
+    expect(maxResumeContentRecursion).toBe(Number(match[1]));
+  });
+});

--- a/apps/frontend/tests/resume-content.test.ts
+++ b/apps/frontend/tests/resume-content.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { hasMeaningfulResumeContent } from '@/lib/utils/resume-content';
+
+/**
+ * Guards the frontend half of a predicate that is mirrored from
+ * `apps/backend/app/services/parser.py::has_meaningful_resume_content`.
+ * The dashboard downgrades a `ready` resume with no meaningful content to
+ * `failed`, so a false positive here means users get a blank PDF instead of a
+ * retry prompt.
+ */
+
+/** Wrap `leaf` in `depth` nested objects: nest(2, 'x') -> { a: { a: 'x' } }. */
+function nest(depth: number, leaf: unknown): unknown {
+  let value = leaf;
+  for (let i = 0; i < depth; i += 1) {
+    value = { a: value };
+  }
+  return value;
+}
+
+describe('hasMeaningfulResumeContent', () => {
+  it('rejects non-object input', () => {
+    expect(hasMeaningfulResumeContent(null)).toBe(false);
+    expect(hasMeaningfulResumeContent(undefined)).toBe(false);
+    expect(hasMeaningfulResumeContent('resume')).toBe(false);
+    expect(hasMeaningfulResumeContent(42)).toBe(false);
+    // A top-level array is not a ResumeData object even when it holds text.
+    expect(hasMeaningfulResumeContent([{ summary: 'Senior engineer' }])).toBe(false);
+  });
+
+  it('rejects the empty object an LLM can return and still validate', () => {
+    expect(hasMeaningfulResumeContent({})).toBe(false);
+  });
+
+  it('rejects schema defaults: empty strings, empty lists, whitespace', () => {
+    expect(
+      hasMeaningfulResumeContent({
+        personalInfo: { name: '', email: '', phone: '   ' },
+        summary: '',
+        workExperience: [],
+        education: [],
+        personalProjects: [],
+        additional: {},
+        customSections: {},
+      })
+    ).toBe(false);
+  });
+
+  it('rejects entries whose only populated keys are structural', () => {
+    expect(
+      hasMeaningfulResumeContent({
+        workExperience: [
+          { id: 'exp-1', order: 0, isVisible: true, company: '', title: '', description: '' },
+        ],
+      })
+    ).toBe(false);
+    expect(
+      hasMeaningfulResumeContent({
+        education: [{ id: 'edu-1', key: 'education', displayName: 'Education', isDefault: true }],
+      })
+    ).toBe(false);
+  });
+
+  it('accepts a populated personalInfo', () => {
+    expect(
+      hasMeaningfulResumeContent({
+        personalInfo: { id: 'p-1', name: 'Ada Lovelace', email: '', phone: '' },
+        summary: '',
+        workExperience: [],
+      })
+    ).toBe(true);
+  });
+
+  it('accepts content nested inside additional', () => {
+    expect(
+      hasMeaningfulResumeContent({
+        personalInfo: {},
+        additional: { skills: [{ id: 's-1', name: 'TypeScript' }] },
+      })
+    ).toBe(true);
+  });
+
+  it('accepts a customSections entry keyed by a structural-looking identifier', () => {
+    // customSections identifiers are dict keys, not schema fields, so
+    // structural-key filtering is deliberately disabled one level down.
+    expect(
+      hasMeaningfulResumeContent({ customSections: { id: { heading: 'Certifications' } } })
+    ).toBe(true);
+    // The same shape under a normal section stays filtered -- this pair is the
+    // whole point of the `section !== 'customSections'` argument.
+    expect(hasMeaningfulResumeContent({ additional: { id: { heading: 'Certifications' } } })).toBe(
+      false
+    );
+  });
+
+  it('resumes structural filtering inside a custom section', () => {
+    expect(hasMeaningfulResumeContent({ customSections: { certs: { id: 'cs-1' } } })).toBe(false);
+    expect(hasMeaningfulResumeContent({ customSections: { certs: { heading: 'AWS' } } })).toBe(
+      true
+    );
+  });
+
+  it('only inspects the seven content sections', () => {
+    expect(
+      hasMeaningfulResumeContent({
+        sectionMeta: [{ displayName: 'Skills', heading: 'Skills' }],
+        templateSettings: { fontFamily: 'Geist' },
+      })
+    ).toBe(false);
+  });
+
+  it('stops recursing past 10 levels', () => {
+    // Depth 9 is still reachable; depth 10 hits the recursion guard.
+    expect(hasMeaningfulResumeContent({ additional: nest(9, 'Reachable') })).toBe(true);
+    expect(hasMeaningfulResumeContent({ additional: nest(10, 'Too deep') })).toBe(false);
+    expect(hasMeaningfulResumeContent({ additional: nest(25, 'Way too deep') })).toBe(false);
+  });
+});


### PR DESCRIPTION
Brings #924 to `main` together with the review follow-ups applied on `dev`.

## What #924 fixes (@wwlwgo)

An LLM returning `{}` validated fine against `ResumeData` (which defaults every field to empty), so uploads were marked `ready` with no content — producing blank PDF exports and tailoring runs over empty data.

- Reject empty structured output, including schema-default-only entries
- Parse only the model's final content, never its reasoning trace
- Scope JSON mode and the full token budget to verified OpenAI-compatible endpoints; unknown ones keep the conservative prompt-only default
- Allow legacy empty-but-`ready` resumes to be reprocessed
- Stop writing model output (which can contain a user's resume) to logs and exception messages

## Review follow-ups (`df17b48`)

- Duplicated meaningful-content predicate extracted out of the dashboard page into `lib/utils/resume-content.ts`, with a parity test that reads `parser.py` and fails when the two copies drift
- Hardcoded vendor endpoint details in `llm.py` lifted into documented constants; matching behavior unchanged
- `"Resume not found"` substring match replaced with `ResumeNotFoundError` (a `ValueError` subclass, so existing handlers still work)
- Recursion depth cap documented against the real schema depth (max 5 vs a cap of 10) and pinned with boundary tests

## Verification

| Check | Before | After |
|---|---|---|
| Backend pytest | 549 passed | **592 passed** |
| Frontend vitest | 265 / 35 files | **278 / 37 files** |
| `tsc --noEmit` | — | exit 0 |
| `eslint` | — | exit 0 |
| `next build` | — | succeeds |

New tests were mutation-checked: deliberately breaking each target turns the relevant test red.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the resume parser from accepting empty or schema-default-only LLM output, which previously validated successfully and caused blank PDF exports and tailoring runs over empty data.

- Rejects structured output with no user-visible content before marking a resume ready, and flags legacy empty-but-ready resumes for reprocessing.
- Parses only the model's final answer, never its reasoning trace.
- Limits JSON mode and the full token budget to verified OpenAI-compatible endpoints; unknown ones keep the conservative prompt-only default.
- Stops writing model output (which can contain a user's resume) to logs and exception messages.

**Refactors**

- Moves the shared meaningful-content predicate into `lib/utils/resume-content.ts`, with a parity test that fails when it drifts from the Python original.
- Replaces the `"Resume not found"` substring match with `ResumeNotFoundError` and lifts endpoint details in `llm.py` into documented constants.

<sup>Written for commit df17b48addb07a8c5652b6bc2b634f8f2027ad66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

