### PR TITLE
[Stack 02/17] Preserve supported GPT-5 sampling parameters

### DIFF
--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -1,6 +1,9 @@
 """Application configuration using pydantic-settings."""
 
 import json
+import os
+import tempfile
+import threading
 from pathlib import Path
 from typing import Any, Literal
 
@@ -8,25 +11,64 @@ from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-# Path to config file for API key persistence
-CONFIG_FILE_PATH = Path(__file__).parent.parent / "data" / "config.json"
 ALLOWED_LOG_LEVELS = ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG")
+_CONFIG_WRITE_LOCK = threading.Lock()
+
+
+def _config_file_path() -> Path:
+    """Return the canonical config path, honoring legacy monkeypatches.
+
+    ``settings.config_path`` owns the runtime location. ``CONFIG_FILE_PATH`` is
+    retained as a compatibility alias for existing callers that monkeypatch
+    that name; only an explicit change from its import-time value wins over the
+    Settings-owned path.
+    """
+    if CONFIG_FILE_PATH != _IMPORTED_CONFIG_FILE_PATH:
+        return CONFIG_FILE_PATH
+    return settings.config_path
 
 
 def _read_config_json() -> dict[str, Any]:
     """Raw read of config.json (no key injection)."""
-    if CONFIG_FILE_PATH.exists():
+    config_path = _config_file_path()
+    if config_path.exists():
         try:
-            return json.loads(CONFIG_FILE_PATH.read_text())
+            return json.loads(config_path.read_text())
         except (json.JSONDecodeError, OSError):
             return {}
     return {}
 
 
 def _write_config_json(config: dict[str, Any]) -> None:
-    """Raw write of config.json (no secret stripping)."""
-    CONFIG_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CONFIG_FILE_PATH.write_text(json.dumps(config, indent=2))
+    """Atomically replace config.json with one complete snapshot.
+
+    Writes are serialized within the process. Callers provide complete
+    snapshots, so concurrent in-process updates resolve in lock-acquisition
+    order. Cross-process writers still install only complete snapshots because
+    replacement is atomic. In both cases the last completed replacement wins;
+    this primitive does not merge fields.
+    """
+    serialized = json.dumps(config, indent=2)
+    with _CONFIG_WRITE_LOCK:
+        config_path = _config_file_path()
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        file_descriptor, temporary_name = tempfile.mkstemp(
+            dir=config_path.parent,
+            prefix=f".{config_path.name}.",
+            suffix=".tmp",
+        )
+        temporary_path = Path(temporary_name)
+        try:
+            with os.fdopen(file_descriptor, "w", encoding="utf-8") as temporary_file:
+                file_descriptor = -1
+                temporary_file.write(serialized)
+                temporary_file.flush()
+                os.fsync(temporary_file.fileno())
+            os.replace(temporary_path, config_path)
+        finally:
+            if file_descriptor >= 0:
+                os.close(file_descriptor)
+            temporary_path.unlink(missing_ok=True)
 
 
 def load_config_file() -> dict[str, Any]:
@@ -337,3 +379,9 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+# Deprecated compatibility alias. Runtime config I/O is owned by
+# ``settings.config_path`` through ``_config_file_path``; downstream tests and
+# integrations that explicitly monkeypatch this name continue to work.
+CONFIG_FILE_PATH = settings.config_path
+_IMPORTED_CONFIG_FILE_PATH = CONFIG_FILE_PATH

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 import tempfile
 import threading
 from pathlib import Path
@@ -15,7 +16,7 @@ ALLOWED_LOG_LEVELS = ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG")
 _CONFIG_WRITE_LOCK = threading.Lock()
 
 
-def _config_file_path() -> Path:
+def get_config_path() -> Path:
     """Return the canonical config path, honoring legacy monkeypatches.
 
     ``settings.config_path`` owns the runtime location. ``CONFIG_FILE_PATH`` is
@@ -30,7 +31,7 @@ def _config_file_path() -> Path:
 
 def _read_config_json() -> dict[str, Any]:
     """Raw read of config.json (no key injection)."""
-    config_path = _config_file_path()
+    config_path = get_config_path()
     if config_path.exists():
         try:
             return json.loads(config_path.read_text())
@@ -50,8 +51,13 @@ def _write_config_json(config: dict[str, Any]) -> None:
     """
     serialized = json.dumps(config, indent=2)
     with _CONFIG_WRITE_LOCK:
-        config_path = _config_file_path()
+        # Follow managed symlinks instead of replacing the link itself. Keep an
+        # existing target's access mode; new configurations remain owner-only.
+        config_path = get_config_path().resolve()
         config_path.parent.mkdir(parents=True, exist_ok=True)
+        existing_mode = (
+            stat.S_IMODE(config_path.stat().st_mode) if config_path.exists() else None
+        )
         file_descriptor, temporary_name = tempfile.mkstemp(
             dir=config_path.parent,
             prefix=f".{config_path.name}.",
@@ -59,12 +65,22 @@ def _write_config_json(config: dict[str, Any]) -> None:
         )
         temporary_path = Path(temporary_name)
         try:
+            if existing_mode is not None:
+                os.chmod(temporary_path, existing_mode)
             with os.fdopen(file_descriptor, "w", encoding="utf-8") as temporary_file:
                 file_descriptor = -1
                 temporary_file.write(serialized)
                 temporary_file.flush()
                 os.fsync(temporary_file.fileno())
             os.replace(temporary_path, config_path)
+            if os.name != "nt":
+                directory_fd = os.open(
+                    config_path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+                )
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
         finally:
             if file_descriptor >= 0:
                 os.close(file_descriptor)
@@ -381,7 +397,7 @@ class Settings(BaseSettings):
 settings = Settings()
 
 # Deprecated compatibility alias. Runtime config I/O is owned by
-# ``settings.config_path`` through ``_config_file_path``; downstream tests and
+# ``settings.config_path`` through ``get_config_path``; downstream tests and
 # integrations that explicitly monkeypatch this name continue to work.
 CONFIG_FILE_PATH = settings.config_path
 _IMPORTED_CONFIG_FILE_PATH = CONFIG_FILE_PATH

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -1,6 +1,7 @@
 """Application configuration using pydantic-settings."""
 
 import json
+import logging
 import os
 import stat
 import tempfile
@@ -13,6 +14,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 ALLOWED_LOG_LEVELS = ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG")
+logger = logging.getLogger(__name__)
 _CONFIG_WRITE_LOCK = threading.Lock()
 
 
@@ -47,7 +49,9 @@ def _write_config_json(config: dict[str, Any]) -> None:
     snapshots, so concurrent in-process updates resolve in lock-acquisition
     order. Cross-process writers still install only complete snapshots because
     replacement is atomic. In both cases the last completed replacement wins;
-    this primitive does not merge fields.
+    this primitive does not merge fields. Directory durability errors after
+    replacement are logged: the snapshot is already installed, so callers must
+    still acknowledge the save and invalidate cached reads.
     """
     serialized = json.dumps(config, indent=2)
     with _CONFIG_WRITE_LOCK:
@@ -74,13 +78,21 @@ def _write_config_json(config: dict[str, Any]) -> None:
                 os.fsync(temporary_file.fileno())
             os.replace(temporary_path, config_path)
             if os.name != "nt":
-                directory_fd = os.open(
-                    config_path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-                )
                 try:
-                    os.fsync(directory_fd)
-                finally:
-                    os.close(directory_fd)
+                    directory_fd = os.open(
+                        config_path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+                    )
+                    try:
+                        os.fsync(directory_fd)
+                    finally:
+                        os.close(directory_fd)
+                except OSError:
+                    logger.warning(
+                        "Config snapshot replaced at %s, but directory durability "
+                        "could not be confirmed",
+                        config_path,
+                        exc_info=True,
+                    )
         finally:
             if file_descriptor >= 0:
                 os.close(file_descriptor)

--- a/apps/backend/app/config_cache.py
+++ b/apps/backend/app/config_cache.py
@@ -8,9 +8,10 @@ import copy
 import json
 import logging
 import time
+from pathlib import Path
 from typing import Any
 
-from app.config import settings
+from app.config import get_config_path
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 #    require making load_config async and changing every caller.
 _config_cache: dict[str, Any] = {}
 _config_cache_time: float = 0.0
+_config_cache_path: Path | None = None
 _CONFIG_CACHE_TTL: float = 300.0  # 5 minutes
 
 
@@ -30,9 +32,10 @@ def invalidate_config_cache() -> None:
 
     Call this after any write to config.json.
     """
-    global _config_cache, _config_cache_time
+    global _config_cache, _config_cache_time, _config_cache_path
     _config_cache = {}
     _config_cache_time = 0.0
+    _config_cache_path = None
 
 
 def load_config() -> dict[str, Any]:
@@ -40,12 +43,17 @@ def load_config() -> dict[str, Any]:
 
     Returns a deep copy so callers cannot corrupt the cached data.
     """
-    global _config_cache, _config_cache_time
+    global _config_cache, _config_cache_time, _config_cache_path
     now = time.monotonic()
-    if _config_cache and (now - _config_cache_time) < _CONFIG_CACHE_TTL:
+    config_path = get_config_path()
+    if (
+        _config_cache
+        and _config_cache_path == config_path
+        and (now - _config_cache_time) < _CONFIG_CACHE_TTL
+    ):
         return copy.deepcopy(_config_cache)
 
-    config_path = settings.config_path
+    _config_cache_path = config_path
     if not config_path.exists():
         _config_cache = {}
         _config_cache_time = now

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -1236,11 +1236,27 @@ def _supports_temperature(
         normalized_model.startswith("gpt-5")
         and not normalized_model.startswith("gpt-5-chat")
     )
+    reasoning_capability = info.get("supports_reasoning")
     if (
         is_reasoning_gpt5
-        and info.get("supports_reasoning") is True
+        and temperature != 1.0
+        and not isinstance(reasoning_capability, bool)
+    ):
+        logging.warning(
+            "Missing or invalid reasoning capability for %s; omitting temperature",
+            model_name,
+        )
+        return False
+    if (
+        is_reasoning_gpt5
+        and reasoning_capability is True
         and temperature != 1.0
     ):
+        if not isinstance(info.get("supports_none_reasoning_effort"), bool):
+            logging.warning(
+                "Missing or invalid no-reasoning capability for %s; omitting temperature",
+                model_name,
+            )
         supports_no_reasoning = (
             info.get("supports_none_reasoning_effort") is True
         )

--- a/apps/backend/app/llm.py
+++ b/apps/backend/app/llm.py
@@ -959,7 +959,9 @@ async def complete(
             "max_tokens": max_tokens,
             "timeout": _calculate_timeout("completion", max_tokens, config.provider),
         }
-        if _supports_temperature(model_name, temperature):
+        if _supports_temperature(
+            model_name, temperature, reasoning_effort=config.reasoning_effort
+        ):
             kwargs["temperature"] = temperature
         if config.reasoning_effort:
             kwargs["reasoning_effort"] = config.reasoning_effort
@@ -1164,22 +1166,29 @@ def _appears_truncated(data: dict, schema_type: str = "resume") -> bool:
     return False
 
 
-def _supports_temperature(model_name: str, temperature: float | None = None) -> bool:
+def _supports_temperature(
+    model_name: str,
+    temperature: float | None = None,
+    reasoning_effort: str | None = None,
+) -> bool:
     """Check if the model supports the given temperature value.
 
     Uses LiteLLM model registry for capability detection, with
-    provider-specific fallbacks for known restrictions:
+    narrowly scoped fallbacks for known restrictions:
       - Anthropic claude-opus-4.*: temperature is deprecated
       - Moonshot kimi-k2.6: only temperature=1 allowed
-      - gpt-5.*: only temperature=1 allowed, on OpenAI and Azure alike
+      - Reasoning GPT-5 models: non-default values require both registry
+        support for no-reasoning mode and an omitted reasoning effort
 
     Queries LiteLLM's model info for every provider so that capability is
-    always determined from the registry rather than a hardcoded list.
+    determined from the registry rather than a provider-wide exemption.
 
     Args:
         model_name: LiteLLM-formatted model name (from get_model_name).
         temperature: The temperature value to check. If None, returns True
             (caller isn't setting a specific value).
+        reasoning_effort: Configured reasoning mode. None means the request
+            omits the parameter and uses a model's no-reasoning default.
 
     Returns:
         True if the model supports the given temperature, False otherwise.
@@ -1214,25 +1223,54 @@ def _supports_temperature(model_name: str, temperature: float | None = None) -> 
     if "kimi-k2.6" in model_name.lower() and temperature != 1.0:
         return False
 
-    # gpt-5 only allows temperature=1, on OpenAI and Azure alike.
-    if "gpt-5" in model_name.lower() and temperature != 1.0:
-        return False
+    # GPT-5 reasoning models allow flexible sampling only when the model map
+    # advertises a no-reasoning mode and the application omits reasoning_effort.
+    # LiteLLM routes the exact gpt-5-chat* family through its regular chat
+    # transform (versioned names such as gpt-5.1-chat remain reasoning models),
+    # so preserve sampling for that family even though its current registry
+    # metadata says supports_reasoning=True. Provider prefixes are ignored so
+    # OpenAI, Azure, and registered compatible aliases receive the same
+    # capability decision. Unknown compatible aliases returned False above.
+    normalized_model = model_name.rsplit("/", 1)[-1].lower()
+    is_reasoning_gpt5 = (
+        normalized_model.startswith("gpt-5")
+        and not normalized_model.startswith("gpt-5-chat")
+    )
+    if (
+        is_reasoning_gpt5
+        and info.get("supports_reasoning") is True
+        and temperature != 1.0
+    ):
+        supports_no_reasoning = (
+            info.get("supports_none_reasoning_effort") is True
+        )
+        if not supports_no_reasoning or reasoning_effort is not None:
+            return False
 
     return True
 
 
-def _get_retry_temperature(model_name: str, attempt: int, base_temp: float = 0.1) -> float | None:
+def _get_retry_temperature(
+    model_name: str,
+    attempt: int,
+    base_temp: float = 0.1,
+    reasoning_effort: str | None = None,
+) -> float | None:
     """LLM-002: Get temperature for retry attempt.
 
     Returns None if the model does not accept the requested temperature.
     Returns 1.0 for kimi-k2.6, which requires an explicit temperature=1.
-    Otherwise returns increasing temperatures for retry variation.
+    Otherwise returns increasing temperatures for retry variation. GPT-5
+    capability checks include the configured reasoning mode; None means the
+    request omits reasoning_effort rather than sending a literal "none".
     """
     # Moonshot kimi-k2.6 only allows temperature=1.
     if "kimi-k2.6" in model_name.lower():
         return 1.0
 
-    if not _supports_temperature(model_name, base_temp):
+    if not _supports_temperature(
+        model_name, base_temp, reasoning_effort=reasoning_effort
+    ):
         return None
 
     temperatures = [base_temp, 0.3, 0.5, 0.7]
@@ -1419,7 +1457,9 @@ async def complete_json(
                 "timeout": _calculate_timeout("json", max_tokens, config.provider),
             }
             # LLM-002: Increase temperature on retry for variation
-            retry_temp = _get_retry_temperature(model_name, attempt)
+            retry_temp = _get_retry_temperature(
+                model_name, attempt, reasoning_effort=config.reasoning_effort
+            )
             if retry_temp is not None:
                 kwargs["temperature"] = retry_temp
             reasoning_effort = config.reasoning_effort

--- a/apps/backend/app/routers/config.py
+++ b/apps/backend/app/routers/config.py
@@ -34,6 +34,7 @@ from app.prompts import (
 from app.prompts.templates import COVER_LETTER_PROMPT, OUTREACH_MESSAGE_PROMPT
 from app.config import (
     get_api_keys_from_config,
+    get_config_path,
     save_api_keys_to_config,
     delete_api_key_from_config,
     clear_all_api_keys,
@@ -66,7 +67,7 @@ router = APIRouter(prefix="/config", tags=["Configuration"])
 
 def _get_config_path() -> Path:
     """Get path to config storage file."""
-    return settings.config_path
+    return get_config_path()
 
 
 def _load_config() -> dict:

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -1,9 +1,116 @@
 """Shared test fixtures for Resume Matcher backend tests."""
 
 import copy
-import importlib
+import os
+import socket
+import sys
+import tempfile
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any, NoReturn
 
 import pytest
+
+
+# Set DATA_DIR before pytest imports any test module. Several integration tests
+# import app.main at module scope, which constructs Settings and the global
+# Database during collection; a function fixture would be too late to protect
+# developer state from those imports.
+_ORIGINAL_DATA_DIR = os.environ.get("DATA_DIR")
+_TEST_DATA_DIR_CONTEXT = tempfile.TemporaryDirectory(prefix="resume-matcher-tests-")
+_TEST_DATA_DIR = Path(_TEST_DATA_DIR_CONTEXT.name)
+os.environ["DATA_DIR"] = str(_TEST_DATA_DIR)
+
+import app.config as _config_module  # noqa: E402 - DATA_DIR must be set first
+
+_IMPORTED_CONFIG_FILE_PATH = _config_module.CONFIG_FILE_PATH
+
+
+class UnexpectedNetworkAccess(RuntimeError):
+    """Raised when a deterministic backend test attempts a real connection."""
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Restore the caller environment and remove session-level temporary data."""
+    del config  # Hook argument is required by pytest but otherwise unused.
+    if _ORIGINAL_DATA_DIR is None:
+        os.environ.pop("DATA_DIR", None)
+    else:
+        os.environ["DATA_DIR"] = _ORIGINAL_DATA_DIR
+    _TEST_DATA_DIR_CONTEXT.cleanup()
+
+
+@pytest.fixture(scope="session")
+def imported_config_file_path() -> Path:
+    """Return config.py's path alias as captured immediately after safe import."""
+    return _IMPORTED_CONFIG_FILE_PATH
+
+
+@pytest.fixture(scope="session")
+def backend_test_data_dir() -> Path:
+    """Return the temporary DATA_DIR installed before application imports."""
+    return _TEST_DATA_DIR
+
+
+@pytest.fixture(autouse=True)
+def deny_external_network(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Make accidental provider traffic fail before opening a socket.
+
+    ASGITransport and respx-backed HTTP tests do not open sockets and continue
+    to exercise their real in-process transports. Tests requiring an actual
+    network connection must explicitly replace this guard at their boundary.
+    """
+
+    def blocked_connection(*args: Any, **kwargs: Any) -> NoReturn:
+        del args, kwargs
+        raise UnexpectedNetworkAccess(
+            "External network access blocked in deterministic backend tests"
+        )
+
+    monkeypatch.setattr(socket, "create_connection", blocked_connection)
+    monkeypatch.setattr(socket.socket, "connect", blocked_connection)
+    monkeypatch.setattr(socket.socket, "connect_ex", blocked_connection)
+    yield
+
+
+@pytest.fixture(autouse=True)
+async def isolated_backend_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[Any]:
+    """Isolate config, crypto and every imported database alias per test."""
+    import app.config as config_module
+    import app.database as database_module
+    from app import crypto
+    from app.config_cache import invalidate_config_cache
+    from app.database import Database
+
+    test_data_dir = tmp_path / "data"
+    test_db = Database(db_path=test_data_dir / "resume_matcher.db")
+
+    monkeypatch.setattr(config_module.settings, "data_dir", test_data_dir)
+    # Preserve compatibility with code/tests that still monkeypatch the legacy
+    # name while guaranteeing old config implementations are safe during RED.
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", test_data_dir / "config.json")
+    monkeypatch.setattr(database_module, "db", test_db)
+
+    # Modules such as routers and app.main import ``db`` by value. Patch every
+    # alias already loaded during collection; modules imported later receive
+    # app.database.db, which is already the isolated instance.
+    for module_name, module in tuple(sys.modules.items()):
+        if not module_name.startswith("app.") or module is None:
+            continue
+        if isinstance(getattr(module, "db", None), Database):
+            monkeypatch.setattr(module, "db", test_db)
+
+    invalidate_config_cache()
+    crypto.reset_cache()
+    try:
+        yield test_db
+    finally:
+        invalidate_config_cache()
+        crypto.reset_cache()
+        await test_db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -184,38 +291,6 @@ def sample_changes():
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-async def isolated_db(tmp_path, monkeypatch):
-    """Replace the global ``db`` singleton with a disposable temp-file SQLite DB
-    across ``app.database`` and every router module that imported it.
-
-    Lets endpoint / e2e tests run against a REAL (but isolated) database instead
-    of a MagicMock, so persistence, the master-resume invariant, and CRUD are
-    actually exercised — without touching the developer's real database. A
-    temp **file** (not ``:memory:``) is required: SQLite's connection pool gives
-    each connection its own in-memory DB, so the async + sync engines would not
-    share state.
-    """
-    import app.database as database_module
-    from app.database import Database
-
-    test_db = Database(db_path=tmp_path / "isolated_db.db")
-    monkeypatch.setattr(database_module, "db", test_db)
-    for router_name in (
-        "resumes",
-        "jobs",
-        "enrichment",
-        "config",
-        "health",
-        "applications",
-        "resume_wizard",
-    ):
-        try:
-            module = importlib.import_module(f"app.routers.{router_name}")
-        except ModuleNotFoundError:
-            continue
-        if hasattr(module, "db"):
-            monkeypatch.setattr(module, "db", test_db)
-    try:
-        yield test_db
-    finally:
-        await test_db.close()
+def isolated_db(isolated_backend_state: Any) -> Any:
+    """Expose the default per-test real SQLite database to tests that need it."""
+    return isolated_backend_state

--- a/apps/backend/tests/integration/_temperature_request_probe.py
+++ b/apps/backend/tests/integration/_temperature_request_probe.py
@@ -1,0 +1,170 @@
+"""Emit synthetic GPT-5 request bodies through LiteLLM and the OpenAI SDK."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+
+def _block_external_io(event: str, args: tuple[object, ...]) -> None:
+    """Fail the probe if the mocked SDK transport ever reaches the network."""
+    if event in {"socket.connect", "socket.getaddrinfo"}:
+        raise RuntimeError(f"temperature contract probe blocked {event}: {args!r}")
+
+
+sys.addaudithook(_block_external_io)
+
+if "DATA_DIR" not in os.environ or "CONFIG_FILE_PATH" not in os.environ:
+    raise RuntimeError("isolated DATA_DIR and CONFIG_FILE_PATH are required")
+
+import httpx  # noqa: E402 - isolation variables must be set before SDK/app imports
+import litellm  # noqa: E402 - isolation variables must be set before SDK/app imports
+from openai import AsyncOpenAI  # noqa: E402 - isolation must precede SDK import
+
+from app.llm import (  # noqa: E402 - isolation must precede application import
+    LLMConfig,
+    complete,
+    complete_json,
+    get_model_name,
+)
+
+
+def _response(content: str) -> SimpleNamespace:
+    """Build the complete response shape consumed by application code."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content, reasoning_content=None)
+            )
+        ]
+    )
+
+
+async def _serialize_request(
+    application_kwargs: dict[str, Any], model_name: str
+) -> dict[str, Any]:
+    """Run application kwargs through real LiteLLM/OpenAI serialization."""
+    captured: list[dict[str, Any]] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        captured.append(body)
+        return httpx.Response(
+            200,
+            json={
+                "id": "synthetic-response",
+                "object": "chat.completion",
+                "created": 0,
+                "model": model_name,
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": {
+                            "role": "assistant",
+                            "content": "synthetic result",
+                        },
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle)
+    ) as http_client:
+        client = AsyncOpenAI(
+            api_key="synthetic-contract-key",
+            base_url="https://synthetic.invalid/v1",
+            http_client=http_client,
+        )
+        request_kwargs = dict(application_kwargs)
+        request_kwargs["model"] = model_name
+        await litellm.acompletion(
+            **request_kwargs,
+            client=client,
+            api_key="synthetic-contract-key",
+            api_base="https://synthetic.invalid/v1",
+        )
+
+    if len(captured) != 1:
+        raise AssertionError(f"expected one SDK request, got {len(captured)}")
+    return captured[0]
+
+
+async def _probe_case(
+    provider: str,
+    model: str,
+    reasoning_effort: str | None,
+    temperature: float = 0.7,
+) -> dict[str, Any]:
+    """Capture complete and malformed-JSON retry requests for one config."""
+    config = LLMConfig(
+        provider=provider,
+        model=model,
+        api_key="synthetic-contract-key",
+        api_base=(
+            "https://synthetic.invalid/v1"
+            if provider == "openai_compatible"
+            else None
+        ),
+        reasoning_effort=reasoning_effort,
+    )
+    model_name = get_model_name(config)
+
+    router = SimpleNamespace(acompletion=AsyncMock(return_value=_response("done")))
+    with patch("app.llm.get_router", return_value=(router, config)):
+        await complete("synthetic prompt", config=config, temperature=temperature)
+    complete_kwargs = dict(router.acompletion.call_args.kwargs)
+
+    router.acompletion = AsyncMock(
+        side_effect=[_response("malformed"), _response('{"changes": []}')]
+    )
+    with patch("app.llm.get_router", return_value=(router, config)):
+        await complete_json(
+            "synthetic prompt", config=config, retries=1, schema_type="diff"
+        )
+    json_kwargs = [dict(call.kwargs) for call in router.acompletion.call_args_list]
+
+    return {
+        "provider": provider,
+        "model": model,
+        "reasoning_effort": reasoning_effort,
+        "requested_temperature": temperature,
+        "complete": await _serialize_request(complete_kwargs, model_name),
+        "json": [
+            await _serialize_request(kwargs, model_name) for kwargs in json_kwargs
+        ],
+    }
+
+
+async def _main() -> None:
+    """Run all approved compatibility scenarios and write stable JSON output."""
+    output_path = Path(sys.argv[1])
+    cases = [
+        ("openai", "gpt-5.1", None, 0.7),
+        ("openai", "gpt-5.2", None, 0.7),
+        ("openai", "gpt-5-chat-latest", None, 0.7),
+        ("openai", "gpt-5.1", "medium", 0.7),
+        ("openai", "gpt-5-nano-2025-08-07", "minimal", 0.7),
+        ("openai_compatible", "gpt-5.1", None, 0.7),
+        ("openai_compatible", "gpt-5.1", "medium", 0.7),
+        ("openai_compatible", "gpt-5-local-llama", None, 0.7),
+        ("openai", "gpt-5.1", "medium", 1.0),
+    ]
+    results = [await _probe_case(*case) for case in cases]
+    output_path.write_text(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/apps/backend/tests/integration/_temperature_request_probe.py
+++ b/apps/backend/tests/integration/_temperature_request_probe.py
@@ -128,11 +128,15 @@ async def _probe_case(
     complete_kwargs = dict(router.acompletion.call_args.kwargs)
 
     router.acompletion = AsyncMock(
-        side_effect=[_response("malformed"), _response('{"changes": []}')]
+        side_effect=[
+            _response("malformed"),
+            _response("still malformed"),
+            _response('{"changes": []}'),
+        ]
     )
     with patch("app.llm.get_router", return_value=(router, config)):
         await complete_json(
-            "synthetic prompt", config=config, retries=1, schema_type="diff"
+            "synthetic prompt", config=config, retries=2, schema_type="diff"
         )
     json_kwargs = [dict(call.kwargs) for call in router.acompletion.call_args_list]
 
@@ -155,6 +159,8 @@ async def _main() -> None:
         ("openai", "gpt-5.1", None, 0.7),
         ("openai", "gpt-5.2", None, 0.7),
         ("openai", "gpt-5-chat-latest", None, 0.7),
+        ("openai", "gpt-5.1-chat-latest", None, 0.7),
+        ("openai", "gpt-5.2-chat-latest", None, 0.7),
         ("openai", "gpt-5.1", "medium", 0.7),
         ("openai", "gpt-5-nano-2025-08-07", "minimal", 0.7),
         ("openai_compatible", "gpt-5.1", None, 0.7),

--- a/apps/backend/tests/integration/test_backend_isolation.py
+++ b/apps/backend/tests/integration/test_backend_isolation.py
@@ -1,0 +1,67 @@
+"""Integration coverage for default test isolation and real startup migration."""
+
+import json
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tinydb import TinyDB
+
+from app import crypto
+from app.config import get_api_keys_from_config, settings
+from app.main import app
+
+
+def test_unstubbed_provider_connection_is_denied() -> None:
+    """A provider socket cannot escape the deterministic backend test process."""
+    with pytest.raises(RuntimeError, match="External network access blocked"):
+        socket.create_connection(("api.openai.com", 443))
+
+
+async def test_real_startup_migrates_only_temporary_storage(
+    isolated_backend_state: Any,
+    tmp_path: Path,
+) -> None:
+    """Real lifespan migration uses isolated config, crypto, and imported DB aliases."""
+    assert settings.data_dir == tmp_path / "data"
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    legacy_db_path = settings.db_path
+    legacy_config_path = settings.config_path
+    legacy_resume = {
+        "resume_id": "legacy-resume",
+        "content": "# Synthetic resume",
+        "is_master": True,
+        "created_at": "2026-09-05T00:00:00+00:00",
+        "updated_at": "2026-09-05T00:00:00+00:00",
+    }
+    tinydb = TinyDB(legacy_db_path)
+    try:
+        tinydb.table("resumes").insert(legacy_resume)
+    finally:
+        tinydb.close()
+    legacy_config_path.write_text(
+        json.dumps(
+            {
+                "provider": "openai",
+                "model": "synthetic-model",
+                "api_key": "synthetic-legacy-key",
+            }
+        )
+    )
+
+    async with app.router.lifespan_context(app):
+        migrated = await isolated_backend_state.get_resume("legacy-resume")
+        assert migrated is not None
+        assert migrated["content"] == "# Synthetic resume"
+        assert get_api_keys_from_config() == {"openai": "synthetic-legacy-key"}
+        assert crypto.decrypt(
+            isolated_backend_state.get_api_key_ciphertexts()["openai"]
+        ) == "synthetic-legacy-key"
+
+    assert not legacy_db_path.exists()
+    assert legacy_db_path.with_suffix(".json.migrated").exists()
+    assert json.loads(legacy_config_path.read_text()) == {
+        "provider": "openai",
+        "model": "synthetic-model",
+    }

--- a/apps/backend/tests/integration/test_config_api.py
+++ b/apps/backend/tests/integration/test_config_api.py
@@ -567,9 +567,11 @@ class TestRequiresBaseUrlValidation:
             )
 
         assert resp.status_code == 200
-        assert json.loads((tmp_path / "data" / "config.json").read_text())["provider"] == (
-            "azure_foundry"
-        )
+        assert json.loads((tmp_path / "data" / "config.json").read_text()) == {
+            "provider": "azure_foundry",
+            "model": "gpt-5-mini",
+            "api_base": "https://example.services.ai.azure.com/openai/v1/responses",
+        }
         mock_health.assert_awaited_once()
         assert sentinel_path.read_text() == '{"sentinel": "developer-state"}'
 
@@ -590,8 +592,9 @@ class TestRequiresBaseUrlValidation:
             )
 
         assert resp.status_code == 200
-        assert json.loads((tmp_path / "data" / "config.json").read_text())["provider"] == (
-            "openai"
-        )
+        assert json.loads((tmp_path / "data" / "config.json").read_text()) == {
+            "provider": "openai",
+            "model": "gpt-5-nano-2025-08-07",
+        }
         mock_health.assert_awaited_once()
         assert sentinel_path.read_text() == '{"sentinel": "developer-state"}'

--- a/apps/backend/tests/integration/test_config_api.py
+++ b/apps/backend/tests/integration/test_config_api.py
@@ -1,5 +1,7 @@
 """Integration tests for configuration endpoints."""
 
+import json
+from pathlib import Path
 from unittest.mock import patch, AsyncMock
 
 import pytest
@@ -544,7 +546,16 @@ class TestRequiresBaseUrlValidation:
         assert detail["field"] == "api_base"
         assert detail["missing"] == ["api_base"]
 
-    async def test_azure_foundry_with_base_url_is_accepted(self, client):
+    @patch("app.routers.config._log_llm_health_check", new_callable=AsyncMock)
+    async def test_azure_foundry_with_base_url_is_accepted(
+        self,
+        mock_health: AsyncMock,
+        client: AsyncClient,
+        tmp_path: Path,
+        backend_test_data_dir: Path,
+    ) -> None:
+        sentinel_path = backend_test_data_dir / "config.json"
+        sentinel_path.write_text('{"sentinel": "developer-state"}')
         async with client:
             resp = await client.put(
                 "/api/v1/config/llm-api-key",
@@ -556,8 +567,22 @@ class TestRequiresBaseUrlValidation:
             )
 
         assert resp.status_code == 200
+        assert json.loads((tmp_path / "data" / "config.json").read_text())["provider"] == (
+            "azure_foundry"
+        )
+        mock_health.assert_awaited_once()
+        assert sentinel_path.read_text() == '{"sentinel": "developer-state"}'
 
-    async def test_other_providers_are_unaffected(self, client):
+    @patch("app.routers.config._log_llm_health_check", new_callable=AsyncMock)
+    async def test_other_providers_are_unaffected(
+        self,
+        mock_health: AsyncMock,
+        client: AsyncClient,
+        tmp_path: Path,
+        backend_test_data_dir: Path,
+    ) -> None:
+        sentinel_path = backend_test_data_dir / "config.json"
+        sentinel_path.write_text('{"sentinel": "developer-state"}')
         async with client:
             resp = await client.put(
                 "/api/v1/config/llm-api-key",
@@ -565,3 +590,8 @@ class TestRequiresBaseUrlValidation:
             )
 
         assert resp.status_code == 200
+        assert json.loads((tmp_path / "data" / "config.json").read_text())["provider"] == (
+            "openai"
+        )
+        mock_health.assert_awaited_once()
+        assert sentinel_path.read_text() == '{"sentinel": "developer-state"}'

--- a/apps/backend/tests/integration/test_config_durability.py
+++ b/apps/backend/tests/integration/test_config_durability.py
@@ -1,0 +1,148 @@
+"""Config saves acknowledge replacement even when directory durability fails."""
+
+import json
+import logging
+import os
+import stat
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import (
+    get_api_keys_from_config,
+    get_config_path,
+    migrate_legacy_keys,
+)
+from app.config_cache import load_config
+from app.main import app
+
+
+DirectoryOperation = Literal["open", "fsync", "close"]
+
+
+def _fail_directory_operation(
+    monkeypatch: pytest.MonkeyPatch,
+    directory: Path,
+    operation: DirectoryOperation,
+) -> None:
+    """Fail the directory operation while keeping file writes and cleanup real."""
+    real_open, real_fsync, real_close = os.open, os.fsync, os.close
+
+    def failing_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if os.fspath(path) == str(directory):
+            raise OSError("synthetic directory open failure")
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    def failing_fsync(fd: int) -> None:
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError("synthetic directory fsync failure")
+        real_fsync(fd)
+
+    def failing_close(fd: int) -> None:
+        is_directory = stat.S_ISDIR(os.fstat(fd).st_mode)
+        # Model a close that releases the descriptor before reporting an error.
+        real_close(fd)
+        if is_directory:
+            raise OSError("synthetic directory close failure")
+
+    if operation == "open":
+        monkeypatch.setattr(os, "open", failing_open)
+    elif operation == "fsync":
+        monkeypatch.setattr(os, "fsync", failing_fsync)
+    else:
+        monkeypatch.setattr(os, "close", failing_close)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Directory fsync is a POSIX contract")
+@pytest.mark.parametrize("failure", [None, "open", "fsync", "close"])
+async def test_committed_config_save_refreshes_cache_despite_directory_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure: DirectoryOperation | None,
+) -> None:
+    """The API and cached readers must agree with the installed snapshot."""
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"enable_cover_letter": false}')
+    assert load_config() == {"enable_cover_letter": False}
+    if failure is not None:
+        _fail_directory_operation(monkeypatch, path.parent, failure)
+
+    with caplog.at_level(logging.WARNING, logger="app.config"):
+        async with AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://test",
+        ) as client:
+            response = await client.put(
+                "/api/v1/config/features", json={"enable_cover_letter": True}
+            )
+
+    assert json.loads(path.read_text()) == {"enable_cover_letter": True}
+    assert load_config() == {"enable_cover_letter": True}, response.text
+    assert response.status_code == 200
+    assert response.json()["enable_cover_letter"] is True
+    assert list(path.parent.glob(".config.json.*.tmp")) == []
+    if failure is not None:
+        assert any(
+            record.name == "app.config"
+            and record.exc_info is not None
+            and f"synthetic directory {failure} failure" in str(record.exc_info[1])
+            for record in caplog.records
+        )
+
+
+async def test_file_fsync_failure_preserves_old_config_and_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-replacement durability failure remains a failed save."""
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"enable_cover_letter": false}')
+    assert load_config() == {"enable_cover_letter": False}
+
+    def fail_file_fsync(fd: int) -> None:
+        assert stat.S_ISREG(os.fstat(fd).st_mode)
+        raise OSError("synthetic file fsync failure")
+
+    monkeypatch.setattr(os, "fsync", fail_file_fsync)
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as client:
+        response = await client.put(
+            "/api/v1/config/features", json={"enable_cover_letter": True}
+        )
+
+    assert response.status_code == 500
+    assert "synthetic file fsync failure" not in response.text
+    assert json.loads(path.read_text()) == {"enable_cover_letter": False}
+    assert load_config() == {"enable_cover_letter": False}
+    assert list(path.parent.glob(".config.json.*.tmp")) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Directory fsync is a POSIX contract")
+@pytest.mark.parametrize("failure", ["open", "fsync", "close"])
+def test_legacy_key_migration_completes_after_directory_durability_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: DirectoryOperation,
+) -> None:
+    """Startup migration can finish once the legacy plaintext is replaced."""
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"provider": "openai", "api_key": "synthetic-test-key"}')
+    _fail_directory_operation(monkeypatch, path.parent, failure)
+
+    migrate_legacy_keys()
+
+    assert json.loads(path.read_text()) == {"provider": "openai"}
+    assert get_api_keys_from_config() == {"openai": "synthetic-test-key"}
+    migrate_legacy_keys()
+    assert get_api_keys_from_config() == {"openai": "synthetic-test-key"}

--- a/apps/backend/tests/integration/test_temperature_request_contract.py
+++ b/apps/backend/tests/integration/test_temperature_request_contract.py
@@ -1,0 +1,113 @@
+"""Final serialized-request regressions for GPT-5 temperature handling."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def serialized_cases(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    """Run the isolated SDK probe once and index its synthetic request bodies."""
+    isolated_root = tmp_path_factory.mktemp("temperature-request-contract")
+    output_path = isolated_root / "requests.json"
+    probe_path = Path(__file__).with_name("_temperature_request_probe.py")
+    environment = os.environ.copy()
+    backend_root = Path(__file__).parents[2]
+    environment.update(
+        {
+            "DATA_DIR": str(isolated_root / "data"),
+            "CONFIG_FILE_PATH": str(isolated_root / "config.json"),
+            "LITELLM_LOCAL_MODEL_COST_MAP": "True",
+            "LITELLM_TELEMETRY": "False",
+            "DO_NOT_TRACK": "1",
+            "PYTHONPATH": os.pathsep.join(
+                (str(backend_root), environment.get("PYTHONPATH", ""))
+            ),
+        }
+    )
+    completed = subprocess.run(
+        [sys.executable, str(probe_path), str(output_path)],
+        cwd=backend_root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    cases = json.loads(output_path.read_text())
+    return {
+        "|".join(
+            (
+                case["provider"],
+                case["model"],
+                str(case["reasoning_effort"]),
+                str(case["requested_temperature"]),
+            )
+        ): case
+        for case in cases
+    }
+
+
+def test_gpt51_and_gpt52_preserve_serialized_sampling_when_reasoning_is_cleared(
+    serialized_cases: dict[str, Any],
+) -> None:
+    """Cleared reasoning keeps complete and content-retry temperatures."""
+    for model in ("gpt-5.1", "gpt-5.2"):
+        case = serialized_cases[f"openai|{model}|None|0.7"]
+        assert case["complete"]["temperature"] == 0.7
+        assert [body["temperature"] for body in case["json"]] == [0.1, 0.3]
+        assert "reasoning_effort" not in case["complete"]
+        assert all("reasoning_effort" not in body for body in case["json"])
+
+
+def test_registered_compatible_alias_preserves_sampling_only_without_reasoning(
+    serialized_cases: dict[str, Any],
+) -> None:
+    """Compatible GPT-5.1 aliases follow the same model/mode capability."""
+    cleared = serialized_cases["openai_compatible|gpt-5.1|None|0.7"]
+    enabled = serialized_cases["openai_compatible|gpt-5.1|medium|0.7"]
+
+    assert cleared["complete"]["temperature"] == 0.7
+    assert [body["temperature"] for body in cleared["json"]] == [0.1, 0.3]
+    assert "temperature" not in enabled["complete"]
+    assert all("temperature" not in body for body in enabled["json"])
+
+
+def test_regular_gpt5_chat_variant_preserves_serialized_sampling(
+    serialized_cases: dict[str, Any],
+) -> None:
+    """The regular gpt-5-chat family stays outside reasoning restrictions."""
+    case = serialized_cases["openai|gpt-5-chat-latest|None|0.7"]
+
+    assert case["complete"]["temperature"] == 0.7
+    assert [body["temperature"] for body in case["json"]] == [0.1, 0.3]
+
+
+def test_restricted_and_unknown_models_omit_serialized_sampling(
+    serialized_cases: dict[str, Any],
+) -> None:
+    """Nano, explicit reasoning, and registry misses remain conservative."""
+    keys = (
+        "openai|gpt-5.1|medium|0.7",
+        "openai|gpt-5-nano-2025-08-07|minimal|0.7",
+        "openai_compatible|gpt-5-local-llama|None|0.7",
+    )
+    for key in keys:
+        case = serialized_cases[key]
+        assert "temperature" not in case["complete"]
+        assert all("temperature" not in body for body in case["json"])
+
+
+def test_explicit_default_temperature_survives_reasoning_mode(
+    serialized_cases: dict[str, Any],
+) -> None:
+    """The supported explicit GPT-5 default remains serialized as 1.0."""
+    case = serialized_cases["openai|gpt-5.1|medium|1.0"]
+    assert case["complete"]["temperature"] == 1.0

--- a/apps/backend/tests/integration/test_temperature_request_contract.py
+++ b/apps/backend/tests/integration/test_temperature_request_contract.py
@@ -62,7 +62,7 @@ def test_gpt51_and_gpt52_preserve_serialized_sampling_when_reasoning_is_cleared(
     for model in ("gpt-5.1", "gpt-5.2"):
         case = serialized_cases[f"openai|{model}|None|0.7"]
         assert case["complete"]["temperature"] == 0.7
-        assert [body["temperature"] for body in case["json"]] == [0.1, 0.3]
+        assert [body["temperature"] for body in case["json"]] == [0.1, 0.3, 0.5]
         assert "reasoning_effort" not in case["complete"]
         assert all("reasoning_effort" not in body for body in case["json"])
 
@@ -75,7 +75,7 @@ def test_registered_compatible_alias_preserves_sampling_only_without_reasoning(
     enabled = serialized_cases["openai_compatible|gpt-5.1|medium|0.7"]
 
     assert cleared["complete"]["temperature"] == 0.7
-    assert [body["temperature"] for body in cleared["json"]] == [0.1, 0.3]
+    assert [body["temperature"] for body in cleared["json"]] == [0.1, 0.3, 0.5]
     assert "temperature" not in enabled["complete"]
     assert all("temperature" not in body for body in enabled["json"])
 
@@ -87,7 +87,7 @@ def test_regular_gpt5_chat_variant_preserves_serialized_sampling(
     case = serialized_cases["openai|gpt-5-chat-latest|None|0.7"]
 
     assert case["complete"]["temperature"] == 0.7
-    assert [body["temperature"] for body in case["json"]] == [0.1, 0.3]
+    assert [body["temperature"] for body in case["json"]] == [0.1, 0.3, 0.5]
 
 
 def test_restricted_and_unknown_models_omit_serialized_sampling(
@@ -111,3 +111,14 @@ def test_explicit_default_temperature_survives_reasoning_mode(
     """The supported explicit GPT-5 default remains serialized as 1.0."""
     case = serialized_cases["openai|gpt-5.1|medium|1.0"]
     assert case["complete"]["temperature"] == 1.0
+
+
+def test_versioned_chat_aliases_follow_the_installed_transport_capabilities(
+    serialized_cases: dict[str, Any],
+) -> None:
+    supported = serialized_cases["openai|gpt-5.1-chat-latest|None|0.7"]
+    restricted = serialized_cases["openai|gpt-5.2-chat-latest|None|0.7"]
+    assert supported["complete"]["temperature"] == 0.7
+    assert [body["temperature"] for body in supported["json"]] == [0.1, 0.3, 0.5]
+    assert "temperature" not in restricted["complete"]
+    assert all("temperature" not in body for body in restricted["json"])

--- a/apps/backend/tests/unit/test_config_persistence.py
+++ b/apps/backend/tests/unit/test_config_persistence.py
@@ -1,0 +1,125 @@
+"""Regression tests for config path ownership and atomic persistence."""
+
+import json
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import app.config as config_module
+from app.config import load_config_file, save_config_file, settings
+from app.config_cache import invalidate_config_cache, load_config
+
+
+def test_imported_config_path_is_owned_by_data_dir(
+    imported_config_file_path: Path,
+    backend_test_data_dir: Path,
+) -> None:
+    """Changing DATA_DIR before import must redirect the config alias too."""
+    assert imported_config_file_path == backend_test_data_dir / "config.json"
+
+
+def test_config_readers_and_writers_follow_runtime_data_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    imported_config_file_path: Path,
+) -> None:
+    """A runtime DATA_DIR override must move config save, load, and cache I/O."""
+    owned_data_dir = tmp_path / "owned"
+    monkeypatch.setattr(settings, "data_dir", owned_data_dir)
+    # Restore the compatibility alias to its untouched import-time value. A
+    # changed alias is intentionally honored for downstream monkeypatch users.
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", imported_config_file_path)
+
+    save_config_file({"provider": "anthropic", "api_key": "must-not-persist"})
+    invalidate_config_cache()
+
+    assert json.loads(settings.config_path.read_text()) == {"provider": "anthropic"}
+    assert load_config_file()["provider"] == "anthropic"
+    assert load_config() == {"provider": "anthropic"}
+
+
+def test_legacy_config_path_monkeypatch_remains_supported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing callers that monkeypatch CONFIG_FILE_PATH keep controlling I/O."""
+    compatibility_path = tmp_path / "compatibility" / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", compatibility_path)
+
+    save_config_file({"provider": "gemini"})
+
+    assert json.loads(compatibility_path.read_text()) == {"provider": "gemini"}
+    assert load_config_file()["provider"] == "gemini"
+
+
+def test_failed_atomic_replace_preserves_snapshot_and_removes_temp_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A replace failure must preserve the old JSON and leave no temp artifact."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"provider": "sentinel"}')
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", config_path)
+
+    def fail_replace(source: str | Path, destination: str | Path) -> None:
+        del source, destination
+        raise OSError("synthetic replace failure")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="synthetic replace failure"):
+        save_config_file({"provider": "openai"})
+
+    assert json.loads(config_path.read_text()) == {"provider": "sentinel"}
+    assert list(tmp_path.glob(".config.json.*.tmp")) == []
+
+
+def test_concurrent_snapshot_replacements_are_serialized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent saves install complete snapshots one at a time."""
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", config_path)
+    real_replace = os.replace
+    writers = 8
+    start = threading.Barrier(writers)
+    observation_lock = threading.Lock()
+    active_replacements = 0
+    maximum_active_replacements = 0
+
+    def observed_replace(source: str | Path, destination: str | Path) -> None:
+        nonlocal active_replacements, maximum_active_replacements
+        with observation_lock:
+            active_replacements += 1
+            maximum_active_replacements = max(
+                maximum_active_replacements, active_replacements
+            )
+        try:
+            time.sleep(0.01)
+            real_replace(source, destination)
+        finally:
+            with observation_lock:
+                active_replacements -= 1
+
+    monkeypatch.setattr(os, "replace", observed_replace)
+    snapshots: list[dict[str, Any]] = [
+        {"writer": index, "payload": str(index) * 4096}
+        for index in range(writers)
+    ]
+
+    def save_after_barrier(snapshot: dict[str, Any]) -> None:
+        start.wait()
+        save_config_file(snapshot)
+
+    with ThreadPoolExecutor(max_workers=writers) as executor:
+        list(executor.map(save_after_barrier, snapshots))
+
+    assert maximum_active_replacements == 1
+    assert json.loads(config_path.read_text()) in snapshots
+    assert list(tmp_path.glob(".config.json.*.tmp")) == []

--- a/apps/backend/tests/unit/test_config_persistence.py
+++ b/apps/backend/tests/unit/test_config_persistence.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -13,6 +14,7 @@ import pytest
 import app.config as config_module
 from app.config import load_config_file, save_config_file, settings
 from app.config_cache import invalidate_config_cache, load_config
+from app.routers.config import _get_config_path
 
 
 def test_imported_config_path_is_owned_by_data_dir(
@@ -55,6 +57,58 @@ def test_legacy_config_path_monkeypatch_remains_supported(
 
     assert json.loads(compatibility_path.read_text()) == {"provider": "gemini"}
     assert load_config_file()["provider"] == "gemini"
+    assert load_config() == {"provider": "gemini"}
+    assert _get_config_path() == compatibility_path
+
+
+def test_cached_config_follows_a_changed_compatibility_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    first.write_text('{"language": "en"}')
+    second.write_text('{"language": "fr"}')
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", first)
+    assert load_config() == {"language": "en"}
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", second)
+    assert load_config() == {"language": "fr"}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions and symlink contract")
+def test_atomic_save_preserves_symlink_target_and_existing_permissions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "managed.json"
+    target.write_text('{"provider": "old"}')
+    target.chmod(0o640)
+    link = tmp_path / "config.json"
+    link.symlink_to(target)
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", link)
+
+    save_config_file({"provider": "gemini"})
+
+    assert link.is_symlink()
+    assert json.loads(target.read_text()) == {"provider": "gemini"}
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Directory fsync is a POSIX contract")
+def test_atomic_save_syncs_the_replaced_directory_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "config.json"
+    monkeypatch.setattr(config_module, "CONFIG_FILE_PATH", path)
+    real_fsync = os.fsync
+    synced_snapshots: list[dict[str, Any]] = []
+
+    def observe_fsync(fd: int) -> None:
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            synced_snapshots.append(json.loads(path.read_text()))
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", observe_fsync)
+    save_config_file({"provider": "gemini"})
+    assert synced_snapshots == [{"provider": "gemini"}]
 
 
 def test_failed_atomic_replace_preserves_snapshot_and_removes_temp_file(

--- a/apps/backend/tests/unit/test_llm.py
+++ b/apps/backend/tests/unit/test_llm.py
@@ -234,17 +234,50 @@ class TestSupportsTemperature:
         assert _supports_temperature("openai/kimi-k2.6", 1.0) is True
 
     @patch("app.llm.litellm.get_model_info")
-    def test_gpt5_only_allows_default(self, mock_get_model_info):
-        """gpt-5 accepts only temperature=1, on OpenAI and Azure alike."""
+    def test_gpt5_only_allows_default(
+        self, mock_get_model_info: MagicMock
+    ) -> None:
+        """Reasoning models without a none mode accept only default temperature."""
         mock_get_model_info.return_value = {
-            "supported_openai_params": ["temperature", "max_tokens"]
+            "supported_openai_params": ["temperature", "max_tokens"],
+            "supports_reasoning": True,
+            "supports_none_reasoning_effort": False,
         }
         assert _supports_temperature("gpt-5.6-terra", 0.1) is False
         assert _supports_temperature("openai/gpt-5-nano-2025-08-07", 0.7) is False
         assert _supports_temperature("azure/gpt-5.6-terra", 0.1) is False
         assert _supports_temperature("gpt-5.6-terra", 1.0) is True
 
-    def test_ollama_gpt5_name_unaffected(self):
+    @patch("app.llm.litellm.get_model_info")
+    def test_gpt51_and_gpt52_allow_sampling_with_reasoning_omitted(
+        self, mock_get_model_info: MagicMock
+    ) -> None:
+        """Models with a no-reasoning mode preserve non-default sampling."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"],
+            "supports_reasoning": True,
+            "supports_none_reasoning_effort": True,
+        }
+
+        assert _supports_temperature("gpt-5.1", 0.7) is True
+        assert _supports_temperature("openai/gpt-5.2", 0.1) is True
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_gpt51_and_gpt52_omit_sampling_with_reasoning_enabled(
+        self, mock_get_model_info: MagicMock
+    ) -> None:
+        """Explicit reasoning keeps non-default sampling out of the request."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"],
+            "supports_reasoning": True,
+            "supports_none_reasoning_effort": True,
+        }
+
+        assert _supports_temperature("gpt-5.1", 0.7, "medium") is False
+        assert _supports_temperature("openai/gpt-5.2", 0.1, "minimal") is False
+        assert _supports_temperature("gpt-5.1", 1.0, "medium") is True
+
+    def test_ollama_gpt5_name_unaffected(self) -> None:
         """An Ollama model merely named gpt-5-* is local, not real gpt-5.
 
         The ollama early return fires before the carve-out. Pinned so a
@@ -254,7 +287,9 @@ class TestSupportsTemperature:
         assert _supports_temperature("ollama/gpt-5-whatever", 0.7) is True
 
     @patch("app.llm.litellm.get_model_info")
-    def test_unregistered_gpt5_name_already_skipped(self, mock_get_model_info):
+    def test_unregistered_gpt5_name_already_skipped(
+        self, mock_get_model_info: MagicMock
+    ) -> None:
         """A self-hosted server's own gpt-5-named model is not in the registry.
 
         It returns False from the registry-miss path above, before the
@@ -270,10 +305,14 @@ class TestSupportsTemperature:
         assert _supports_temperature("unknown-vendor/model", 0.7) is False
 
     @patch("app.llm.litellm.get_model_info")
-    def test_case_insensitive_model_name(self, mock_get_model_info):
+    def test_case_insensitive_model_name(
+        self, mock_get_model_info: MagicMock
+    ) -> None:
         """Provider-specific checks are case-insensitive."""
         mock_get_model_info.return_value = {
-            "supported_openai_params": ["temperature", "max_tokens"]
+            "supported_openai_params": ["temperature", "max_tokens"],
+            "supports_reasoning": True,
+            "supports_none_reasoning_effort": False,
         }
         assert _supports_temperature("Anthropic/Claude-Opus-4-7", 0.7) is False
         assert _supports_temperature("OPENAI/KIMI-K2.6", 0.7) is False
@@ -311,13 +350,35 @@ class TestGetRetryTemperature:
         assert _get_retry_temperature("anthropic/claude-opus-4-7", 3) is None
 
     @patch("app.llm.litellm.get_model_info")
-    def test_gpt5_returns_none(self, mock_get_model_info):
-        """gpt-5 accepts only temperature=1, so the retry path omits it."""
+    def test_gpt5_returns_none(self, mock_get_model_info: MagicMock) -> None:
+        """Restricted reasoning models omit non-default retry temperatures."""
         mock_get_model_info.return_value = {
-            "supported_openai_params": ["temperature", "max_tokens"]
+            "supported_openai_params": ["temperature", "max_tokens"],
+            "supports_reasoning": True,
+            "supports_none_reasoning_effort": False,
         }
         assert _get_retry_temperature("openai/gpt-5-nano-2025-08-07", 0) is None
         assert _get_retry_temperature("gpt-5.6-terra", 2) is None
+
+    @patch("app.llm.litellm.get_model_info")
+    def test_gpt51_retry_sampling_depends_on_reasoning_mode(
+        self, mock_get_model_info: MagicMock
+    ) -> None:
+        """Content retries vary sampling only when no reasoning is configured."""
+        mock_get_model_info.return_value = {
+            "supported_openai_params": ["temperature", "max_tokens"],
+            "supports_reasoning": True,
+            "supports_none_reasoning_effort": True,
+        }
+
+        assert _get_retry_temperature("openai/gpt-5.1", 0) == 0.1
+        assert _get_retry_temperature("openai/gpt-5.1", 1) == 0.3
+        assert (
+            _get_retry_temperature(
+                "openai/gpt-5.1", 0, reasoning_effort="medium"
+            )
+            is None
+        )
 
     @patch("app.llm.litellm.get_model_info")
     def test_kimi_k26_returns_one(self, mock_get_model_info):

--- a/apps/backend/tests/unit/test_sampling_capabilities.py
+++ b/apps/backend/tests/unit/test_sampling_capabilities.py
@@ -1,0 +1,22 @@
+"""A changed model registry must not enable unsupported GPT-5 sampling."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.llm import _supports_temperature
+
+
+@pytest.mark.parametrize("reasoning_capability", [None, "true", 1])
+def test_unknown_reasoning_capability_omits_flexible_sampling(
+    reasoning_capability: Any,
+) -> None:
+    model_info = {
+        "supported_openai_params": ["temperature"],
+        "supports_reasoning": reasoning_capability,
+        "supports_none_reasoning_effort": True,
+    }
+    with patch("app.llm.litellm.get_model_info", return_value=model_info):
+        assert not _supports_temperature("gpt-5.1", 0.7, reasoning_effort=None)
+        assert _supports_temperature("gpt-5.1", 1.0, reasoning_effort=None)

--- a/docs/agent/llm-integration.md
+++ b/docs/agent/llm-integration.md
@@ -67,6 +67,12 @@ which omits the parameter; the schema does not accept the literal string
 non-default temperature is omitted. The regular `gpt-5-chat*` family stays on
 LiteLLM's normal chat path and keeps registry-supported sampling.
 
+OpenAI documents `none` as the default reasoning level for GPT-5.1 and GPT-5.2
+in its [model guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.2).
+Versioned chat aliases follow their own registered capabilities rather than a
+blanket `-chat` name exemption. Missing or malformed reasoning capability fields
+produce a warning and omit non-default sampling, so registry drift fails conservatively.
+
 The same registry/model/reasoning decision applies to OpenAI, Azure, and
 registered `openai_compatible` aliases. This avoids a blanket
 compatible-provider exemption: a gateway alias for GPT-5 Nano or a GPT-5.1/5.2
@@ -94,7 +100,8 @@ completion and JSON retry paths are covered by
 `tests/integration/test_temperature_request_contract.py`: real LiteLLM and
 OpenAI SDK serialization into an in-memory HTTP transport, using synthetic
 credentials and no provider network traffic. Those tests also retain Nano,
-explicit reasoning, explicit `1.0`, and compatible-alias controls. No live
+explicit reasoning, explicit `1.0`, versioned chat aliases, both automatic retry
+temperatures, and compatible-alias controls. No live
 provider acceptance or output-quality claim is made by these tests.
 
 ## JSON Extraction

--- a/docs/agent/llm-integration.md
+++ b/docs/agent/llm-integration.md
@@ -44,20 +44,58 @@ The `complete_json()` function automatically enables `response_format={"type": "
 
 ## Retry Logic
 
-JSON completions include 2 automatic retries with progressively lower temperature:
+JSON completions include up to 2 automatic content retries with increasing
+temperature for response variation when the model supports sampling:
 
-- Attempt 1: temperature 0.1
-- Attempt 2: temperature 0.0
+- Initial attempt: temperature 0.1
+- First retry: temperature 0.3
+- Second retry: temperature 0.5
 
 ## Temperature Support
 
-`_supports_temperature()` determines whether `temperature` is sent at all. Capability comes from LiteLLM's model registry, with overrides for restrictions the registry does not record.
+`_supports_temperature()` determines whether `temperature` is sent at all.
+Capability comes from LiteLLM's model registry, with narrow overrides for
+restrictions the registry's supported-parameter list does not fully describe.
 
-The gpt-5 family is one such restriction. The registry lists `temperature` as a supported parameter, which is accurate, but only the default value of 1 is accepted ([litellm#13397](https://github.com/BerriAI/litellm/issues/13397)). This holds on OpenAI and on Azure alike.
+Reasoning GPT-5 models that do not offer a no-reasoning mode, including GPT-5
+Nano, accept only the default temperature of `1`. Models whose registry entry
+advertises `supports_none_reasoning_effort`, including GPT-5.1 and GPT-5.2,
+also accept non-default temperatures when reasoning is omitted. In application
+configuration, cleared reasoning is represented by `reasoning_effort=None`,
+which omits the parameter; the schema does not accept the literal string
+`"none"`. If an explicit reasoning mode such as `minimal` or `medium` is set,
+non-default temperature is omitted. The regular `gpt-5-chat*` family stays on
+LiteLLM's normal chat path and keeps registry-supported sampling.
 
-The override matches on model name rather than provider. Azure gpt-5 deployments resolve to `azure/` prefixed names, and a self-hosted `openai_compatible` model under a custom name is absent from the registry and already treated as unsupported before the override runs.
+The same registry/model/reasoning decision applies to OpenAI, Azure, and
+registered `openai_compatible` aliases. This avoids a blanket
+compatible-provider exemption: a gateway alias for GPT-5 Nano or a GPT-5.1/5.2
+request with explicit reasoning remains restricted. Unknown aliases stay
+conservative and omit temperature, while Ollama keeps its explicit local-model
+fallback.
 
-`_get_retry_temperature()` therefore returns `None` for gpt-5, omitting the parameter so the provider applies its own default.
+`_get_retry_temperature()` uses the same capability decision for content
+retries. It returns `None` when sampling is restricted, so the provider applies
+its default, and preserves retry variation when reasoning is cleared on a model
+that supports no-reasoning sampling.
+
+### PR #929 / issue #975 verification
+
+On the tested LiteLLM 1.86.2 stack, the original default GPT-5 Nano failure
+reported in PR #929 was **not reproduced**. The application already enables
+`litellm.drop_params`, and LiteLLM removes Nano's unsupported non-default
+temperature before the OpenAI SDK serializes the request. This is evidence
+about that dependency stack, not a claim that every gateway accepts the same
+parameters.
+
+The reproduced regression was supported sampling being removed from GPT-5.1
+and GPT-5.2 with reasoning cleared, and from `gpt-5-chat-latest`. The application
+completion and JSON retry paths are covered by
+`tests/integration/test_temperature_request_contract.py`: real LiteLLM and
+OpenAI SDK serialization into an in-memory HTTP transport, using synthetic
+credentials and no provider network traffic. Those tests also retain Nano,
+explicit reasoning, explicit `1.0`, and compatible-alias controls. No live
+provider acceptance or output-quality claim is made by these tests.
 
 ## JSON Extraction
 


### PR DESCRIPTION
## Description

The GPT-5 guard added by #929 also removed supported sampling from GPT-5.1/5.2 when reasoning was cleared, and from GPT-5 Chat. The guard now combines registry capabilities, the model's reasoning/chat path and configured reasoning mode. Normal completions and JSON retries preserve supported temperatures while restricted modes still omit them.

## Related Issue

Fixes #975

**Stack 02/17**, based on #976 (`fix/reliability-01-config-isolation`). Part of the reliability work tracked by #931. Merge from the bottom upward; this PR shows only its own slice against the previous branch.

## Type

- [x] Bug Fix
- [x] Documentation Update

## Proposed Changes

- Apply one capability decision to OpenAI/Azure and registered compatible aliases; keep unknown aliases conservative.
- Verify final SDK-serialized requests with real LiteLLM 1.86.2 and OpenAI SDK code using an in-memory HTTP transport and synthetic credentials.
- Document that the original default-Nano failure was not reproduced on this dependency stack because LiteLLM already drops the unsupported parameter; fix misleading family-wide descriptions and missing test annotations.








<!-- verified-review-update:start -->
## Verified review corrections

Capability metadata is validated conservatively. Transport tests now check the initial request and both JSON retries, including versioned chat variants.

[Complete report, per-comment dispositions and file map](https://github.com/srbhr/Resume-Matcher/blob/628a62c22193c6d4f678bdf07cb2d9d8b41aeac7/docs/agent/architecture/hosted-review-corrections.md). All 314 captured review records are accounted for: 173 fixed, 97 duplicate, 13 already resolved and 31 not actionable, with evidence. Follow-up changes that require later stages are documented there; the original commit chain remains intact. Integration uses one merge commit from #992 to main so the ancestor PRs merge indirectly without overlapping Docker publications.

<!-- verified-review-update:end -->

## How to Test

The complete assembled stack at `628a62c2` passed 1,067 backend tests (2 paid evaluations deselected), 500 frontend tests in 55 files, frontend lint, TypeScript, formatting and production build. Actual Next navigation/download/draft-isolation controls, real Chromium PDF tests, the Python annotation audit and actionlint passed. The complete runtime suites apply to #992's assembled stack. All 17 intermediate heads also passed separate Next type generation, TypeScript and Python syntax checks; later stage 17 changes received the final full-suite validation.

[Hosted two-architecture Docker validation](https://github.com/srbhr/Resume-Matcher/actions/runs/34018356221) was dispatched for this exact assembled SHA with `dry_run=true`; registry logins and publication are disabled. Verified hosted result: **in progress**. The run uses this exact published SHA. Tests use synthetic fixtures and isolated storage; paid provider evaluations were not run.

## Additional Information

No live-provider acceptance or output-quality result is claimed. Behavior follows the tested LiteLLM registry and transform rules, so dependency upgrades should rerun the serialized-request contracts.

