### PR TITLE
fix(llm): skip temperature for OpenAI GPT-5 family

### DIFF
--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -1171,6 +1171,7 @@ def _supports_temperature(model_name: str, temperature: float | None = None) -> 
     provider-specific fallbacks for known restrictions:
       - Anthropic claude-opus-4.*: temperature is deprecated
       - Moonshot kimi-k2.6: only temperature=1 allowed
+      - gpt-5.*: only temperature=1 allowed, on OpenAI and Azure alike
 
     Queries LiteLLM's model info for every provider so that capability is
     always determined from the registry rather than a hardcoded list.
@@ -1213,14 +1214,33 @@ def _supports_temperature(model_name: str, temperature: float | None = None) -> 
     if "kimi-k2.6" in model_name.lower() and temperature != 1.0:
         return False
 
+    # The gpt-5 family accepts only the default temperature (1), on OpenAI and
+    # on Azure deployments alike (BerriAI/litellm#13397). The registry lists
+    # temperature as a supported param, which is true but only for that one
+    # value, so the check above does not catch it.
+    #
+    # Matched on name rather than provider, deliberately. A self-hosted
+    # openai_compatible server running its own model under a custom name is
+    # not in the registry and has already returned False above, so scoping by
+    # provider would not reach it. What remains is a name LiteLLM resolves to
+    # a real gpt-5, which every other capability decision in this module
+    # (get_safe_max_tokens, _supports_json_mode) already treats as that model.
+    # The failure modes are asymmetric: omitting temperature costs some retry
+    # variation, sending it to a real gpt-5 fails the request outright.
+    if "gpt-5" in model_name.lower() and temperature != 1.0:
+        return False
+
     return True
 
 
 def _get_retry_temperature(model_name: str, attempt: int, base_temp: float = 0.1) -> float | None:
     """LLM-002: Get temperature for retry attempt.
 
-    Returns None if the model does not support temperature at all.
-    Returns 1.0 for models that only support temperature=1.
+    Returns None when the model will not accept the requested temperature,
+    either because it does not support the parameter at all (Opus 4.x) or
+    because it accepts only the default (gpt-5 family). Omitting the
+    parameter lets the provider apply its own default.
+    Returns 1.0 for kimi-k2.6, which requires an explicit temperature=1.
     Otherwise returns increasing temperatures for retry variation.
     """
     # Moonshot kimi-k2.6 only allows temperature=1.

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -1214,19 +1214,7 @@ def _supports_temperature(model_name: str, temperature: float | None = None) -> 
     if "kimi-k2.6" in model_name.lower() and temperature != 1.0:
         return False
 
-    # The gpt-5 family accepts only the default temperature (1), on OpenAI and
-    # on Azure deployments alike (BerriAI/litellm#13397). The registry lists
-    # temperature as a supported param, which is true but only for that one
-    # value, so the check above does not catch it.
-    #
-    # Matched on name rather than provider, deliberately. A self-hosted
-    # openai_compatible server running its own model under a custom name is
-    # not in the registry and has already returned False above, so scoping by
-    # provider would not reach it. What remains is a name LiteLLM resolves to
-    # a real gpt-5, which every other capability decision in this module
-    # (get_safe_max_tokens, _supports_json_mode) already treats as that model.
-    # The failure modes are asymmetric: omitting temperature costs some retry
-    # variation, sending it to a real gpt-5 fails the request outright.
+    # gpt-5 only allows temperature=1, on OpenAI and Azure alike.
     if "gpt-5" in model_name.lower() and temperature != 1.0:
         return False
 
@@ -1236,10 +1224,7 @@ def _supports_temperature(model_name: str, temperature: float | None = None) -> 
 def _get_retry_temperature(model_name: str, attempt: int, base_temp: float = 0.1) -> float | None:
     """LLM-002: Get temperature for retry attempt.
 
-    Returns None when the model will not accept the requested temperature,
-    either because it does not support the parameter at all (Opus 4.x) or
-    because it accepts only the default (gpt-5 family). Omitting the
-    parameter lets the provider apply its own default.
+    Returns None if the model does not accept the requested temperature.
     Returns 1.0 for kimi-k2.6, which requires an explicit temperature=1.
     Otherwise returns increasing temperatures for retry variation.
     """

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -234,6 +234,36 @@ class TestSupportsTemperature:
         assert _supports_temperature("openai/kimi-k2.6", 1.0) is True
 
     @patch("app.llm.litellm.get_model_info")
+    def test_gpt5_only_allows_default(self, mock_get_model_info):
+        """gpt-5 accepts only temperature=1, on OpenAI and Azure alike."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _supports_temperature("gpt-5.6-terra", 0.1) is False
+        assert _supports_temperature("openai/gpt-5-nano-2025-08-07", 0.7) is False
+        assert _supports_temperature("azure/gpt-5.6-terra", 0.1) is False
+        assert _supports_temperature("gpt-5.6-terra", 1.0) is True
+
+    def test_ollama_gpt5_name_unaffected(self):
+        """An Ollama model merely named gpt-5-* is local, not real gpt-5.
+
+        The ollama early return fires before the carve-out. Pinned so a
+        reordering does not start stripping temperature from local models.
+        """
+        assert _supports_temperature("ollama_chat/gpt-5.6-terra", 0.1) is True
+        assert _supports_temperature("ollama/gpt-5-whatever", 0.7) is True
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_unregistered_gpt5_name_already_skipped(self, mock_get_model_info):
+        """A self-hosted server's own gpt-5-named model is not in the registry.
+
+        It returns False from the registry-miss path above, before the
+        carve-out, so the carve-out does not change behaviour for it.
+        """
+        mock_get_model_info.side_effect = Exception("model not found")
+        assert _supports_temperature("openai/gpt-5-local-llama", 0.7) is False
+
+    @patch("app.llm.litellm.get_model_info")
     def test_model_not_in_registry(self, mock_get_model_info):
         """Unknown model not in registry — be conservative, skip temperature."""
         mock_get_model_info.side_effect = Exception("model not found")
@@ -248,6 +278,7 @@ class TestSupportsTemperature:
         assert _supports_temperature("Anthropic/Claude-Opus-4-7", 0.7) is False
         assert _supports_temperature("OPENAI/KIMI-K2.6", 0.7) is False
         assert _supports_temperature("openai/KIMI-K2.6", 1.0) is True
+        assert _supports_temperature("OpenAI/GPT-5.6-Terra", 0.1) is False
 
 
 # ---------------------------------------------------------------------------
@@ -278,6 +309,15 @@ class TestGetRetryTemperature:
         }
         assert _get_retry_temperature("anthropic/claude-opus-4-7", 0) is None
         assert _get_retry_temperature("anthropic/claude-opus-4-7", 3) is None
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_gpt5_returns_none(self, mock_get_model_info):
+        """gpt-5 accepts only temperature=1, so the retry path omits it."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"]
+        }
+        assert _get_retry_temperature("openai/gpt-5-nano-2025-08-07", 0) is None
+        assert _get_retry_temperature("gpt-5.6-terra", 2) is None
 
     @patch("app.llm.litellm.get_model_info")
     def test_kimi_k26_returns_one(self, mock_get_model_info):

--- a/docs/agent/llm-integration.md
+++ b/docs/agent/llm-integration.md
@@ -49,6 +49,16 @@ JSON completions include 2 automatic retries with progressively lower temperatur
 - Attempt 1: temperature 0.1
 - Attempt 2: temperature 0.0
 
+## Temperature Support
+
+`_supports_temperature()` determines whether `temperature` is sent at all. Capability comes from LiteLLM's model registry, with overrides for restrictions the registry does not record.
+
+The gpt-5 family is one such restriction. The registry lists `temperature` as a supported parameter, which is accurate, but only the default value of 1 is accepted ([litellm#13397](https://github.com/BerriAI/litellm/issues/13397)). This holds on OpenAI and on Azure alike.
+
+The override matches on model name rather than provider. Azure gpt-5 deployments resolve to `azure/` prefixed names, and a self-hosted `openai_compatible` model under a custom name is absent from the registry and already treated as unsupported before the override runs.
+
+`_get_retry_temperature()` therefore returns `None` for gpt-5, omitting the parameter so the provider applies its own default.
+
 ## JSON Extraction
 
 Robust bracket-matching algorithm in `_extract_json()` handles:


### PR DESCRIPTION
## Problem

Any analysis run against an OpenAI GPT-5 model fails with a 500. The backend logs:

```
litellm.BadRequestError: OpenAIException - Unsupported value: 'temperature'
does not support 0.1 with this model. Only the default (1) value is
supported.. Received Model Group=primary
```

This is easy to misread as a bad config, because Test Connection succeeds.
The health-check path builds its kwargs without a temperature, so it never
trips the restriction. Only the actual analysis does.

`gpt-5-nano-2025-08-07` is the `LLM_MODEL` default in
`apps/backend/.env.example`, so a fresh install pointed at OpenAI hits this
on its first analysis. Reproduced on `gpt-5.6-terra`.

## Root Cause

`_supports_temperature()` (added in #773, for #759) decides whether to send
a temperature. It trusts LiteLLM's registry, then applies explicit
carve-outs for Anthropic Opus 4.x and Moonshot kimi-k2.6.

The GPT-5 family slips through. LiteLLM lists `temperature` in
`supported_openai_params` for these models, which is accurate, but only the
value 1 is accepted. The registry check passes, the configured temperature
is sent, and OpenAI rejects it.

Both call paths are affected. `complete()` calls `_supports_temperature()`
directly. `complete_json()` reaches it through `_get_retry_temperature()`,
which uses `base_temp=0.1`, so every retry fails the same way and all
attempts are exhausted.

There is prior art for this family needing special handling: #747, where
`reasoning_effort` had to be made conditional for GPT-5.

## Fix

One guard in `_supports_temperature()`, following the existing kimi-k2.6
pattern:

```python
    # Moonshot kimi-k2.6 only allows temperature=1.
    if "kimi-k2.6" in model_name.lower() and temperature != 1.0:
        return False

    # OpenAI GPT-5 family only accepts the default temperature (1). The
    # registry lists temperature as a supported param, which is true, but
    # only for that single value, so the check above does not catch it.
    if "gpt-5" in model_name.lower() and temperature != 1.0:
        return False

    return True
```

LiteLLM then omits the parameter and OpenAI applies its own default. This
covers both call paths, since `_get_retry_temperature()` already returns
`None` when temperature is unsupported.

I did not mirror the kimi-k2.6 early `return 1.0` in
`_get_retry_temperature()`. Omitting the parameter is equivalent for GPT-5
and keeps the special-casing in one place. Happy to switch to an explicit
`1.0` if you would rather the two read identically.

## Verification

- New test `test_gpt5_only_allows_default` covers `gpt-5.6-terra` and
  `openai/gpt-5-nano-2025-08-07` at non-default temperatures, and confirms
  temperature=1.0 still passes.
- Extended `test_case_insensitive_model_name` with a mixed-case GPT-5 name,
  matching the existing Opus and kimi assertions.
- Both new assertions fail on `main` and pass with this change.
- `.githooks/pre-push` gate run in full: backend suite 590 passed, 3
  skipped, 1 deselected; `scripts/check_locale_parity.py` clean.
- Frontend untouched.

To reproduce manually: configure the OpenAI provider with a GPT-5 model,
upload a resume, run an analysis. 500 on `main`, completes with this change.

## Impact

- Backend only, 17 lines.
- No behaviour change for any other provider. Non-GPT-5 models still take
  the configured temperature exactly as before.
- Unblocks OpenAI GPT-5 users, including anyone on the shipped default.

## Notes

I did not run `black .` as CONTRIBUTING suggests. `app/llm.py` and
`tests/unit/test_llm.py` are not currently Black-formatted, so it would
rewrite 23 unrelated hunks and bury the fix. The added lines are already
within Black's line length and it leaves them untouched. Happy to reformat
those files separately if you want them brought into line.

Unrelated, but noticed while testing: `npm run build` still fails in the
Docker build. Next 16.2.12's turbopack cannot resolve
`@vercel/turbopack-next/internal/font/google/font` for the Noto Sans
SC/JP/KR faces in `app/layout.tsx`. Looks like the same problem as #626,
which is open and now conflicted. I worked around it locally by mounting
the patched file over the published image. Happy to look at #626 separately
as I'm unemployed 🤷 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes analysis runs against OpenAI GPT-5 models, which failed with a 500 because those models only accept the default temperature (1) and any other value is rejected. GPT-5 models now skip the temperature parameter unless it is exactly 1.0, letting OpenAI apply its default; all other models behave unchanged.

- Covers both normal and retry calls, so retries no longer fail the same way.
- Matches on model name rather than provider, so Azure deployments are covered too; self-hosted `openai_compatible` gpt-5-named models are unaffected since the registry-miss path already skips them.
- Adds regression tests for GPT-5 model names, case-insensitive matching, Azure, Ollama models merely named gpt-5-*, and the retry path.
- Moves the temperature-support rationale for gpt-5 into a new Temperature Support section in `docs/agent/llm-integration.md`.
- The existing connection test did not catch the bug because it never sends a temperature.

<sup>Written for commit 953c05d221c0ad6d05158e0a77cac05bd837d331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/srbhr/Resume-Matcher/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



