### PR TITLE
feat: tracker column visibility management (#920) + review follow-ups

### DIFF
--- a/apps/frontend/components/tracker/kanban-board.tsx
+++ b/apps/frontend/components/tracker/kanban-board.tsx
@@ -36,6 +36,7 @@ import { planMove } from './reorder';
 import { ManageColumnsDialog } from './manage-columns-dialog';
 import {
   readHiddenStatuses,
+  toggleHiddenStatus,
   writeHiddenStatuses,
 } from '@/lib/utils/tracker-column-visibility';
 
@@ -60,13 +61,19 @@ export function KanbanBoard() {
   const [openCardId, setOpenCardId] = useState<string | null>(null);
   const [manualAddOpen, setManualAddOpen] = useState(false);
   const [manageOpen, setManageOpen] = useState(false);
-  const [hiddenStatuses, setHiddenStatuses] = useState<Set<ApplicationStatus>>(
-    () => readHiddenStatuses()
+  const [hiddenStatuses, setHiddenStatuses] = useState<Set<ApplicationStatus>>(() =>
+    readHiddenStatuses()
   );
 
-  useEffect(() => {
-    writeHiddenStatuses(hiddenStatuses);
-  }, [hiddenStatuses]);
+  // Persist on an actual change only — an effect keyed on the state would also
+  // write the just-read value straight back on mount.
+  const handleToggleStatus = (status: ApplicationStatus) => {
+    const next = toggleHiddenStatus(hiddenStatuses, status);
+    // Refused (last visible stage): identical instance, nothing to store.
+    if (next === hiddenStatuses) return;
+    setHiddenStatuses(next);
+    writeHiddenStatuses(next);
+  };
 
   // Horizontal-scroll affordance: the seven stages overflow the canvas, so we
   // track whether more columns sit off-screen and surface controls + a stage
@@ -352,17 +359,7 @@ export function KanbanBoard() {
         open={manageOpen}
         onOpenChange={setManageOpen}
         hiddenStatuses={hiddenStatuses}
-        onToggle={(status) =>
-          setHiddenStatuses((prev) => {
-            const next = new Set(prev);
-            if (next.has(status)) {
-              next.delete(status);
-            } else {
-              next.add(status);
-            }
-            return next;
-          })
-        }
+        onToggle={handleToggleStatus}
       />
     </div>
   );

--- a/apps/frontend/components/tracker/kanban-board.tsx
+++ b/apps/frontend/components/tracker/kanban-board.tsx
@@ -12,6 +12,7 @@ import {
 } from '@dnd-kit/core';
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import Plus from 'lucide-react/dist/esm/icons/plus';
+import Settings from 'lucide-react/dist/esm/icons/settings';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
 import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left';
 import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right';
@@ -32,6 +33,11 @@ import { BulkActionBar } from './bulk-action-bar';
 import { CardDetailModal } from './card-detail-modal';
 import { ManualAddApplicationDialog } from './manual-add-application-dialog';
 import { planMove } from './reorder';
+import { ManageColumnsDialog } from './manage-columns-dialog';
+import {
+  readHiddenStatuses,
+  writeHiddenStatuses,
+} from '@/lib/utils/tracker-column-visibility';
 
 function emptyColumns(): ApplicationColumns {
   return APPLICATION_STATUS_ORDER.reduce((acc, status) => {
@@ -53,6 +59,14 @@ export function KanbanBoard() {
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [openCardId, setOpenCardId] = useState<string | null>(null);
   const [manualAddOpen, setManualAddOpen] = useState(false);
+  const [manageOpen, setManageOpen] = useState(false);
+  const [hiddenStatuses, setHiddenStatuses] = useState<Set<ApplicationStatus>>(
+    () => readHiddenStatuses()
+  );
+
+  useEffect(() => {
+    writeHiddenStatuses(hiddenStatuses);
+  }, [hiddenStatuses]);
 
   // Horizontal-scroll affordance: the seven stages overflow the canvas, so we
   // track whether more columns sit off-screen and surface controls + a stage
@@ -82,6 +96,11 @@ export function KanbanBoard() {
   const allCards: Application[] = useMemo(
     () => APPLICATION_STATUS_ORDER.flatMap((status) => columns[status]),
     [columns]
+  );
+
+  const visibleStatuses = useMemo(
+    () => APPLICATION_STATUS_ORDER.filter((status) => !hiddenStatuses.has(status)),
+    [hiddenStatuses]
   );
 
   // Master resume ids that back more than one card → "shared resume" badge.
@@ -196,6 +215,10 @@ export function KanbanBoard() {
           </p>
         </div>
         <div className="flex items-center gap-3">
+          <Button variant="outline" onClick={() => setManageOpen(true)}>
+            <Settings className="h-4 w-4" />
+            {t('tracker.manage')}
+          </Button>
           {showScrollControls && (
             <div className="flex items-center">
               <button
@@ -261,12 +284,12 @@ export function KanbanBoard() {
             onDragEnd={handleDragEnd}
           >
             <div ref={scrollRef} className="flex min-h-0 flex-1 overflow-x-auto">
-              {APPLICATION_STATUS_ORDER.map((status, index) => (
+              {visibleStatuses.map((status, index) => (
                 <div
                   key={status}
                   data-column={status}
                   className={`flex ${
-                    index < APPLICATION_STATUS_ORDER.length - 1 ? 'border-r border-black' : ''
+                    index < visibleStatuses.length - 1 ? 'border-r border-black' : ''
                   }`}
                 >
                   <KanbanColumn
@@ -295,7 +318,7 @@ export function KanbanBoard() {
             </span>
           )}
           <div className="flex items-center gap-2">
-            {APPLICATION_STATUS_ORDER.map((status) => (
+            {visibleStatuses.map((status) => (
               <button
                 key={status}
                 type="button"
@@ -323,6 +346,23 @@ export function KanbanBoard() {
         open={manualAddOpen}
         onOpenChange={setManualAddOpen}
         onCreated={load}
+      />
+
+      <ManageColumnsDialog
+        open={manageOpen}
+        onOpenChange={setManageOpen}
+        hiddenStatuses={hiddenStatuses}
+        onToggle={(status) =>
+          setHiddenStatuses((prev) => {
+            const next = new Set(prev);
+            if (next.has(status)) {
+              next.delete(status);
+            } else {
+              next.add(status);
+            }
+            return next;
+          })
+        }
       />
     </div>
   );

--- a/apps/frontend/components/tracker/manage-columns-dialog.tsx
+++ b/apps/frontend/components/tracker/manage-columns-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { ToggleSwitch } from '@/components/ui/toggle-switch';
+import { isLastVisibleStatus } from '@/lib/utils/tracker-column-visibility';
 
 interface ManageColumnsDialogProps {
   open: boolean;
@@ -40,14 +41,28 @@ export function ManageColumnsDialog({
         <div className="max-h-[60vh] space-y-3 overflow-y-auto py-4">
           {APPLICATION_STATUS_ORDER.map((status) => {
             const hidden = hiddenStatuses.has(status);
+            // The last stage on the board is locked: hiding it would leave a
+            // blank canvas reachable only through this dialog.
+            const lastVisible = isLastVisibleStatus(hiddenStatuses, status);
             return (
-              <ToggleSwitch
-                key={status}
-                checked={!hidden}
-                onCheckedChange={() => onToggle(status)}
-                label={t(`tracker.columns.${status}`)}
-                description={hidden ? t('tracker.manageDialog.hide') : t('tracker.manageDialog.show')}
-              />
+              <div key={status}>
+                <ToggleSwitch
+                  checked={!hidden}
+                  onCheckedChange={() => onToggle(status)}
+                  label={t(`tracker.columns.${status}`)}
+                  // State label, not an action: the switch position already
+                  // carries the action.
+                  description={
+                    hidden ? t('tracker.manageDialog.hidden') : t('tracker.manageDialog.visible')
+                  }
+                  disabled={lastVisible}
+                />
+                {lastVisible && (
+                  <p className="mt-1 font-mono text-[11px] uppercase tracking-wide text-ink-soft">
+                    {t('tracker.manageDialog.lastVisibleHint')}
+                  </p>
+                )}
+              </div>
             );
           })}
         </div>

--- a/apps/frontend/components/tracker/manage-columns-dialog.tsx
+++ b/apps/frontend/components/tracker/manage-columns-dialog.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React from 'react';
+import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
+import { useTranslations } from '@/lib/i18n';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ToggleSwitch } from '@/components/ui/toggle-switch';
+
+interface ManageColumnsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hiddenStatuses: Set<ApplicationStatus>;
+  onToggle: (status: ApplicationStatus) => void;
+}
+
+export function ManageColumnsDialog({
+  open,
+  onOpenChange,
+  hiddenStatuses,
+  onToggle,
+}: ManageColumnsDialogProps) {
+  const { t } = useTranslations();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md p-6">
+        <DialogHeader>
+          <DialogTitle>{t('tracker.manageDialog.title')}</DialogTitle>
+          <DialogDescription>{t('tracker.manageDialog.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] space-y-3 overflow-y-auto py-4">
+          {APPLICATION_STATUS_ORDER.map((status) => {
+            const hidden = hiddenStatuses.has(status);
+            return (
+              <ToggleSwitch
+                key={status}
+                checked={!hidden}
+                onCheckedChange={() => onToggle(status)}
+                label={t(`tracker.columns.${status}`)}
+                description={hidden ? t('tracker.manageDialog.hide') : t('tracker.manageDialog.show')}
+              />
+            );
+          })}
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>{t('tracker.manageDialog.close')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/lib/utils/tracker-column-visibility.ts
+++ b/apps/frontend/lib/utils/tracker-column-visibility.ts
@@ -4,6 +4,11 @@ import { safeStorage } from '@/lib/utils/resume-draft-storage';
 export const TRACKER_HIDDEN_STATUSES_KEY = 'tracker_hidden_statuses';
 
 export function readHiddenStatuses(): Set<ApplicationStatus> {
+  // Server render has no localStorage: return the default (everything visible)
+  // instead of reaching for storage, matching the house pattern used by the
+  // builder's template-settings initialiser.
+  if (typeof window === 'undefined') return new Set();
+
   const raw = safeStorage.get(TRACKER_HIDDEN_STATUSES_KEY);
   if (!raw) return new Set();
 
@@ -27,4 +32,35 @@ export function readHiddenStatuses(): Set<ApplicationStatus> {
 export function writeHiddenStatuses(hidden: Set<ApplicationStatus>): boolean {
   const ordered = APPLICATION_STATUS_ORDER.filter((status) => hidden.has(status));
   return safeStorage.set(TRACKER_HIDDEN_STATUSES_KEY, JSON.stringify(ordered));
+}
+
+/**
+ * True when `status` is the only stage still on the board. Hiding it would
+ * leave a blank canvas whose only escape hatch is the Manage dialog, so the
+ * board keeps at least one column at all times.
+ */
+export function isLastVisibleStatus(
+  hidden: Set<ApplicationStatus>,
+  status: ApplicationStatus
+): boolean {
+  if (hidden.has(status)) return false;
+  return APPLICATION_STATUS_ORDER.every(
+    (candidate) => candidate === status || hidden.has(candidate)
+  );
+}
+
+/**
+ * Flip one stage's visibility, enforcing the "at least one visible column"
+ * invariant. Returns the SAME set instance when the toggle is refused so
+ * callers can skip both the re-render and the persist.
+ */
+export function toggleHiddenStatus(
+  hidden: Set<ApplicationStatus>,
+  status: ApplicationStatus
+): Set<ApplicationStatus> {
+  const next = new Set(hidden);
+  if (next.delete(status)) return next;
+  if (isLastVisibleStatus(hidden, status)) return hidden;
+  next.add(status);
+  return next;
 }

--- a/apps/frontend/lib/utils/tracker-column-visibility.ts
+++ b/apps/frontend/lib/utils/tracker-column-visibility.ts
@@ -1,0 +1,30 @@
+import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
+import { safeStorage } from '@/lib/utils/resume-draft-storage';
+
+export const TRACKER_HIDDEN_STATUSES_KEY = 'tracker_hidden_statuses';
+
+export function readHiddenStatuses(): Set<ApplicationStatus> {
+  const raw = safeStorage.get(TRACKER_HIDDEN_STATUSES_KEY);
+  if (!raw) return new Set();
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+
+    const validStatuses = new Set<ApplicationStatus>(APPLICATION_STATUS_ORDER);
+    const hidden = new Set<ApplicationStatus>();
+    for (const value of parsed) {
+      if (typeof value === 'string' && validStatuses.has(value as ApplicationStatus)) {
+        hidden.add(value as ApplicationStatus);
+      }
+    }
+    return hidden;
+  } catch {
+    return new Set();
+  }
+}
+
+export function writeHiddenStatuses(hidden: Set<ApplicationStatus>): boolean {
+  const ordered = APPLICATION_STATUS_ORDER.filter((status) => hidden.has(status));
+  return safeStorage.set(TRACKER_HIDDEN_STATUSES_KEY, JSON.stringify(ordered));
+}

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -979,8 +979,9 @@
     "manageDialog": {
       "title": "Manage Columns",
       "description": "Choose which stages appear on the board.",
-      "show": "Show",
-      "hide": "Hide",
+      "visible": "Visible",
+      "hidden": "Hidden",
+      "lastVisibleHint": "At least one stage must stay visible.",
       "close": "Done"
     },
     "scroll": {

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "Scroll left",
       "next": "Scroll right",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "Desplazar a la izquierda",
       "next": "Desplazar a la derecha",

--- a/apps/frontend/messages/es.json
+++ b/apps/frontend/messages/es.json
@@ -975,13 +975,14 @@
     }
   },
   "tracker": {
-    "manage": "Manage",
+    "manage": "Gestionar",
     "manageDialog": {
-      "title": "Manage Columns",
-      "description": "Choose which stages appear on the board.",
-      "show": "Show",
-      "hide": "Hide",
-      "close": "Done"
+      "title": "Gestionar columnas",
+      "description": "Elige qué etapas aparecen en el tablero.",
+      "visible": "Visible",
+      "hidden": "Oculta",
+      "lastVisibleHint": "Al menos una etapa debe permanecer visible.",
+      "close": "Listo"
     },
     "scroll": {
       "prev": "Desplazar a la izquierda",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "Faire défiler à gauche",
       "next": "Faire défiler à droite",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -975,13 +975,14 @@
     }
   },
   "tracker": {
-    "manage": "Manage",
+    "manage": "Gérer",
     "manageDialog": {
-      "title": "Manage Columns",
-      "description": "Choose which stages appear on the board.",
-      "show": "Show",
-      "hide": "Hide",
-      "close": "Done"
+      "title": "Gérer les colonnes",
+      "description": "Choisissez les étapes affichées sur le tableau.",
+      "visible": "Visible",
+      "hidden": "Masquée",
+      "lastVisibleHint": "Au moins une étape doit rester visible.",
+      "close": "Terminé"
     },
     "scroll": {
       "prev": "Faire défiler à gauche",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -975,13 +975,14 @@
     }
   },
   "tracker": {
-    "manage": "Manage",
+    "manage": "管理",
     "manageDialog": {
-      "title": "Manage Columns",
-      "description": "Choose which stages appear on the board.",
-      "show": "Show",
-      "hide": "Hide",
-      "close": "Done"
+      "title": "列の管理",
+      "description": "ボードに表示するステージを選択します。",
+      "visible": "表示中",
+      "hidden": "非表示",
+      "lastVisibleHint": "少なくとも1つのステージは表示しておく必要があります。",
+      "close": "完了"
     },
     "scroll": {
       "prev": "左へスクロール",

--- a/apps/frontend/messages/ja.json
+++ b/apps/frontend/messages/ja.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "左へスクロール",
       "next": "右へスクロール",

--- a/apps/frontend/messages/ko.json
+++ b/apps/frontend/messages/ko.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "왼쪽으로 스크롤",
       "next": "오른쪽으로 스크롤",

--- a/apps/frontend/messages/ko.json
+++ b/apps/frontend/messages/ko.json
@@ -975,13 +975,14 @@
     }
   },
   "tracker": {
-    "manage": "Manage",
+    "manage": "관리",
     "manageDialog": {
-      "title": "Manage Columns",
-      "description": "Choose which stages appear on the board.",
-      "show": "Show",
-      "hide": "Hide",
-      "close": "Done"
+      "title": "열 관리",
+      "description": "보드에 표시할 단계를 선택하세요.",
+      "visible": "표시됨",
+      "hidden": "숨김",
+      "lastVisibleHint": "최소 한 개의 단계는 표시되어 있어야 합니다.",
+      "close": "완료"
     },
     "scroll": {
       "prev": "왼쪽으로 스크롤",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "Manage",
+    "manageDialog": {
+      "title": "Manage Columns",
+      "description": "Choose which stages appear on the board.",
+      "show": "Show",
+      "hide": "Hide",
+      "close": "Done"
+    },
     "scroll": {
       "prev": "Rolar para a esquerda",
       "next": "Rolar para a direita",

--- a/apps/frontend/messages/pt-BR.json
+++ b/apps/frontend/messages/pt-BR.json
@@ -975,13 +975,14 @@
     }
   },
   "tracker": {
-    "manage": "Manage",
+    "manage": "Gerenciar",
     "manageDialog": {
-      "title": "Manage Columns",
-      "description": "Choose which stages appear on the board.",
-      "show": "Show",
-      "hide": "Hide",
-      "close": "Done"
+      "title": "Gerenciar colunas",
+      "description": "Escolha quais etapas aparecem no quadro.",
+      "visible": "Visível",
+      "hidden": "Oculta",
+      "lastVisibleHint": "Pelo menos uma etapa deve permanecer visível.",
+      "close": "Concluído"
     },
     "scroll": {
       "prev": "Rolar para a esquerda",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -975,6 +975,14 @@
     }
   },
   "tracker": {
+    "manage": "管理",
+    "manageDialog": {
+      "title": "管理状态模块",
+      "description": "选择看板中显示的状态模块。",
+      "show": "显示",
+      "hide": "隐藏",
+      "close": "完成"
+    },
     "scroll": {
       "prev": "向左滚动",
       "next": "向右滚动",

--- a/apps/frontend/messages/zh.json
+++ b/apps/frontend/messages/zh.json
@@ -977,10 +977,11 @@
   "tracker": {
     "manage": "管理",
     "manageDialog": {
-      "title": "管理状态模块",
-      "description": "选择看板中显示的状态模块。",
-      "show": "显示",
-      "hide": "隐藏",
+      "title": "管理看板列",
+      "description": "选择在看板上显示的阶段。",
+      "visible": "已显示",
+      "hidden": "已隐藏",
+      "lastVisibleHint": "至少需要保留一个阶段处于显示状态。",
       "close": "完成"
     },
     "scroll": {

--- a/apps/frontend/tests/manage-columns-dialog.test.tsx
+++ b/apps/frontend/tests/manage-columns-dialog.test.tsx
@@ -1,12 +1,68 @@
-import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { ManageColumnsDialog } from '@/components/tracker/manage-columns-dialog';
+import { KanbanBoard } from '@/components/tracker/kanban-board';
+import {
+  APPLICATION_STATUS_ORDER,
+  listApplications,
+  type Application,
+  type ApplicationColumns,
+  type ApplicationStatus,
+} from '@/lib/api/tracker';
+import { TRACKER_HIDDEN_STATUSES_KEY } from '@/lib/utils/tracker-column-visibility';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
 
 vi.mock('@/lib/i18n', () => ({
   useTranslations: () => ({
     t: (key: string) => key,
   }),
 }));
+
+vi.mock('@/lib/api/tracker', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api/tracker')>('@/lib/api/tracker');
+  return { ...actual, listApplications: vi.fn() };
+});
+
+// Wraps (does not replace) the real dialog so the board's `onToggle` can be
+// invoked directly — the board must hold the "one visible column" invariant on
+// its own, not only because the dialog disables the switch.
+const boardDialog = vi.hoisted(() => ({
+  onToggle: null as ((status: string) => void) | null,
+}));
+
+vi.mock('@/components/tracker/manage-columns-dialog', async () => {
+  const actual = await vi.importActual<typeof import('@/components/tracker/manage-columns-dialog')>(
+    '@/components/tracker/manage-columns-dialog'
+  );
+  return {
+    ManageColumnsDialog: (props: Parameters<typeof actual.ManageColumnsDialog>[0]) => {
+      boardDialog.onToggle = props.onToggle as (status: string) => void;
+      return React.createElement(actual.ManageColumnsDialog, props);
+    },
+  };
+});
+
+const ALL_BUT_SAVED = APPLICATION_STATUS_ORDER.filter((status) => status !== 'saved');
+
+function switchFor(status: ApplicationStatus): HTMLElement {
+  return screen.getByRole('switch', { name: `tracker.columns.${status}` });
+}
+
+function rowFor(status: ApplicationStatus): HTMLElement {
+  const row = switchFor(status).closest('div');
+  if (!row) throw new Error(`no row rendered for ${status}`);
+  return row;
+}
+
+function visibleColumns(): string[] {
+  return Array.from(document.querySelectorAll('[data-column]')).map(
+    (el) => el.getAttribute('data-column') ?? ''
+  );
+}
 
 describe('ManageColumnsDialog', () => {
   it('renders one switch per tracker status', () => {
@@ -33,10 +89,147 @@ describe('ManageColumnsDialog', () => {
       />
     );
 
-    const interviewSwitch = screen.getByRole('switch', { name: 'tracker.columns.interview' });
+    const interviewSwitch = switchFor('interview');
     expect(interviewSwitch).toHaveAttribute('aria-checked', 'false');
 
     fireEvent.click(interviewSwitch);
     expect(onToggle).toHaveBeenCalledWith('interview');
+  });
+
+  it('describes each stage by its state, not by an action', () => {
+    render(
+      <ManageColumnsDialog
+        open
+        onOpenChange={vi.fn()}
+        hiddenStatuses={new Set(['interview'])}
+        onToggle={vi.fn()}
+      />
+    );
+
+    expect(
+      within(rowFor('interview')).getByText('tracker.manageDialog.hidden')
+    ).toBeInTheDocument();
+    expect(within(rowFor('applied')).getByText('tracker.manageDialog.visible')).toBeInTheDocument();
+    expect(screen.getAllByText('tracker.manageDialog.hidden')).toHaveLength(1);
+    expect(screen.getAllByText('tracker.manageDialog.visible')).toHaveLength(6);
+  });
+
+  it('locks the last visible stage and explains why', () => {
+    const onToggle = vi.fn();
+    render(
+      <ManageColumnsDialog
+        open
+        onOpenChange={vi.fn()}
+        hiddenStatuses={new Set(ALL_BUT_SAVED)}
+        onToggle={onToggle}
+      />
+    );
+
+    const lastVisible = switchFor('saved');
+    expect(lastVisible).toBeDisabled();
+    expect(screen.getAllByText('tracker.manageDialog.lastVisibleHint')).toHaveLength(1);
+
+    fireEvent.click(lastVisible);
+    expect(onToggle).not.toHaveBeenCalled();
+
+    // Hidden stages stay togglable so the board is always recoverable.
+    const hiddenSwitch = switchFor('applied');
+    expect(hiddenSwitch).not.toBeDisabled();
+    fireEvent.click(hiddenSwitch);
+    expect(onToggle).toHaveBeenCalledWith('applied');
+  });
+
+  it('shows no lock hint while two stages are visible', () => {
+    render(
+      <ManageColumnsDialog
+        open
+        onOpenChange={vi.fn()}
+        hiddenStatuses={new Set(ALL_BUT_SAVED.slice(1))}
+        onToggle={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('tracker.manageDialog.lastVisibleHint')).not.toBeInTheDocument();
+    expect(switchFor('saved')).not.toBeDisabled();
+  });
+});
+
+describe('KanbanBoard column visibility', () => {
+  const application: Application = {
+    application_id: 'app-1',
+    job_id: 'job-1',
+    resume_id: 'res-1',
+    master_resume_id: null,
+    status: 'saved',
+    company: 'ACME',
+    role: 'Engineer',
+    applied_at: null,
+    notes: null,
+    position: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+
+  function columnsFixture(): ApplicationColumns {
+    const columns = APPLICATION_STATUS_ORDER.reduce((acc, status) => {
+      acc[status] = [];
+      return acc;
+    }, {} as ApplicationColumns);
+    columns.saved = [application];
+    return columns;
+  }
+
+  async function renderBoard() {
+    render(<KanbanBoard />);
+    await waitFor(() => expect(visibleColumns().length).toBeGreaterThan(0));
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    boardDialog.onToggle = null;
+    vi.mocked(listApplications).mockResolvedValue({ columns: columnsFixture() });
+  });
+
+  it('does not write the stored selection back on mount', async () => {
+    // Deliberately non-canonical order: a mount-time persist would rewrite it.
+    const stored = JSON.stringify(['rejected', 'interview']);
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, stored);
+
+    await renderBoard();
+
+    expect(localStorage.getItem(TRACKER_HIDDEN_STATUSES_KEY)).toBe(stored);
+    expect(visibleColumns()).toEqual(
+      APPLICATION_STATUS_ORDER.filter((s) => s !== 'rejected' && s !== 'interview')
+    );
+  });
+
+  it('persists a stage the user actually hides', async () => {
+    await renderBoard();
+
+    fireEvent.click(screen.getByRole('button', { name: 'tracker.manage' }));
+    fireEvent.click(switchFor('applied'));
+
+    expect(localStorage.getItem(TRACKER_HIDDEN_STATUSES_KEY)).toBe(JSON.stringify(['applied']));
+    expect(visibleColumns()).not.toContain('applied');
+
+    // ...and un-hiding round-trips back to an empty selection.
+    fireEvent.click(switchFor('applied'));
+    expect(localStorage.getItem(TRACKER_HIDDEN_STATUSES_KEY)).toBe(JSON.stringify([]));
+    expect(visibleColumns()).toContain('applied');
+  });
+
+  it('refuses to hide the last visible stage even when the dialog is bypassed', async () => {
+    const stored = JSON.stringify(ALL_BUT_SAVED);
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, stored);
+
+    await renderBoard();
+    expect(visibleColumns()).toEqual(['saved']);
+
+    const toggle = boardDialog.onToggle;
+    expect(toggle).toBeTypeOf('function');
+    act(() => toggle?.('saved'));
+
+    expect(visibleColumns()).toEqual(['saved']);
+    expect(localStorage.getItem(TRACKER_HIDDEN_STATUSES_KEY)).toBe(stored);
   });
 });

--- a/apps/frontend/tests/manage-columns-dialog.test.tsx
+++ b/apps/frontend/tests/manage-columns-dialog.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ManageColumnsDialog } from '@/components/tracker/manage-columns-dialog';
+
+vi.mock('@/lib/i18n', () => ({
+  useTranslations: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('ManageColumnsDialog', () => {
+  it('renders one switch per tracker status', () => {
+    render(
+      <ManageColumnsDialog
+        open
+        onOpenChange={vi.fn()}
+        hiddenStatuses={new Set(['interview'])}
+        onToggle={vi.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('switch')).toHaveLength(7);
+  });
+
+  it('reports toggles with the status key', () => {
+    const onToggle = vi.fn();
+    render(
+      <ManageColumnsDialog
+        open
+        onOpenChange={vi.fn()}
+        hiddenStatuses={new Set(['interview'])}
+        onToggle={onToggle}
+      />
+    );
+
+    const interviewSwitch = screen.getByRole('switch', { name: 'tracker.columns.interview' });
+    expect(interviewSwitch).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(interviewSwitch);
+    expect(onToggle).toHaveBeenCalledWith('interview');
+  });
+});

--- a/apps/frontend/tests/tracker-column-visibility.test.ts
+++ b/apps/frontend/tests/tracker-column-visibility.test.ts
@@ -1,14 +1,22 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
 import {
+  isLastVisibleStatus,
   readHiddenStatuses,
+  toggleHiddenStatus,
   TRACKER_HIDDEN_STATUSES_KEY,
   writeHiddenStatuses,
 } from '@/lib/utils/tracker-column-visibility';
 
+const ALL_BUT_SAVED = APPLICATION_STATUS_ORDER.filter((status) => status !== 'saved');
+
 describe('tracker column visibility storage', () => {
   beforeEach(() => {
     localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('defaults to all statuses visible', () => {
@@ -47,5 +55,77 @@ describe('tracker column visibility storage', () => {
       APPLICATION_STATUS_ORDER[0],
       APPLICATION_STATUS_ORDER[APPLICATION_STATUS_ORDER.length - 1],
     ]);
+  });
+
+  it('returns an empty set when there is no window (server render)', () => {
+    // Stored preferences exist, so an unguarded read would return them and this
+    // assertion would fail — storage must not be touched without a window.
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, JSON.stringify(['interview', 'rejected']));
+    vi.stubGlobal('window', undefined);
+
+    expect(typeof window).toBe('undefined');
+    expect(readHiddenStatuses().size).toBe(0);
+  });
+});
+
+describe('isLastVisibleStatus', () => {
+  it('is false while another stage is still visible', () => {
+    const hidden = new Set<ApplicationStatus>(ALL_BUT_SAVED.slice(1));
+    expect(isLastVisibleStatus(hidden, 'saved')).toBe(false);
+  });
+
+  it('is true for the only stage left on the board', () => {
+    const hidden = new Set<ApplicationStatus>(ALL_BUT_SAVED);
+    expect(isLastVisibleStatus(hidden, 'saved')).toBe(true);
+  });
+
+  it('is false for an already-hidden stage', () => {
+    const hidden = new Set<ApplicationStatus>(ALL_BUT_SAVED);
+    expect(isLastVisibleStatus(hidden, 'applied')).toBe(false);
+  });
+});
+
+describe('toggleHiddenStatus', () => {
+  it('hides a visible stage', () => {
+    const next = toggleHiddenStatus(new Set<ApplicationStatus>(), 'interview');
+    expect(Array.from(next)).toEqual(['interview']);
+  });
+
+  it('re-shows a hidden stage', () => {
+    const next = toggleHiddenStatus(new Set<ApplicationStatus>(['interview']), 'interview');
+    expect(next.size).toBe(0);
+  });
+
+  it('re-shows a hidden stage even when it is the only visible one that would remain', () => {
+    // Unhiding is never blocked: only hiding the last visible stage is.
+    const next = toggleHiddenStatus(
+      new Set<ApplicationStatus>(APPLICATION_STATUS_ORDER),
+      'applied'
+    );
+    expect(next.has('applied')).toBe(false);
+  });
+
+  it('refuses to hide the last visible stage', () => {
+    const hidden = new Set<ApplicationStatus>(ALL_BUT_SAVED);
+    const next = toggleHiddenStatus(hidden, 'saved');
+
+    // Same instance signals "refused" so callers skip the re-render and persist.
+    expect(next).toBe(hidden);
+    expect(next.has('saved')).toBe(false);
+    expect(APPLICATION_STATUS_ORDER.filter((status) => !next.has(status))).toEqual(['saved']);
+  });
+
+  it('never leaves the board without a column', () => {
+    let hidden = new Set<ApplicationStatus>();
+    for (const status of APPLICATION_STATUS_ORDER) {
+      hidden = toggleHiddenStatus(hidden, status);
+    }
+    expect(APPLICATION_STATUS_ORDER.filter((status) => !hidden.has(status)).length).toBe(1);
+  });
+
+  it('does not mutate the set it is given', () => {
+    const hidden = new Set<ApplicationStatus>(['interview']);
+    toggleHiddenStatus(hidden, 'applied');
+    expect(Array.from(hidden)).toEqual(['interview']);
   });
 });

--- a/apps/frontend/tests/tracker-column-visibility.test.ts
+++ b/apps/frontend/tests/tracker-column-visibility.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { APPLICATION_STATUS_ORDER, type ApplicationStatus } from '@/lib/api/tracker';
+import {
+  readHiddenStatuses,
+  TRACKER_HIDDEN_STATUSES_KEY,
+  writeHiddenStatuses,
+} from '@/lib/utils/tracker-column-visibility';
+
+describe('tracker column visibility storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to all statuses visible', () => {
+    expect(readHiddenStatuses().size).toBe(0);
+  });
+
+  it('persists and reloads hidden statuses', () => {
+    const hidden = new Set<ApplicationStatus>(['interview', 'rejected']);
+
+    expect(writeHiddenStatuses(hidden)).toBe(true);
+
+    const loaded = readHiddenStatuses();
+    expect(loaded.has('interview')).toBe(true);
+    expect(loaded.has('rejected')).toBe(true);
+    expect(loaded.has('applied')).toBe(false);
+  });
+
+  it('ignores corrupt JSON', () => {
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, '{broken');
+    expect(readHiddenStatuses().size).toBe(0);
+  });
+
+  it('ignores unknown statuses', () => {
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, JSON.stringify(['interview', 'unknown']));
+    expect(Array.from(readHiddenStatuses())).toEqual(['interview']);
+  });
+
+  it('ignores non-array payloads', () => {
+    localStorage.setItem(TRACKER_HIDDEN_STATUSES_KEY, JSON.stringify({ saved: true }));
+    expect(readHiddenStatuses().size).toBe(0);
+  });
+
+  it('writes statuses in the canonical order', () => {
+    writeHiddenStatuses(new Set<ApplicationStatus>(['rejected', 'saved']));
+    expect(JSON.parse(localStorage.getItem(TRACKER_HIDDEN_STATUSES_KEY) ?? '[]')).toEqual([
+      APPLICATION_STATUS_ORDER[0],
+      APPLICATION_STATUS_ORDER[APPLICATION_STATUS_ORDER.length - 1],
+    ]);
+  });
+});


### PR DESCRIPTION
Brings #920 to `main` together with the review follow-ups applied on `dev`.

## What #920 adds (@LongD1stanceRunner)

A **Manage Columns** dialog on the tracker Kanban board. Users can hide status columns they don't use; the choice persists per browser via `safeStorage` under `tracker_hidden_statuses`. Hidden stages keep their cards, stop accepting drops, and reappear when unhidden. Both the columns and the quick-nav chips respect the selection. No backend or API change.

## Review follow-ups (`e39bd3d`)

- **Blank board prevented.** Hiding all seven stages left an empty canvas with no explanation. The last visible stage is now locked — its toggle is disabled with a hint — and the board's handler refuses the change independently, so the invariant survives even if the dialog is bypassed. Un-hiding is never blocked.
- **Toggle wording fixed.** Rows described each stage with an action that contradicted the switch position ("Hide" beneath an already-hidden column). They now read as state labels; `manageDialog.show`/`.hide` are replaced by `.visible`/`.hidden`, plus a new `.lastVisibleHint`.
- **Strings actually translated.** They shipped as English in es, fr, ja, ko and pt-BR. `zh` was translated but used "status module" instead of the board/stage vocabulary used elsewhere in its own `tracker.*` tree. Each locale now matches the terminology already in that file.
- **No mount-time storage write** — persistence happens on a real change.
- **SSR guard** on `readHiddenStatuses`, matching the `typeof window` pattern used in `resume-builder.tsx`.

## Verification

| Check | Before | After |
|---|---|---|
| Frontend vitest | 286 / 39 files | **302 / 39 files** |
| Backend pytest | 592 passed | **592 passed** (untouched) |
| `tsc --noEmit` | — | exit 0 |
| `eslint` | — | exit 0 |
| `next build` | — | succeeds |
| Locale parity | — | vitest spec + `scripts/check_locale_parity.py` both green |

New tests were mutation-checked: removing the last-visible guard, swapping the state labels back, dropping the disabled state or the hint, and restoring the mount-time write each turn the relevant test red.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Manage Columns dialog to the tracker Kanban board so users can hide status columns they don't use. The selection persists per browser via `safeStorage` under `tracker_hidden_statuses`; hidden columns keep their cards and stop accepting drops.

- Hiding all columns is impossible — the last visible stage is locked, and the board enforces the invariant even if the dialog is bypassed.
- Toggle rows now describe state ("Visible"/"Hidden") instead of an action that contradicted the switch position.
- Manage Columns strings are now genuinely translated in every locale, using each file's existing stage terminology.
- Persistence happens only on a real change; no mount-time storage write, and `readHiddenStatuses` is SSR-guarded.

<sup>Written for commit e39bd3db1551d743e40bacdb3c9d7a377a625f5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

